### PR TITLE
feat: delete and restore vault items (#010)

### DIFF
--- a/Macwarden/App/AppContainer.swift
+++ b/Macwarden/App/AppContainer.swift
@@ -25,11 +25,14 @@ final class AppContainer: ObservableObject {
 
     // MARK: - Domain use cases
 
-    let syncUseCase:          SyncUseCaseImpl
-    let loginUseCase:         LoginUseCaseImpl
-    let unlockUseCase:        UnlockUseCaseImpl
-    let searchVaultUseCase:   SearchVaultUseCaseImpl
-    let editVaultItemUseCase: EditVaultItemUseCaseImpl
+    let syncUseCase:             SyncUseCaseImpl
+    let loginUseCase:            LoginUseCaseImpl
+    let unlockUseCase:           UnlockUseCaseImpl
+    let searchVaultUseCase:      SearchVaultUseCaseImpl
+    let editVaultItemUseCase:    EditVaultItemUseCaseImpl
+    let deleteVaultItemUseCase:  DeleteVaultItemUseCaseImpl
+    let restoreVaultItemUseCase: RestoreVaultItemUseCaseImpl
+    let emptyTrashUseCase:       EmptyTrashUseCaseImpl
 
     // MARK: - Init
 
@@ -57,11 +60,14 @@ final class AppContainer: ObservableObject {
         self.faviconLoader   = FaviconLoader()
         self.authRepository  = auth
         self.syncRepository  = sync
-        self.syncUseCase          = SyncUseCaseImpl(sync: sync)
-        self.loginUseCase         = LoginUseCaseImpl(auth: auth, sync: sync)
-        self.unlockUseCase        = UnlockUseCaseImpl(auth: auth, sync: sync)
-        self.searchVaultUseCase   = SearchVaultUseCaseImpl(vault: vault)
-        self.editVaultItemUseCase = EditVaultItemUseCaseImpl(repository: vault)
+        self.syncUseCase             = SyncUseCaseImpl(sync: sync)
+        self.loginUseCase            = LoginUseCaseImpl(auth: auth, sync: sync)
+        self.unlockUseCase           = UnlockUseCaseImpl(auth: auth, sync: sync)
+        self.searchVaultUseCase      = SearchVaultUseCaseImpl(vault: vault)
+        self.editVaultItemUseCase    = EditVaultItemUseCaseImpl(repository: vault)
+        self.deleteVaultItemUseCase  = DeleteVaultItemUseCaseImpl(repository: vault)
+        self.restoreVaultItemUseCase = RestoreVaultItemUseCaseImpl(repository: vault)
+        self.emptyTrashUseCase       = EmptyTrashUseCaseImpl(repository: vault)
     }
 
     // MARK: - Factories
@@ -78,7 +84,13 @@ final class AppContainer: ObservableObject {
 
     /// Creates a `VaultBrowserViewModel` backed by the live vault store.
     func makeVaultBrowserViewModel() -> VaultBrowserViewModel {
-        VaultBrowserViewModel(vault: vaultStore, search: searchVaultUseCase)
+        VaultBrowserViewModel(
+            vault:   vaultStore,
+            search:  searchVaultUseCase,
+            delete:  deleteVaultItemUseCase,
+            restore: restoreVaultItemUseCase,
+            emptyTrash: emptyTrashUseCase
+        )
     }
 
     /// Creates an `ItemEditViewModel` for the given item, wired with the live edit use case.

--- a/Macwarden/Data/Network/MacwardenAPIClient.swift
+++ b/Macwarden/Data/Network/MacwardenAPIClient.swift
@@ -72,6 +72,36 @@ protocol MacwardenAPIClientProtocol: Actor {
     ///
     /// Reference: Bitwarden Server API PUT /api/ciphers/{id}
     func updateCipher(id: String, cipher: RawCipher) async throws -> RawCipher
+
+    /// DELETE `/api/ciphers/{id}` — soft-deletes a cipher by moving it to Trash.
+    ///
+    /// Sets `deletedDate` on the server. The item remains in the user's vault data and
+    /// can be restored. Bitwarden cloud auto-purges trashed items after 30 days server-side;
+    /// self-hosted Vaultwarden only auto-purges if `TRASH_AUTO_DELETE_DAYS` is configured.
+    ///
+    /// Reference: Bitwarden Server API DELETE /api/ciphers/{id}
+    func softDeleteCipher(id: String) async throws
+
+    /// PUT `/api/ciphers/{id}/restore` — restores a trashed cipher to the active vault.
+    ///
+    /// Clears `deletedDate` on the server. The item becomes visible in the active vault again.
+    ///
+    /// Reference: Bitwarden Server API PUT /api/ciphers/{id}/restore
+    func restoreCipher(id: String) async throws
+
+    /// DELETE `/api/ciphers/purge` — permanently deletes all trashed ciphers.
+    ///
+    /// **Irreversible.** All items with a non-nil `deletedDate` are permanently removed
+    /// from the server.
+    ///
+    /// Note: The Bitwarden server accepts an optional `masterPasswordHash` body parameter on
+    /// this endpoint as an additional confirmation. v1 omits it and relies on the UI confirmation
+    /// alert instead. A future phase should add master-password re-verification before purge.
+    /// TODO: Add master-password re-prompt before calling this endpoint (deferred — requires
+    /// SecureEnclave entitlement + re-hash flow).
+    ///
+    /// Reference: Bitwarden Server API DELETE /api/ciphers/purge
+    func purgeTrashedCiphers() async throws
 }
 
 // MARK: - Wire Models
@@ -451,6 +481,79 @@ actor MacwardenAPIClientImpl: MacwardenAPIClientProtocol {
         return updated
     }
 
+    // MARK: - softDeleteCipher
+
+    func softDeleteCipher(id: String) async throws {
+        guard let base = baseURL else { throw APIError.baseURLNotSet }
+        let url = base.appendingPathComponent("api/ciphers/\(id)")
+
+        if DebugConfig.isEnabled {
+            logger.debug("[debug] softDeleteCipher → DELETE \(url.absoluteString, privacy: .public)")
+        }
+
+        var request = baseRequest(url: url)
+        request.httpMethod = "DELETE"
+        if let token = accessToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        try await performEmpty(request: request)
+        if DebugConfig.isEnabled {
+            logger.debug("[debug] softDeleteCipher ← ok id=\(id, privacy: .public)")
+        }
+    }
+
+    // MARK: - restoreCipher
+
+    func restoreCipher(id: String) async throws {
+        guard let base = baseURL else { throw APIError.baseURLNotSet }
+        let url = base.appendingPathComponent("api/ciphers/\(id)/restore")
+
+        if DebugConfig.isEnabled {
+            logger.debug("[debug] restoreCipher → PUT \(url.absoluteString, privacy: .public)")
+        }
+
+        var request = baseRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token = accessToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        // Empty body — the server identifies the cipher by URL path.
+        request.httpBody = Data("{}".utf8)
+
+        try await performEmpty(request: request)
+        if DebugConfig.isEnabled {
+            logger.debug("[debug] restoreCipher ← ok id=\(id, privacy: .public)")
+        }
+    }
+
+    // MARK: - purgeTrashedCiphers
+
+    func purgeTrashedCiphers() async throws {
+        guard let base = baseURL else { throw APIError.baseURLNotSet }
+        let url = base.appendingPathComponent("api/ciphers/purge")
+
+        if DebugConfig.isEnabled {
+            logger.debug("[debug] purgeTrashedCiphers → DELETE \(url.absoluteString, privacy: .public)")
+        }
+
+        var request = baseRequest(url: url)
+        request.httpMethod = "DELETE"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token = accessToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        // Empty JSON body — masterPasswordHash intentionally omitted in v1.
+        // See TODO in MacwardenAPIClientProtocol.purgeTrashedCiphers for rationale.
+        request.httpBody = Data("{}".utf8)
+
+        try await performEmpty(request: request)
+        if DebugConfig.isEnabled {
+            logger.debug("[debug] purgeTrashedCiphers ← ok")
+        }
+    }
+
     // MARK: - refreshAccessToken
 
     func refreshAccessToken(refreshToken: String) async throws -> (accessToken: String, refreshToken: String?) {
@@ -542,6 +645,26 @@ actor MacwardenAPIClientImpl: MacwardenAPIClientProtocol {
                 }
             }
             throw APIError.decodingFailed
+        }
+    }
+
+    /// Sends `request` and checks the HTTP status code, discarding the response body.
+    ///
+    /// Used for endpoints that return 200/204 with no meaningful response body
+    /// (soft-delete, restore, purge). Throws `APIError.httpError` on non-2xx responses.
+    private func performEmpty(request: URLRequest) async throws {
+        let (data, response) = try await session.data(for: request)
+
+        guard let http = response as? HTTPURLResponse else {
+            throw APIError.httpError(statusCode: 0, body: "")
+        }
+
+        logger.debug("[\(http.statusCode)] \(request.httpMethod ?? "?") \(request.url?.path ?? "")")
+
+        guard (200..<300).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            logger.error("HTTP \(http.statusCode) for \(request.url?.path ?? "unknown")")
+            throw APIError.httpError(statusCode: http.statusCode, body: body)
         }
     }
 

--- a/Macwarden/Data/Network/MacwardenAPIClient.swift
+++ b/Macwarden/Data/Network/MacwardenAPIClient.swift
@@ -73,14 +73,25 @@ protocol MacwardenAPIClientProtocol: Actor {
     /// Reference: Bitwarden Server API PUT /api/ciphers/{id}
     func updateCipher(id: String, cipher: RawCipher) async throws -> RawCipher
 
-    /// DELETE `/api/ciphers/{id}` — soft-deletes a cipher by moving it to Trash.
+    /// PUT `/api/ciphers/{id}/delete` — soft-deletes a cipher by moving it to Trash.
     ///
     /// Sets `deletedDate` on the server. The item remains in the user's vault data and
     /// can be restored. Bitwarden cloud auto-purges trashed items after 30 days server-side;
     /// self-hosted Vaultwarden only auto-purges if `TRASH_AUTO_DELETE_DAYS` is configured.
     ///
-    /// Reference: Bitwarden Server API DELETE /api/ciphers/{id}
+    /// Note: `DELETE /api/ciphers/{id}` is the *permanent* delete endpoint — do NOT use it
+    /// for soft-delete. The soft-delete endpoint is `PUT /api/ciphers/{id}/delete`.
+    ///
+    /// Reference: Bitwarden Server API PUT /api/ciphers/{id}/delete
     func softDeleteCipher(id: String) async throws
+
+    /// DELETE `/api/ciphers/{id}` — permanently deletes a cipher.
+    ///
+    /// **Irreversible.** Removes the cipher from the server entirely.
+    /// Used only when deleting an item that is already in Trash.
+    ///
+    /// Reference: Bitwarden Server API DELETE /api/ciphers/{id}
+    func permanentDeleteCipher(id: String) async throws
 
     /// PUT `/api/ciphers/{id}/restore` — restores a trashed cipher to the active vault.
     ///
@@ -498,10 +509,34 @@ actor MacwardenAPIClientImpl: MacwardenAPIClientProtocol {
 
     func softDeleteCipher(id: String) async throws {
         guard let base = baseURL else { throw APIError.baseURLNotSet }
+        // PUT /api/ciphers/{id}/delete — soft-delete (moves to Trash, sets deletedDate).
+        // Do NOT use DELETE /api/ciphers/{id} here; that endpoint permanently removes the cipher.
+        let url = base.appendingPathComponent("api/ciphers/\(id)/delete")
+
+        if DebugConfig.isEnabled {
+            logger.debug("[debug] softDeleteCipher → PUT \(url.absoluteString, privacy: .public)")
+        }
+
+        var request = baseRequest(url: url)
+        request.httpMethod = "PUT"
+        if let token = accessToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        try await performEmpty(request: request)
+        if DebugConfig.isEnabled {
+            logger.debug("[debug] softDeleteCipher ← ok id=\(id, privacy: .public)")
+        }
+    }
+
+    // MARK: - permanentDeleteCipher
+
+    func permanentDeleteCipher(id: String) async throws {
+        guard let base = baseURL else { throw APIError.baseURLNotSet }
         let url = base.appendingPathComponent("api/ciphers/\(id)")
 
         if DebugConfig.isEnabled {
-            logger.debug("[debug] softDeleteCipher → DELETE \(url.absoluteString, privacy: .public)")
+            logger.debug("[debug] permanentDeleteCipher → DELETE \(url.absoluteString, privacy: .public)")
         }
 
         var request = baseRequest(url: url)
@@ -512,7 +547,7 @@ actor MacwardenAPIClientImpl: MacwardenAPIClientProtocol {
 
         try await performEmpty(request: request)
         if DebugConfig.isEnabled {
-            logger.debug("[debug] softDeleteCipher ← ok id=\(id, privacy: .public)")
+            logger.debug("[debug] permanentDeleteCipher ← ok id=\(id, privacy: .public)")
         }
     }
 

--- a/Macwarden/Data/Network/MacwardenAPIClient.swift
+++ b/Macwarden/Data/Network/MacwardenAPIClient.swift
@@ -204,6 +204,19 @@ nonisolated enum APIError: Error, Equatable {
     case baseURLNotSet
 }
 
+extension APIError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .httpError(let statusCode, let body):
+            return body.isEmpty ? "Server error \(statusCode)." : "Server error \(statusCode): \(body)"
+        case .decodingFailed:
+            return "The server response could not be read. Please try again."
+        case .baseURLNotSet:
+            return "No server URL is configured."
+        }
+    }
+}
+
 // MARK: - Implementation
 
 /// URLSession-backed Bitwarden API client.
@@ -515,12 +528,11 @@ actor MacwardenAPIClientImpl: MacwardenAPIClientProtocol {
 
         var request = baseRequest(url: url)
         request.httpMethod = "PUT"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         if let token = accessToken {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
-        // Empty body — the server identifies the cipher by URL path.
-        request.httpBody = Data("{}".utf8)
+        // No body — the server identifies the cipher by URL path only.
+        // Sending Content-Type: application/json with a body causes Vaultwarden to return 400.
 
         try await performEmpty(request: request)
         if DebugConfig.isEnabled {

--- a/Macwarden/Data/Repositories/VaultRepositoryImpl.swift
+++ b/Macwarden/Data/Repositories/VaultRepositoryImpl.swift
@@ -181,35 +181,32 @@ final class VaultRepositoryImpl: VaultRepository {
 
     // MARK: - Delete / Restore / Empty Trash
 
-    /// Soft-deletes `id` by calling `DELETE /api/ciphers/{id}`.
+    /// Deletes `id`: soft-delete if active, permanent delete if already in Trash.
     ///
-    /// - Security goal: no vault key material is needed for delete — the request carries only
-    ///   the cipher ID. The access token (held by `MacwardenAPIClientImpl`) authorises the
-    ///   operation. No plaintext data is sent.
-    /// - On success the item is marked deleted in the local cache so the active list updates
-    ///   immediately without waiting for a full re-sync.
+    /// - Security goal: no vault key material is needed — only the cipher ID is sent.
+    ///   The access token (held by `MacwardenAPIClientImpl`) authorises the operation.
+    /// - Bitwarden uses two distinct endpoints:
+    ///   `PUT /ciphers/{id}/delete` for soft-delete and `DELETE /ciphers/{id}` for permanent.
+    /// - On success the local cache is updated immediately so the UI reflects the change
+    ///   without waiting for a full re-sync.
     func deleteItem(id: String) async throws {
-        // The Bitwarden server interprets `DELETE /ciphers/{id}` based on the item's current
-        // state: if `deletedDate` is nil (active item) it soft-deletes (moves to trash);
-        // if `deletedDate` is already set (trashed item) it permanently removes the cipher.
-        // The local cache mirrors this: soft-delete marks `isDeleted = true`; permanent
-        // delete removes the item entry entirely.
-        try await apiClient.softDeleteCipher(id: id)
-        if let idx = items.firstIndex(where: { $0.id == id }) {
-            if items[idx].isDeleted {
-                // Already in trash → server permanently deleted it → remove from cache.
-                items.remove(at: idx)
-                logger.info("Vault item permanently deleted: \(id, privacy: .public)")
-            } else {
-                // Active item → server soft-deleted it → mark as deleted in cache.
-                let old = items[idx]
-                items[idx] = VaultItem(
-                    id: old.id, name: old.name, isFavorite: old.isFavorite, isDeleted: true,
-                    creationDate: old.creationDate, revisionDate: old.revisionDate,
-                    content: old.content, reprompt: old.reprompt
-                )
-                logger.info("Vault item soft-deleted: \(id, privacy: .public)")
-            }
+        guard let idx = items.firstIndex(where: { $0.id == id }) else { return }
+
+        if items[idx].isDeleted {
+            // Already in Trash → permanently remove from server and cache.
+            try await apiClient.permanentDeleteCipher(id: id)
+            items.remove(at: idx)
+            logger.info("Vault item permanently deleted: \(id, privacy: .public)")
+        } else {
+            // Active item → soft-delete (moves to Trash on server).
+            try await apiClient.softDeleteCipher(id: id)
+            let old = items[idx]
+            items[idx] = VaultItem(
+                id: old.id, name: old.name, isFavorite: old.isFavorite, isDeleted: true,
+                creationDate: old.creationDate, revisionDate: old.revisionDate,
+                content: old.content, reprompt: old.reprompt
+            )
+            logger.info("Vault item soft-deleted: \(id, privacy: .public)")
         }
     }
 

--- a/Macwarden/Data/Repositories/VaultRepositoryImpl.swift
+++ b/Macwarden/Data/Repositories/VaultRepositoryImpl.swift
@@ -59,14 +59,23 @@ final class VaultRepositoryImpl: VaultRepository {
     }
 
     func items(for selection: SidebarSelection) throws -> [VaultItem] {
-        let base = items.filter { !$0.isDeleted }
         switch selection {
-        case .allItems:
-            return sorted(base)
-        case .favorites:
-            return sorted(base.filter(\.isFavorite))
-        case .type(let itemType):
-            return sorted(base.filter { $0.content.matchesItemType(itemType) })
+        case .trash:
+            // Trash shows only soft-deleted items; the isDeleted filter is inverted here.
+            return sorted(items.filter(\.isDeleted))
+        default:
+            let base = items.filter { !$0.isDeleted }
+            switch selection {
+            case .allItems:
+                return sorted(base)
+            case .favorites:
+                return sorted(base.filter(\.isFavorite))
+            case .type(let itemType):
+                return sorted(base.filter { $0.content.matchesItemType(itemType) })
+            case .trash:
+                // Handled above — unreachable, but required for exhaustive switch.
+                return []
+            }
         }
     }
 
@@ -83,6 +92,7 @@ final class VaultRepositoryImpl: VaultRepository {
         var counts: [SidebarSelection: Int] = [:]
         counts[.allItems]          = base.count
         counts[.favorites]         = base.filter(\.isFavorite).count
+        counts[.trash]             = items.filter(\.isDeleted).count
         for type in ItemType.allCases {
             counts[.type(type)]    = base.filter { $0.content.matchesItemType(type) }.count
         }
@@ -167,6 +177,67 @@ final class VaultRepositoryImpl: VaultRepository {
         logger.info("Vault item updated: \(draft.id, privacy: .public)")
 
         return updatedItem
+    }
+
+    // MARK: - Delete / Restore / Empty Trash
+
+    /// Soft-deletes `id` by calling `DELETE /api/ciphers/{id}`.
+    ///
+    /// - Security goal: no vault key material is needed for delete — the request carries only
+    ///   the cipher ID. The access token (held by `MacwardenAPIClientImpl`) authorises the
+    ///   operation. No plaintext data is sent.
+    /// - On success the item is marked deleted in the local cache so the active list updates
+    ///   immediately without waiting for a full re-sync.
+    func deleteItem(id: String) async throws {
+        // The Bitwarden server interprets `DELETE /ciphers/{id}` based on the item's current
+        // state: if `deletedDate` is nil (active item) it soft-deletes (moves to trash);
+        // if `deletedDate` is already set (trashed item) it permanently removes the cipher.
+        // The local cache mirrors this: soft-delete marks `isDeleted = true`; permanent
+        // delete removes the item entry entirely.
+        try await apiClient.softDeleteCipher(id: id)
+        if let idx = items.firstIndex(where: { $0.id == id }) {
+            if items[idx].isDeleted {
+                // Already in trash → server permanently deleted it → remove from cache.
+                items.remove(at: idx)
+                logger.info("Vault item permanently deleted: \(id, privacy: .public)")
+            } else {
+                // Active item → server soft-deleted it → mark as deleted in cache.
+                let old = items[idx]
+                items[idx] = VaultItem(
+                    id: old.id, name: old.name, isFavorite: old.isFavorite, isDeleted: true,
+                    creationDate: old.creationDate, revisionDate: old.revisionDate,
+                    content: old.content, reprompt: old.reprompt
+                )
+                logger.info("Vault item soft-deleted: \(id, privacy: .public)")
+            }
+        }
+    }
+
+    /// Restores the trashed item with `id` by calling `PUT /api/ciphers/{id}/restore`.
+    ///
+    /// - Security goal: same as `deleteItem` — only the cipher ID is sent; no key material.
+    /// - On success the item is marked active in the local cache.
+    func restoreItem(id: String) async throws {
+        try await apiClient.restoreCipher(id: id)
+        if let idx = items.firstIndex(where: { $0.id == id }) {
+            let old = items[idx]
+            items[idx] = VaultItem(
+                id: old.id, name: old.name, isFavorite: old.isFavorite, isDeleted: false,
+                creationDate: old.creationDate, revisionDate: old.revisionDate,
+                content: old.content, reprompt: old.reprompt
+            )
+        }
+        logger.info("Vault item restored: \(id, privacy: .public)")
+    }
+
+    /// Permanently deletes all trashed items by calling `DELETE /api/ciphers/purge`.
+    ///
+    /// - Security goal: no key material sent; the access token authorises the bulk purge.
+    /// - On success all items with `isDeleted == true` are removed from the local cache.
+    func emptyTrash() async throws {
+        try await apiClient.purgeTrashedCiphers()
+        items.removeAll(where: \.isDeleted)
+        logger.info("Trash emptied (all trashed items permanently deleted)")
     }
 
     // MARK: - Private helpers

--- a/Macwarden/Data/UseCases/DeleteVaultItemUseCaseImpl.swift
+++ b/Macwarden/Data/UseCases/DeleteVaultItemUseCaseImpl.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Delegates soft-delete to `VaultRepository.deleteItem(id:)`.
+final class DeleteVaultItemUseCaseImpl: DeleteVaultItemUseCase {
+
+    private let repository: any VaultRepository
+
+    init(repository: any VaultRepository) {
+        self.repository = repository
+    }
+
+    func execute(id: String) async throws {
+        try await repository.deleteItem(id: id)
+    }
+}

--- a/Macwarden/Data/UseCases/EmptyTrashUseCaseImpl.swift
+++ b/Macwarden/Data/UseCases/EmptyTrashUseCaseImpl.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Delegates empty-trash to `VaultRepository.emptyTrash()`.
+final class EmptyTrashUseCaseImpl: EmptyTrashUseCase {
+
+    private let repository: any VaultRepository
+
+    init(repository: any VaultRepository) {
+        self.repository = repository
+    }
+
+    func execute() async throws {
+        try await repository.emptyTrash()
+    }
+}

--- a/Macwarden/Data/UseCases/RestoreVaultItemUseCaseImpl.swift
+++ b/Macwarden/Data/UseCases/RestoreVaultItemUseCaseImpl.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Delegates restore to `VaultRepository.restoreItem(id:)`.
+final class RestoreVaultItemUseCaseImpl: RestoreVaultItemUseCase {
+
+    private let repository: any VaultRepository
+
+    init(repository: any VaultRepository) {
+        self.repository = repository
+    }
+
+    func execute(id: String) async throws {
+        try await repository.restoreItem(id: id)
+    }
+}

--- a/Macwarden/Domain/Entities/SidebarSelection.swift
+++ b/Macwarden/Domain/Entities/SidebarSelection.swift
@@ -43,6 +43,9 @@ nonisolated enum SidebarSelection {
     case allItems
     case favorites
     case type(ItemType)
+    /// Soft-deleted items awaiting permanent removal (Bitwarden Trash).
+    /// Items in trash have `isDeleted == true` and are excluded from all other selections.
+    case trash
 }
 
 extension SidebarSelection: Hashable {
@@ -51,6 +54,7 @@ extension SidebarSelection: Hashable {
         case (.allItems, .allItems):         return true
         case (.favorites, .favorites):       return true
         case (.type(let a), .type(let b)):   return a == b
+        case (.trash, .trash):               return true
         default:                             return false
         }
     }
@@ -60,6 +64,7 @@ extension SidebarSelection: Hashable {
         case .allItems:        hasher.combine(0)
         case .favorites:       hasher.combine(1)
         case .type(let type):  hasher.combine(2); hasher.combine(type)
+        case .trash:           hasher.combine(3)
         }
     }
 }

--- a/Macwarden/Domain/Repositories/VaultRepository.swift
+++ b/Macwarden/Domain/Repositories/VaultRepository.swift
@@ -49,6 +49,30 @@ protocol VaultRepository: AnyObject {
     /// - Throws: `VaultError.vaultLocked` if the vault is locked (translated from the Data layer).
     /// - Throws: `APIError` on network or HTTP failure.
     func update(_ draft: DraftVaultItem) async throws -> VaultItem
+
+    /// Soft-deletes the item with `id` by calling `DELETE /ciphers/{id}`.
+    ///
+    /// The item moves to Trash (`isDeleted == true`) on the server and is removed from the
+    /// active vault in the local cache. It remains recoverable until permanently deleted.
+    ///
+    /// - Throws: `APIError` on network or HTTP failure.
+    func deleteItem(id: String) async throws
+
+    /// Restores a trashed item by calling `PUT /ciphers/{id}/restore`.
+    ///
+    /// Clears `isDeleted` on the server and moves the item back to the active vault
+    /// in the local cache.
+    ///
+    /// - Throws: `APIError` on network or HTTP failure.
+    func restoreItem(id: String) async throws
+
+    /// Permanently deletes all items in trash by calling `DELETE /ciphers/purge`.
+    ///
+    /// This operation is irreversible — all trashed items are removed from the server
+    /// and cleared from the local cache.
+    ///
+    /// - Throws: `APIError` on network or HTTP failure.
+    func emptyTrash() async throws
 }
 
 // MARK: - Errors

--- a/Macwarden/Domain/UseCases/DeleteVaultItemUseCase.swift
+++ b/Macwarden/Domain/UseCases/DeleteVaultItemUseCase.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Soft-deletes a vault item by moving it to the Bitwarden Trash.
+///
+/// The item remains on the server (recoverable via `RestoreVaultItemUseCase`) until
+/// it is permanently deleted. This operation never erases data irrecoverably on its own.
+///
+/// Implemented by `DeleteVaultItemUseCaseImpl` in the Data layer.
+protocol DeleteVaultItemUseCase: AnyObject {
+    /// Moves the item identified by `id` to Trash.
+    ///
+    /// - Parameter id: The cipher UUID of the item to soft-delete.
+    /// - Throws: `APIError` on network or HTTP failure.
+    func execute(id: String) async throws
+}

--- a/Macwarden/Domain/UseCases/EmptyTrashUseCase.swift
+++ b/Macwarden/Domain/UseCases/EmptyTrashUseCase.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Permanently deletes all items in the Bitwarden Trash in a single bulk operation.
+///
+/// **This operation is irreversible.** All trashed items are removed from the server
+/// and cannot be recovered. The caller is responsible for presenting a confirmation
+/// dialog before invoking `execute()`.
+///
+/// Implemented by `EmptyTrashUseCaseImpl` in the Data layer.
+protocol EmptyTrashUseCase: AnyObject {
+    /// Permanently deletes every item currently in Trash.
+    ///
+    /// - Throws: `APIError` on network or HTTP failure.
+    func execute() async throws
+}

--- a/Macwarden/Domain/UseCases/RestoreVaultItemUseCase.swift
+++ b/Macwarden/Domain/UseCases/RestoreVaultItemUseCase.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Restores a soft-deleted vault item from Trash back to the active vault.
+///
+/// Implemented by `RestoreVaultItemUseCaseImpl` in the Data layer.
+protocol RestoreVaultItemUseCase: AnyObject {
+    /// Restores the trashed item identified by `id` to the active vault.
+    ///
+    /// - Parameter id: The cipher UUID of the trashed item to restore.
+    /// - Throws: `APIError` on network or HTTP failure.
+    func execute(id: String) async throws
+}

--- a/Macwarden/Macwarden.xcodeproj/project.pbxproj
+++ b/Macwarden/Macwarden.xcodeproj/project.pbxproj
@@ -76,6 +76,13 @@
 		FD30240C189E483CBB5E2E3B /* SidebarSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7044163F8FD4199B4925DD2 /* SidebarSelection.swift */; };
 		FE3145A0627D44CABC58ADCE /* MaskedFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8197007AA7E412D96A52B14 /* MaskedFieldView.swift */; };
 		FF0FFCD0FDD849318EBBFF77 /* FaviconLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50445584AD814B6EBD971FDA /* FaviconLoader.swift */; };
+		48891CE90AC444CF810E1256 /* DeleteVaultItemUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB0E4B753854AFF89FFFAA2 /* DeleteVaultItemUseCase.swift */; };
+		50B64B0B76674E2EAE36E66C /* RestoreVaultItemUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4929412F2A6B4670960BFB53 /* RestoreVaultItemUseCase.swift */; };
+		41470174C79D49A0BABA5AD5 /* EmptyTrashUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DB0B6F1E792423F9F3F557B /* EmptyTrashUseCase.swift */; };
+		C95CAFFEA54E4E66BED34362 /* DeleteVaultItemUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42858B188901413C9FD6C6E6 /* DeleteVaultItemUseCaseImpl.swift */; };
+		3BC539D6D63240D0B5315A0D /* RestoreVaultItemUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75776838723C412E94327CDD /* RestoreVaultItemUseCaseImpl.swift */; };
+		0213A4B95E9A4DE6938AE657 /* EmptyTrashUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E56F28CB464B95A922F683 /* EmptyTrashUseCaseImpl.swift */; };
+		421368787851407FBCA9D99F /* TrashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212734E66AE74662AD28E6CB /* TrashView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -161,6 +168,14 @@
 		F95EFA050DE64617AC5076CD /* CustomFieldsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldsSection.swift; sourceTree = "<group>"; };
 		FC4A8B1C2F9D34E100123456 /* LocalConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = LocalConfig.xcconfig; sourceTree = SOURCE_ROOT; };
 		FF00112233445566778899AA /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
+		EDB0E4B753854AFF89FFFAA2 /* DeleteVaultItemUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteVaultItemUseCase.swift; sourceTree = "<group>"; };
+		4929412F2A6B4670960BFB53 /* RestoreVaultItemUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreVaultItemUseCase.swift; sourceTree = "<group>"; };
+		9DB0B6F1E792423F9F3F557B /* EmptyTrashUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTrashUseCase.swift; sourceTree = "<group>"; };
+		42858B188901413C9FD6C6E6 /* DeleteVaultItemUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteVaultItemUseCaseImpl.swift; sourceTree = "<group>"; };
+		75776838723C412E94327CDD /* RestoreVaultItemUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreVaultItemUseCaseImpl.swift; sourceTree = "<group>"; };
+		F8E56F28CB464B95A922F683 /* EmptyTrashUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTrashUseCaseImpl.swift; sourceTree = "<group>"; };
+		212734E66AE74662AD28E6CB /* TrashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashView.swift; sourceTree = "<group>"; };
+		2D38B14DD3084CD9A3AA4FFF /* TrashJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashJourneyTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -246,6 +261,9 @@
 				5EBA517603CA448A8F9106AF /* SyncUseCase.swift */,
 				09B93B56553644E49DE5C512 /* SearchVaultUseCase.swift */,
 				D4E5F6071829304AC6D7E8F9 /* EditVaultItemUseCase.swift */,
+				EDB0E4B753854AFF89FFFAA2 /* DeleteVaultItemUseCase.swift */,
+				4929412F2A6B4670960BFB53 /* RestoreVaultItemUseCase.swift */,
+				9DB0B6F1E792423F9F3F557B /* EmptyTrashUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -341,6 +359,7 @@
 				8A9B0C1D2E3F4050A1B2C3D4 /* Edit */,
 				4309FCFA2F680CBD0031C9F4 /* ItemList */,
 				4309FCF92F680CB40031C9F4 /* Sidebar */,
+				7F9C2582320343D997856712 /* Trash */,
 			);
 			path = Vault;
 			sourceTree = "<group>";
@@ -456,6 +475,7 @@
 			isa = PBXGroup;
 			children = (
 				6D7E8F90718293040A1B2C3D /* EditItemJourneyTests.swift */,
+				2D38B14DD3084CD9A3AA4FFF /* TrashJourneyTests.swift */,
 			);
 			path = UITests;
 			sourceTree = "<group>";
@@ -543,8 +563,19 @@
 				8504983920144A92B0241CA9 /* SyncUseCaseImpl.swift */,
 				6B41D0A2F7E54938AE12C8B5 /* SearchVaultUseCaseImpl.swift */,
 				F607182930405A6CE8F90A1B /* EditVaultItemUseCaseImpl.swift */,
+				42858B188901413C9FD6C6E6 /* DeleteVaultItemUseCaseImpl.swift */,
+				75776838723C412E94327CDD /* RestoreVaultItemUseCaseImpl.swift */,
+				F8E56F28CB464B95A922F683 /* EmptyTrashUseCaseImpl.swift */,
 			);
 			path = UseCases;
+			sourceTree = "<group>";
+		};
+		7F9C2582320343D997856712 /* Trash */ = {
+			isa = PBXGroup;
+			children = (
+				212734E66AE74662AD28E6CB /* TrashView.swift */,
+			);
+			path = Trash;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -735,6 +766,13 @@
 				C3D2E3F400A1B05B50607080 /* SecureNoteEditForm.swift in Sources */,
 				E5F400A1B2C3D07D70809000 /* SSHKeyEditForm.swift in Sources */,
 				071B2C3D4E5F609F90A0B1C2 /* CustomFieldsEditSection.swift in Sources */,
+				48891CE90AC444CF810E1256 /* DeleteVaultItemUseCase.swift in Sources */,
+				50B64B0B76674E2EAE36E66C /* RestoreVaultItemUseCase.swift in Sources */,
+				41470174C79D49A0BABA5AD5 /* EmptyTrashUseCase.swift in Sources */,
+				C95CAFFEA54E4E66BED34362 /* DeleteVaultItemUseCaseImpl.swift in Sources */,
+				3BC539D6D63240D0B5315A0D /* RestoreVaultItemUseCaseImpl.swift in Sources */,
+				0213A4B95E9A4DE6938AE657 /* EmptyTrashUseCaseImpl.swift in Sources */,
+				421368787851407FBCA9D99F /* TrashView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Macwarden/MacwardenTests/DeleteRestoreVaultItemUseCaseTests.swift
+++ b/Macwarden/MacwardenTests/DeleteRestoreVaultItemUseCaseTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import Macwarden
+
+// MARK: - DeleteRestoreVaultItemUseCaseTests
+
+/// Unit tests for `DeleteVaultItemUseCaseImpl`, `RestoreVaultItemUseCaseImpl`,
+/// and `EmptyTrashUseCaseImpl`.
+///
+/// Each use case is a thin delegate — tests verify correct delegation to the
+/// repository and that errors propagate correctly.
+@MainActor
+final class DeleteRestoreVaultItemUseCaseTests: XCTestCase {
+
+    private var mockRepo: MockVaultRepository!
+    private let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+    override func setUp() async throws {
+        try await super.setUp()
+        mockRepo = MockVaultRepository()
+    }
+
+    // MARK: - DeleteVaultItemUseCase
+
+    func test_delete_delegatesToRepository() async throws {
+        let sut = DeleteVaultItemUseCaseImpl(repository: mockRepo)
+        try await sut.execute(id: "abc")
+
+        XCTAssertEqual(mockRepo.deleteCallCount, 1)
+        XCTAssertEqual(mockRepo.lastDeletedId, "abc")
+    }
+
+    func test_delete_repositoryThrows_rethrowsError() async {
+        mockRepo.stubbedDeleteError = APIError.httpError(statusCode: 500, body: "error")
+        let sut = DeleteVaultItemUseCaseImpl(repository: mockRepo)
+
+        do {
+            try await sut.execute(id: "abc")
+            XCTFail("Expected error to be thrown")
+        } catch let error as APIError {
+            guard case .httpError(let code, _) = error else {
+                return XCTFail("Expected .httpError, got \(error)")
+            }
+            XCTAssertEqual(code, 500)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    // MARK: - RestoreVaultItemUseCase
+
+    func test_restore_delegatesToRepository() async throws {
+        let sut = RestoreVaultItemUseCaseImpl(repository: mockRepo)
+        try await sut.execute(id: "xyz")
+
+        XCTAssertEqual(mockRepo.restoreCallCount, 1)
+        XCTAssertEqual(mockRepo.lastRestoredId, "xyz")
+    }
+
+    func test_restore_repositoryThrows_rethrowsError() async {
+        mockRepo.stubbedRestoreError = APIError.httpError(statusCode: 404, body: "not found")
+        let sut = RestoreVaultItemUseCaseImpl(repository: mockRepo)
+
+        do {
+            try await sut.execute(id: "xyz")
+            XCTFail("Expected error to be thrown")
+        } catch let error as APIError {
+            guard case .httpError(let code, _) = error else {
+                return XCTFail("Expected .httpError, got \(error)")
+            }
+            XCTAssertEqual(code, 404)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    // MARK: - EmptyTrashUseCase
+
+    func test_emptyTrash_delegatesToRepository() async throws {
+        let sut = EmptyTrashUseCaseImpl(repository: mockRepo)
+        try await sut.execute()
+
+        XCTAssertEqual(mockRepo.emptyTrashCallCount, 1)
+    }
+
+    func test_emptyTrash_repositoryThrows_rethrowsError() async {
+        mockRepo.stubbedEmptyTrashError = APIError.httpError(statusCode: 503, body: "unavailable")
+        let sut = EmptyTrashUseCaseImpl(repository: mockRepo)
+
+        do {
+            try await sut.execute()
+            XCTFail("Expected error to be thrown")
+        } catch let error as APIError {
+            guard case .httpError(let code, _) = error else {
+                return XCTFail("Expected .httpError, got \(error)")
+            }
+            XCTAssertEqual(code, 503)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+}

--- a/Macwarden/MacwardenTests/Mocks/MockMacwardenAPIClient.swift
+++ b/Macwarden/MacwardenTests/Mocks/MockMacwardenAPIClient.swift
@@ -134,6 +134,18 @@ actor MockMacwardenAPIClient: MacwardenAPIClientProtocol {
         if let err = softDeleteShouldThrow { throw err }
     }
 
+    // MARK: - Stubs: permanentDeleteCipher
+
+    nonisolated(unsafe) var permanentDeleteShouldThrow: Error?
+    nonisolated(unsafe) var permanentDeleteCallCount: Int = 0
+    nonisolated(unsafe) var lastPermanentDeletedId: String?
+
+    func permanentDeleteCipher(id: String) async throws {
+        permanentDeleteCallCount += 1
+        lastPermanentDeletedId = id
+        if let err = permanentDeleteShouldThrow { throw err }
+    }
+
     // MARK: - Stubs: restoreCipher
 
     nonisolated(unsafe) var restoreShouldThrow: Error?

--- a/Macwarden/MacwardenTests/Mocks/MockMacwardenAPIClient.swift
+++ b/Macwarden/MacwardenTests/Mocks/MockMacwardenAPIClient.swift
@@ -121,4 +121,38 @@ actor MockMacwardenAPIClient: MacwardenAPIClientProtocol {
         if let err = updateCipherShouldThrow { throw err }
         return updateCipherResponse ?? cipher
     }
+
+    // MARK: - Stubs: softDeleteCipher
+
+    nonisolated(unsafe) var softDeleteShouldThrow: Error?
+    nonisolated(unsafe) var softDeleteCallCount: Int = 0
+    nonisolated(unsafe) var lastSoftDeletedId: String?
+
+    func softDeleteCipher(id: String) async throws {
+        softDeleteCallCount += 1
+        lastSoftDeletedId = id
+        if let err = softDeleteShouldThrow { throw err }
+    }
+
+    // MARK: - Stubs: restoreCipher
+
+    nonisolated(unsafe) var restoreShouldThrow: Error?
+    nonisolated(unsafe) var restoreCallCount: Int = 0
+    nonisolated(unsafe) var lastRestoredId: String?
+
+    func restoreCipher(id: String) async throws {
+        restoreCallCount += 1
+        lastRestoredId = id
+        if let err = restoreShouldThrow { throw err }
+    }
+
+    // MARK: - Stubs: purgeTrashedCiphers
+
+    nonisolated(unsafe) var purgeShouldThrow: Error?
+    nonisolated(unsafe) var purgeCallCount: Int = 0
+
+    func purgeTrashedCiphers() async throws {
+        purgeCallCount += 1
+        if let err = purgeShouldThrow { throw err }
+    }
 }

--- a/Macwarden/MacwardenTests/Mocks/MockVaultRepository.swift
+++ b/Macwarden/MacwardenTests/Mocks/MockVaultRepository.swift
@@ -72,6 +72,42 @@ final class MockVaultRepository: VaultRepository {
         }
         return result
     }
+
+    // MARK: - deleteItem stubbing
+
+    var stubbedDeleteError: Error?
+    private(set) var deleteCallCount: Int = 0
+    private(set) var lastDeletedId: String?
+
+    func deleteItem(id: String) async throws {
+        deleteCallCount += 1
+        lastDeletedId = id
+        if let error = stubbedDeleteError { throw error }
+        populatedItems.removeAll { $0.id == id }
+    }
+
+    // MARK: - restoreItem stubbing
+
+    var stubbedRestoreError: Error?
+    private(set) var restoreCallCount: Int = 0
+    private(set) var lastRestoredId: String?
+
+    func restoreItem(id: String) async throws {
+        restoreCallCount += 1
+        lastRestoredId = id
+        if let error = stubbedRestoreError { throw error }
+    }
+
+    // MARK: - emptyTrash stubbing
+
+    var stubbedEmptyTrashError: Error?
+    private(set) var emptyTrashCallCount: Int = 0
+
+    func emptyTrash() async throws {
+        emptyTrashCallCount += 1
+        if let error = stubbedEmptyTrashError { throw error }
+        populatedItems.removeAll(where: \.isDeleted)
+    }
 }
 
 // MARK: - ItemContent helper

--- a/Macwarden/MacwardenTests/VaultRepositoryImplDeleteRestoreTests.swift
+++ b/Macwarden/MacwardenTests/VaultRepositoryImplDeleteRestoreTests.swift
@@ -1,0 +1,215 @@
+import XCTest
+@testable import Macwarden
+
+// MARK: - VaultRepositoryImplDeleteRestoreTests
+
+/// Integration tests for the delete, restore, and empty-trash operations in
+/// `VaultRepositoryImpl`.
+///
+/// Covers:
+///   - deleteItem soft-deletes active items (marks isDeleted, stays in cache)
+///   - deleteItem permanently removes already-trashed items from cache
+///   - restoreItem marks trashed items as active
+///   - emptyTrash removes all trashed items from cache
+///   - items(for: .trash) returns only trashed items
+///   - itemCounts includes .trash count
+///   - API errors propagate correctly
+@MainActor
+final class VaultRepositoryImplDeleteRestoreTests: XCTestCase {
+
+    private var sut: VaultRepositoryImpl!
+    private var mockAPI: MockMacwardenAPIClient!
+    private var mockCrypto: MockMacwardenCryptoService!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        mockAPI    = MockMacwardenAPIClient()
+        mockCrypto = MockMacwardenCryptoService()
+        sut        = VaultRepositoryImpl(apiClient: mockAPI, crypto: mockCrypto)
+    }
+
+    // MARK: - Helpers
+
+    private func makeLogin(
+        id: String = UUID().uuidString,
+        name: String,
+        isDeleted: Bool = false
+    ) -> VaultItem {
+        VaultItem(
+            id: id, name: name, isFavorite: false, isDeleted: isDeleted,
+            creationDate: Date(), revisionDate: Date(),
+            content: .login(LoginContent(
+                username: nil, password: nil, uris: [], totp: nil,
+                notes: nil, customFields: []
+            ))
+        )
+    }
+
+    // MARK: - deleteItem (soft-delete active item)
+
+    func testDeleteItem_activeItem_marksDeletedInCache() async throws {
+        let item = makeLogin(id: "id-1", name: "Active Item")
+        sut.populate(items: [item], syncedAt: Date())
+
+        try await sut.deleteItem(id: "id-1")
+
+        // Item should still be in the cache but marked deleted.
+        let allActive = try sut.allItems()
+        XCTAssertTrue(allActive.isEmpty, "Active list should exclude soft-deleted item")
+
+        let trashed = try sut.items(for: .trash)
+        XCTAssertEqual(trashed.count, 1)
+        XCTAssertEqual(trashed[0].id, "id-1")
+        XCTAssertTrue(trashed[0].isDeleted)
+    }
+
+    func testDeleteItem_activeItem_callsAPIOnce() async throws {
+        let item = makeLogin(id: "id-1", name: "Active")
+        sut.populate(items: [item], syncedAt: Date())
+
+        try await sut.deleteItem(id: "id-1")
+
+        XCTAssertEqual(mockAPI.softDeleteCallCount, 1)
+        XCTAssertEqual(mockAPI.lastSoftDeletedId, "id-1")
+    }
+
+    func testDeleteItem_trashedItem_removesFromCachePermanently() async throws {
+        let item = makeLogin(id: "id-2", name: "Trashed Item", isDeleted: true)
+        sut.populate(items: [item], syncedAt: Date())
+
+        try await sut.deleteItem(id: "id-2")
+
+        // Item should be completely removed.
+        let trashed = try sut.items(for: .trash)
+        XCTAssertTrue(trashed.isEmpty, "Item should be removed from cache after permanent delete")
+    }
+
+    func testDeleteItem_apiError_doesNotUpdateCache() async throws {
+        let item = makeLogin(id: "id-3", name: "Item")
+        sut.populate(items: [item], syncedAt: Date())
+        mockAPI.softDeleteShouldThrow = APIError.httpError(statusCode: 500, body: "fail")
+
+        do {
+            try await sut.deleteItem(id: "id-3")
+            XCTFail("Expected error")
+        } catch { }
+
+        // Cache should be unchanged after a failed API call.
+        let active = try sut.allItems()
+        XCTAssertEqual(active.count, 1, "Item should remain active when API call fails")
+    }
+
+    // MARK: - restoreItem
+
+    func testRestoreItem_trashedItem_marksActiveInCache() async throws {
+        let item = makeLogin(id: "id-4", name: "Trashed", isDeleted: true)
+        sut.populate(items: [item], syncedAt: Date())
+
+        try await sut.restoreItem(id: "id-4")
+
+        let active = try sut.allItems()
+        XCTAssertEqual(active.count, 1)
+        XCTAssertFalse(active[0].isDeleted)
+
+        let trashed = try sut.items(for: .trash)
+        XCTAssertTrue(trashed.isEmpty, "Restored item should not appear in trash")
+    }
+
+    func testRestoreItem_callsAPIOnce() async throws {
+        let item = makeLogin(id: "id-4", name: "Trashed", isDeleted: true)
+        sut.populate(items: [item], syncedAt: Date())
+
+        try await sut.restoreItem(id: "id-4")
+
+        XCTAssertEqual(mockAPI.restoreCallCount, 1)
+        XCTAssertEqual(mockAPI.lastRestoredId, "id-4")
+    }
+
+    func testRestoreItem_apiError_doesNotUpdateCache() async throws {
+        let item = makeLogin(id: "id-5", name: "Trashed", isDeleted: true)
+        sut.populate(items: [item], syncedAt: Date())
+        mockAPI.restoreShouldThrow = APIError.httpError(statusCode: 503, body: "unavailable")
+
+        do {
+            try await sut.restoreItem(id: "id-5")
+            XCTFail("Expected error")
+        } catch { }
+
+        let trashed = try sut.items(for: .trash)
+        XCTAssertEqual(trashed.count, 1, "Trashed item should remain when API call fails")
+    }
+
+    // MARK: - emptyTrash
+
+    func testEmptyTrash_removesAllTrashedItemsFromCache() async throws {
+        let active  = makeLogin(name: "Active",    isDeleted: false)
+        let trash1  = makeLogin(name: "Trashed 1", isDeleted: true)
+        let trash2  = makeLogin(name: "Trashed 2", isDeleted: true)
+        sut.populate(items: [active, trash1, trash2], syncedAt: Date())
+
+        try await sut.emptyTrash()
+
+        let trashed = try sut.items(for: .trash)
+        XCTAssertTrue(trashed.isEmpty, "All trashed items should be removed after empty-trash")
+
+        // Active item should be unaffected.
+        let stillActive = try sut.allItems()
+        XCTAssertEqual(stillActive.count, 1)
+        XCTAssertEqual(stillActive[0].name, "Active")
+    }
+
+    func testEmptyTrash_callsAPIOnce() async throws {
+        sut.populate(items: [makeLogin(name: "T", isDeleted: true)], syncedAt: Date())
+
+        try await sut.emptyTrash()
+
+        XCTAssertEqual(mockAPI.purgeCallCount, 1)
+    }
+
+    func testEmptyTrash_apiError_doesNotUpdateCache() async throws {
+        let item = makeLogin(name: "Trashed", isDeleted: true)
+        sut.populate(items: [item], syncedAt: Date())
+        mockAPI.purgeShouldThrow = APIError.httpError(statusCode: 500, body: "fail")
+
+        do {
+            try await sut.emptyTrash()
+            XCTFail("Expected error")
+        } catch { }
+
+        let trashed = try sut.items(for: .trash)
+        XCTAssertEqual(trashed.count, 1, "Trashed items should remain when API call fails")
+    }
+
+    // MARK: - items(for: .trash)
+
+    func testItemsForTrash_onlyReturnsTrashedItems() throws {
+        let active  = makeLogin(name: "Active",  isDeleted: false)
+        let trashed = makeLogin(name: "Trashed", isDeleted: true)
+        sut.populate(items: [active, trashed], syncedAt: Date())
+
+        let result = try sut.items(for: .trash)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].name, "Trashed")
+    }
+
+    func testItemsForTrash_empty_returnsEmpty() throws {
+        sut.populate(items: [makeLogin(name: "Active")], syncedAt: Date())
+        let result = try sut.items(for: .trash)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - itemCounts(.trash)
+
+    func testItemCounts_includesTrashCount() throws {
+        let items: [VaultItem] = [
+            makeLogin(name: "A", isDeleted: false),
+            makeLogin(name: "B", isDeleted: true),
+            makeLogin(name: "C", isDeleted: true),
+        ]
+        sut.populate(items: items, syncedAt: Date())
+
+        let counts = try sut.itemCounts()
+        XCTAssertEqual(counts[.trash], 2, "Trash count should reflect all isDeleted items")
+        XCTAssertEqual(counts[.allItems], 1, "Active count should exclude deleted items")
+    }
+}

--- a/Macwarden/Presentation/AccessibilityIdentifiers.swift
+++ b/Macwarden/Presentation/AccessibilityIdentifiers.swift
@@ -60,6 +60,7 @@ nonisolated enum AccessibilityID {
         static let list              = "sidebar.list"
         static let allItems          = "sidebar.allItems"
         static let favorites         = "sidebar.favorites"
+        static let trash             = "sidebar.trash"
         static func type(_ name: String) -> String { "sidebar.type.\(name)" }
     }
 
@@ -111,5 +112,20 @@ nonisolated enum AccessibilityID {
         static let discardButton = "edit.button.discard"
         /// The inline error banner shown on save failure.
         static let errorBanner   = "edit.errorBanner"
+    }
+
+    // MARK: - Trash (delete-restore-items)
+
+    enum Trash {
+        /// The "Empty Trash" toolbar button in TrashView.
+        static let emptyTrashButton  = "trash.button.emptyTrash"
+        /// The empty-state view shown when Trash contains no items.
+        static let emptyState        = "trash.emptyState"
+        /// The banner shown in ItemDetailView when the selected item is in trash.
+        static let statusBanner      = "trash.statusBanner"
+        /// The "Restore" toolbar button in ItemDetailView for trashed items.
+        static let restoreButton     = "trash.button.restore"
+        /// The "Delete Permanently" toolbar button in ItemDetailView for trashed items.
+        static let permanentDeleteButton = "trash.button.permanentDelete"
     }
 }

--- a/Macwarden/Presentation/Vault/Detail/ItemDetailView.swift
+++ b/Macwarden/Presentation/Vault/Detail/ItemDetailView.swift
@@ -18,6 +18,13 @@ struct ItemDetailView: View {
     /// Called when the edit sheet opens (`true`) or closes (`false`).
     /// Drives `MenuBarViewModel.canEdit` / `canSave` state (task 9.5).
     var onEditSheetChanged: ((Bool) -> Void)? = nil
+    /// Called to soft-delete the current active item (moves it to Trash).
+    /// Nil when the detail pane does not support delete (e.g. unit-test stubs).
+    var onSoftDelete: ((String) async -> Void)? = nil
+    /// Called to restore the current trashed item back to the active vault.
+    var onRestore: ((String) async -> Void)? = nil
+    /// Called to permanently delete the current trashed item.
+    var onPermanentDelete: ((String) async -> Void)? = nil
 
     /// Incremented by `VaultBrowserViewModel.triggerEdit()` when the "Item > Edit" menu bar
     /// action fires (spec §9.3). `.onChange` opens the edit sheet for the current item.
@@ -33,9 +40,21 @@ struct ItemDetailView: View {
     /// released (nil'd) when the sheet is dismissed to clear the draft from memory (§III).
     @State private var editViewModel: ItemEditViewModel?
 
+    // Confirmation alert state for soft-delete from the detail toolbar.
+    @State private var showSoftDeleteAlert:    Bool = false
+    // Confirmation alert state for permanent delete from the detail toolbar (trashed items).
+    @State private var showPermanentDeleteAlert: Bool = false
+
     var body: some View {
         if let item {
             VStack(spacing: 0) {
+                // Trash status banner — shown when the item is soft-deleted.
+                // Editing is disabled for trashed items (the Bitwarden API rejects PUT on
+                // a deleted cipher); the user must restore before editing.
+                if item.isDeleted {
+                    trashBanner(for: item)
+                }
+
                 // Item name header with favicon/type icon
                 HStack(alignment: .center, spacing: 12) {
                     FaviconView(
@@ -79,17 +98,57 @@ struct ItemDetailView: View {
                 .padding(12)
             }
             .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    // Edit button — visible only when an item is selected (this branch).
-                    // ⌘E shortcut fires only when the button is enabled (sheet not open).
-                    // spec §8.5, §8.7
-                    Button("Edit") {
-                        openEditSheet(for: item)
+                if item.isDeleted {
+                    // Trashed item toolbar: Restore + Delete Permanently.
+                    // The Edit button is intentionally absent — the Bitwarden API returns
+                    // an error if PUT is called on a cipher with a non-nil deletedDate.
+                    ToolbarItemGroup(placement: .primaryAction) {
+                        Button("Restore") {
+                            Task { await onRestore?(item.id) }
+                        }
+                        .accessibilityIdentifier(AccessibilityID.Trash.restoreButton)
+
+                        Button("Delete Permanently", role: .destructive) {
+                            showPermanentDeleteAlert = true
+                        }
+                        .accessibilityIdentifier(AccessibilityID.Trash.permanentDeleteButton)
                     }
-                    .disabled(isEditSheetPresented)
-                    .keyboardShortcut("e", modifiers: .command)
-                    .accessibilityIdentifier(AccessibilityID.Edit.editButton)
+                } else {
+                    // Active item toolbar: Edit + Delete.
+                    ToolbarItemGroup(placement: .primaryAction) {
+                        Button("Delete", role: .destructive) {
+                            showSoftDeleteAlert = true
+                        }
+
+                        // Edit button — visible only when an item is selected (this branch).
+                        // ⌘E shortcut fires only when the button is enabled (sheet not open).
+                        // spec §8.5, §8.7
+                        Button("Edit") {
+                            openEditSheet(for: item)
+                        }
+                        .disabled(isEditSheetPresented)
+                        .keyboardShortcut("e", modifiers: .command)
+                        .accessibilityIdentifier(AccessibilityID.Edit.editButton)
+                    }
                 }
+            }
+            // Soft-delete confirmation alert (active items).
+            .alert("Move to Trash?", isPresented: $showSoftDeleteAlert) {
+                Button("Move to Trash", role: .destructive) {
+                    Task { await onSoftDelete?(item.id) }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text(""\(item.name)" will be moved to Trash.")
+            }
+            // Permanent delete confirmation alert (trashed items).
+            .alert("Delete Permanently?", isPresented: $showPermanentDeleteAlert) {
+                Button("Delete Permanently", role: .destructive) {
+                    Task { await onPermanentDelete?(item.id) }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text(""\(item.name)" will be permanently deleted and cannot be recovered.")
             }
             .sheet(isPresented: $isEditSheetPresented, onDismiss: {
                 editViewModel = nil
@@ -100,7 +159,8 @@ struct ItemDetailView: View {
                 }
             }
             // Menu bar "Edit" action — mirrors the toolbar Edit button (spec §9.3).
-            .onChangeCompat(of: editTrigger) { openEditSheet(for: item) }
+            // Guard against trashed items: edit is not permitted while in trash.
+            .onChangeCompat(of: editTrigger) { if !item.isDeleted { openEditSheet(for: item) } }
             // Menu bar "Save" action — mirrors the in-sheet Save button (spec §9.4).
             // `ItemEditViewModel.save()` is a no-op if `canSave` is false, so this is safe
             // even when called while the name is blank or a save is already in-flight.
@@ -113,6 +173,26 @@ struct ItemDetailView: View {
             )
             .accessibilityIdentifier(AccessibilityID.Detail.emptyState)
         }
+    }
+
+    // MARK: - Trash banner
+
+    /// Banner shown at the top of the detail pane when the item is in Trash.
+    /// Communicates that the item is not editable and can be restored or permanently deleted.
+    @ViewBuilder
+    private func trashBanner(for item: VaultItem) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "trash")
+                .foregroundStyle(.secondary)
+            Text("This item is in Trash.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(.horizontal, Spacing.pageMargin)
+        .padding(.vertical, 8)
+        .background(Color.secondary.opacity(0.1))
+        .accessibilityIdentifier(AccessibilityID.Trash.statusBanner)
     }
 
     // MARK: - Edit sheet

--- a/Macwarden/Presentation/Vault/Detail/ItemDetailView.swift
+++ b/Macwarden/Presentation/Vault/Detail/ItemDetailView.swift
@@ -139,7 +139,7 @@ struct ItemDetailView: View {
                 }
                 Button("Cancel", role: .cancel) {}
             } message: {
-                Text(""\(item.name)" will be moved to Trash.")
+                Text("\"\(item.name)\" will be moved to Trash.")
             }
             // Permanent delete confirmation alert (trashed items).
             .alert("Delete Permanently?", isPresented: $showPermanentDeleteAlert) {
@@ -148,7 +148,7 @@ struct ItemDetailView: View {
                 }
                 Button("Cancel", role: .cancel) {}
             } message: {
-                Text(""\(item.name)" will be permanently deleted and cannot be recovered.")
+                Text("\"\(item.name)\" will be permanently deleted and cannot be recovered.")
             }
             .sheet(isPresented: $isEditSheetPresented, onDismiss: {
                 editViewModel = nil

--- a/Macwarden/Presentation/Vault/ItemList/ItemListView.swift
+++ b/Macwarden/Presentation/Vault/ItemList/ItemListView.swift
@@ -6,11 +6,19 @@ import SwiftUI
 ///
 /// Items are already pre-sorted by `VaultRepositoryImpl`; this view renders them as-is.
 /// An empty state message is shown when the list is empty (FR-042).
+/// Each row has a context menu with a "Delete" action that moves the item to Trash.
 struct ItemListView: View {
 
     let items:         [VaultItem]
     @Binding var selection: VaultItem?
     let faviconLoader: FaviconLoader
+    /// Called when the user confirms moving an item to Trash from the row context menu.
+    /// Nil disables the delete context-menu action (e.g. when trash actions are unavailable).
+    var onDelete: ((String) async -> Void)? = nil
+
+    // Tracks which item is pending a soft-delete confirmation alert.
+    @State private var itemToDelete:    VaultItem? = nil
+    @State private var showDeleteAlert: Bool       = false
 
     var body: some View {
         Group {
@@ -26,6 +34,29 @@ struct ItemListView: View {
                     ItemRowView(item: item, faviconLoader: faviconLoader)
                         .tag(item)
                         .accessibilityIdentifier(AccessibilityID.ItemList.row(item.id))
+                        .contextMenu {
+                            if onDelete != nil {
+                                Button("Delete", role: .destructive) {
+                                    itemToDelete    = item
+                                    showDeleteAlert = true
+                                }
+                            }
+                        }
+                }
+                // Soft-delete confirmation alert — shown when the user selects "Delete"
+                // from a row context menu. The item is only moved to Trash, not permanently
+                // deleted; it can be recovered from the Trash view.
+                .alert(
+                    "Move to Trash?",
+                    isPresented: $showDeleteAlert,
+                    presenting:  itemToDelete
+                ) { item in
+                    Button("Move to Trash", role: .destructive) {
+                        Task { await onDelete?(item.id) }
+                    }
+                    Button("Cancel", role: .cancel) {}
+                } message: { item in
+                    Text(""\(item.name)" will be moved to Trash.")
                 }
             }
         }

--- a/Macwarden/Presentation/Vault/ItemList/ItemListView.swift
+++ b/Macwarden/Presentation/Vault/ItemList/ItemListView.swift
@@ -56,7 +56,7 @@ struct ItemListView: View {
                     }
                     Button("Cancel", role: .cancel) {}
                 } message: { item in
-                    Text(""\(item.name)" will be moved to Trash.")
+                    Text("\"\(item.name)\" will be moved to Trash.")
                 }
             }
         }

--- a/Macwarden/Presentation/Vault/Sidebar/SidebarView.swift
+++ b/Macwarden/Presentation/Vault/Sidebar/SidebarView.swift
@@ -43,6 +43,18 @@ struct SidebarView: View {
                     .accessibilityIdentifier(AccessibilityID.Sidebar.type(type.displayName))
                 }
             }
+
+            // MARK: Trash section
+            // Shown without a badge count when empty so users know the section exists.
+            Section {
+                SidebarRowView(
+                    title:       "Trash",
+                    systemImage: "trash",
+                    selection:   .trash,
+                    count:       itemCounts[.trash] ?? 0
+                )
+                .accessibilityIdentifier(AccessibilityID.Sidebar.trash)
+            }
         }
         .navigationTitle("Macwarden")
     }

--- a/Macwarden/Presentation/Vault/Trash/TrashView.swift
+++ b/Macwarden/Presentation/Vault/Trash/TrashView.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+// MARK: - TrashView
+
+/// Middle-column list of trashed vault items (items where `isDeleted == true`).
+///
+/// Provides:
+/// - Empty state when no items are in trash.
+/// - Per-row context menus with "Restore" and "Delete Permanently" actions.
+/// - "Empty Trash" toolbar button (disabled when the list is empty).
+/// - Confirmation alerts before any destructive operation.
+struct TrashView: View {
+
+    let items:         [VaultItem]
+    @Binding var selection: VaultItem?
+    let faviconLoader: FaviconLoader
+    let onRestore:          (String) async -> Void
+    /// Called to permanently delete a single trashed item (irreversible).
+    let onPermanentDelete:  (String) async -> Void
+    let onEmptyTrash:       () async -> Void
+
+    // Confirmation alert state for single-item permanent delete.
+    @State private var itemToDelete:    VaultItem? = nil
+    @State private var showDeleteAlert: Bool       = false
+
+    // Confirmation alert state for empty-trash.
+    @State private var showEmptyTrashAlert: Bool = false
+
+    var body: some View {
+        Group {
+            if items.isEmpty {
+                emptyState
+            } else {
+                List(items, id: \.id, selection: $selection) { item in
+                    ItemRowView(item: item, faviconLoader: faviconLoader)
+                        .tag(item)
+                        .accessibilityIdentifier(AccessibilityID.ItemList.row(item.id))
+                        .contextMenu {
+                            Button("Restore") {
+                                Task { await onRestore(item.id) }
+                            }
+                            Divider()
+                            Button("Delete Permanently", role: .destructive) {
+                                itemToDelete    = item
+                                showDeleteAlert = true
+                            }
+                            .accessibilityIdentifier(AccessibilityID.Trash.permanentDeleteButton)
+                        }
+                }
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Empty Trash") {
+                    showEmptyTrashAlert = true
+                }
+                .disabled(items.isEmpty)
+                .accessibilityIdentifier(AccessibilityID.Trash.emptyTrashButton)
+            }
+        }
+        // Confirmation alert: single permanent delete.
+        .alert(
+            "Delete Permanently?",
+            isPresented: $showDeleteAlert,
+            presenting:  itemToDelete
+        ) { item in
+            Button("Delete Permanently", role: .destructive) {
+                Task { await onPermanentDelete(item.id) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { item in
+            Text(""\(item.name)" will be permanently deleted and cannot be recovered.")
+        }
+        // Confirmation alert: empty trash.
+        .alert("Empty Trash?", isPresented: $showEmptyTrashAlert) {
+            Button("Empty Trash", role: .destructive) {
+                Task { await onEmptyTrash() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("All \(items.count) item\(items.count == 1 ? "" : "s") in Trash will be permanently deleted and cannot be recovered.")
+        }
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        ContentUnavailableView(
+            "No Items in Trash",
+            systemImage: "trash",
+            description: Text("Items you delete will appear here.")
+        )
+        .accessibilityIdentifier(AccessibilityID.Trash.emptyState)
+    }
+}

--- a/Macwarden/Presentation/Vault/Trash/TrashView.swift
+++ b/Macwarden/Presentation/Vault/Trash/TrashView.swift
@@ -69,7 +69,7 @@ struct TrashView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: { item in
-            Text(""\(item.name)" will be permanently deleted and cannot be recovered.")
+            Text("\"\(item.name)\" will be permanently deleted and cannot be recovered.")
         }
         // Confirmation alert: empty trash.
         .alert("Empty Trash?", isPresented: $showEmptyTrashAlert) {

--- a/Macwarden/Presentation/Vault/VaultBrowserView.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserView.swift
@@ -64,12 +64,12 @@ struct VaultBrowserView: View {
                         viewModel.handleEditSheetState(open)
                         onEditSheetState?(open)
                     },
-                    // Relay menu bar Edit/Save actions into the detail pane (spec §9.3–9.4).
-                    editTrigger:         viewModel.editTrigger,
-                    saveTrigger:         viewModel.saveTrigger,
                     onSoftDelete:        { id in await viewModel.performSoftDelete(id: id) },
                     onRestore:           { id in await viewModel.performRestore(id: id) },
-                    onPermanentDelete:   { id in await viewModel.performPermanentDelete(id: id) }
+                    onPermanentDelete:   { id in await viewModel.performPermanentDelete(id: id) },
+                    // Relay menu bar Edit/Save actions into the detail pane (spec §9.3–9.4).
+                    editTrigger:         viewModel.editTrigger,
+                    saveTrigger:         viewModel.saveTrigger
                 )
             }
         )

--- a/Macwarden/Presentation/Vault/VaultBrowserView.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserView.swift
@@ -33,11 +33,24 @@ struct VaultBrowserView: View {
             content: {
                 VStack(spacing: 0) {
                     syncErrorBanner
-                    ItemListView(
-                        items:        viewModel.displayedItems,
-                        selection:    $viewModel.itemSelection,
-                        faviconLoader: faviconLoader
-                    )
+                    if viewModel.sidebarSelection == .trash {
+                        // Trash pane — shows soft-deleted items with restore/purge actions.
+                        TrashView(
+                            items:           viewModel.displayedItems,
+                            selection:       $viewModel.itemSelection,
+                            faviconLoader:   faviconLoader,
+                            onRestore:       { id in await viewModel.performRestore(id: id) },
+                            onPermanentDelete: { id in await viewModel.performPermanentDelete(id: id) },
+                            onEmptyTrash:    { await viewModel.performEmptyTrash() }
+                        )
+                    } else {
+                        ItemListView(
+                            items:        viewModel.displayedItems,
+                            selection:    $viewModel.itemSelection,
+                            faviconLoader: faviconLoader,
+                            onDelete:     { id in await viewModel.performSoftDelete(id: id) }
+                        )
+                    }
                 }
                 .navigationSplitViewColumnWidth(min: 220, ideal: 280)
             },
@@ -53,12 +66,24 @@ struct VaultBrowserView: View {
                     },
                     // Relay menu bar Edit/Save actions into the detail pane (spec §9.3–9.4).
                     editTrigger:         viewModel.editTrigger,
-                    saveTrigger:         viewModel.saveTrigger
+                    saveTrigger:         viewModel.saveTrigger,
+                    onSoftDelete:        { id in await viewModel.performSoftDelete(id: id) },
+                    onRestore:           { id in await viewModel.performRestore(id: id) },
+                    onPermanentDelete:   { id in await viewModel.performPermanentDelete(id: id) }
                 )
             }
         )
         .navigationSplitViewStyle(.balanced)
         .searchable(text: $viewModel.searchQuery, prompt: "Search vault")
+        // Error alert for delete / restore / empty-trash failures.
+        .alert("Action Failed", isPresented: Binding(
+            get:  { viewModel.actionError != nil },
+            set:  { if !$0 { viewModel.actionError = nil } }
+        )) {
+            Button("OK", role: .cancel) { viewModel.actionError = nil }
+        } message: {
+            Text(viewModel.actionError ?? "")
+        }
         .accessibilityIdentifier(AccessibilityID.Vault.navigationSplit)
         .toolbar {
             ToolbarItem(placement: .automatic) {

--- a/Macwarden/Presentation/Vault/VaultBrowserViewModel.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserViewModel.swift
@@ -42,10 +42,19 @@ final class VaultBrowserViewModel: ObservableObject {
     /// to enable/disable the Edit and Save menu bar actions.
     @Published private(set) var editSheetOpen: Bool = false
 
+    // MARK: - Published state (trash actions)
+
+    /// Set when a delete, restore, or empty-trash operation fails.
+    /// The Presentation layer surfaces this as an alert.
+    @Published var actionError: String? = nil
+
     // MARK: - Dependencies
 
-    private let vault:  any VaultRepository
-    private let search: any SearchVaultUseCase
+    private let vault:           any VaultRepository
+    private let search:          any SearchVaultUseCase
+    private let deleteUseCase:   any DeleteVaultItemUseCase
+    private let restoreUseCase:  any RestoreVaultItemUseCase
+    private let emptyTrashCase:  any EmptyTrashUseCase
     private let logger = Logger(subsystem: "com.macwarden", category: "VaultBrowserViewModel")
 
     // MARK: - Menu bar action relay
@@ -69,9 +78,18 @@ final class VaultBrowserViewModel: ObservableObject {
 
     // MARK: - Init
 
-    init(vault: any VaultRepository, search: any SearchVaultUseCase) {
-        self.vault  = vault
-        self.search = search
+    init(
+        vault:      any VaultRepository,
+        search:     any SearchVaultUseCase,
+        delete:     any DeleteVaultItemUseCase,
+        restore:    any RestoreVaultItemUseCase,
+        emptyTrash: any EmptyTrashUseCase
+    ) {
+        self.vault          = vault
+        self.search         = search
+        self.deleteUseCase  = delete
+        self.restoreUseCase = restore
+        self.emptyTrashCase = emptyTrash
         refreshItems()
         refreshCounts()
         lastSyncedAt = vault.lastSyncedAt
@@ -153,5 +171,76 @@ final class VaultBrowserViewModel: ObservableObject {
         itemSelection = updatedItem
         refreshItems()
         refreshCounts()
+    }
+
+    // MARK: - Delete / Restore / Empty Trash
+
+    /// Soft-deletes `id`, moving it to Trash.
+    ///
+    /// On success refreshes the active list and sidebar counts. If the deleted item was
+    /// selected in the detail pane, it is deselected so the empty-state appears.
+    /// Errors are surfaced via `actionError` for the Presentation layer to show as an alert.
+    func performSoftDelete(id: String) async {
+        do {
+            try await deleteUseCase.execute(id: id)
+            logger.info("Item soft-deleted: \(id, privacy: .public)")
+            if itemSelection?.id == id { itemSelection = nil }
+            refreshItems()
+            refreshCounts()
+        } catch {
+            logger.error("Soft-delete failed for \(id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            actionError = error.localizedDescription
+        }
+    }
+
+    /// Restores the trashed item with `id` to the active vault.
+    ///
+    /// On success refreshes the list and sidebar counts. If the restored item was selected
+    /// in the detail pane, deselects it (it has moved to the active vault).
+    func performRestore(id: String) async {
+        do {
+            try await restoreUseCase.execute(id: id)
+            logger.info("Item restored: \(id, privacy: .public)")
+            if itemSelection?.id == id { itemSelection = nil }
+            refreshItems()
+            refreshCounts()
+        } catch {
+            logger.error("Restore failed for \(id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            actionError = error.localizedDescription
+        }
+    }
+
+    /// Permanently deletes the trashed item with `id`.
+    ///
+    /// The item must already be in Trash (`isDeleted == true`). Calling `DELETE /ciphers/{id}`
+    /// on a trashed item causes the Bitwarden server to permanently remove it.
+    /// The caller is responsible for showing a confirmation alert before invoking this method.
+    func performPermanentDelete(id: String) async {
+        do {
+            try await deleteUseCase.execute(id: id)
+            logger.info("Item permanently deleted: \(id, privacy: .public)")
+            if itemSelection?.id == id { itemSelection = nil }
+            refreshItems()
+            refreshCounts()
+        } catch {
+            logger.error("Permanent delete failed for \(id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            actionError = error.localizedDescription
+        }
+    }
+
+    /// Permanently deletes all items in Trash.
+    ///
+    /// The caller is responsible for showing a confirmation alert before invoking this method.
+    func performEmptyTrash() async {
+        do {
+            try await emptyTrashCase.execute()
+            logger.info("Trash emptied")
+            if itemSelection?.isDeleted == true { itemSelection = nil }
+            refreshItems()
+            refreshCounts()
+        } catch {
+            logger.error("Empty trash failed: \(error.localizedDescription, privacy: .public)")
+            actionError = error.localizedDescription
+        }
     }
 }

--- a/Macwarden/Tests/UITests/TrashJourneyTests.swift
+++ b/Macwarden/Tests/UITests/TrashJourneyTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+
+/// XCUITest: Trash Journey (delete-restore-items)
+///
+/// Validates the full delete → trash → restore flow and the permanent delete + empty-trash
+/// flows through the UI.
+///
+/// Prerequisites: App launched with `--ui-testing`, `--inject-session`, `--inject-vault`,
+/// `--skip-sync` so a pre-populated vault (including at least one active item and one
+/// pre-trashed item) is available without a network round-trip.
+final class TrashJourneyTests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments = ["--ui-testing", "--inject-session", "--inject-vault", "--skip-sync"]
+        app.launch()
+
+        let vaultNav = app.otherElements["vault.navigationSplit"]
+        XCTAssertTrue(vaultNav.waitForExistence(timeout: 30), "Vault browser must be visible")
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+    }
+
+    // MARK: - 7.1: Soft-delete from list, verify item appears in Trash
+
+    /// Soft-deletes the first item via the list context menu and verifies it appears
+    /// in the Trash sidebar selection.
+    func testSoftDelete_fromListContextMenu_itemAppearsInTrash() throws {
+        let list     = app.tables["itemList.list"]
+        let firstRow = list.cells.firstMatch
+        XCTAssertTrue(firstRow.waitForExistence(timeout: 5), "Vault list must have at least one item")
+
+        let itemName = firstRow.staticTexts.firstMatch.label
+
+        // Right-click to open the context menu and choose Delete.
+        firstRow.rightClick()
+        let deleteMenuItem = app.menuItems["Delete"]
+        XCTAssertTrue(deleteMenuItem.waitForExistence(timeout: 3))
+        deleteMenuItem.click()
+
+        // Confirm the "Move to Trash?" alert.
+        let moveToTrashButton = app.buttons["Move to Trash"]
+        XCTAssertTrue(moveToTrashButton.waitForExistence(timeout: 3))
+        moveToTrashButton.click()
+
+        // Navigate to Trash.
+        let trashSidebarRow = app.buttons["sidebar.trash"]
+        XCTAssertTrue(trashSidebarRow.waitForExistence(timeout: 3))
+        trashSidebarRow.click()
+
+        // Verify the deleted item now appears in the Trash list.
+        let trashedRow = app.tables["itemList.list"].cells.containing(.staticText, identifier: itemName).firstMatch
+        XCTAssertTrue(trashedRow.waitForExistence(timeout: 5), "Deleted item should appear in Trash")
+    }
+
+    // MARK: - 7.2: Restore from Trash, verify item reappears in active vault
+
+    /// Restores a trashed item via the Trash context menu and verifies it reappears
+    /// in the active vault's All Items list.
+    func testRestore_fromTrashContextMenu_itemReappearsInActiveVault() throws {
+        // Navigate to Trash.
+        let trashSidebarRow = app.buttons["sidebar.trash"]
+        XCTAssertTrue(trashSidebarRow.waitForExistence(timeout: 5))
+        trashSidebarRow.click()
+
+        let trashList = app.tables["itemList.list"]
+        let firstTrashed = trashList.cells.firstMatch
+        XCTAssertTrue(firstTrashed.waitForExistence(timeout: 5), "Trash must have at least one item")
+
+        let itemName = firstTrashed.staticTexts.firstMatch.label
+
+        // Right-click to open context menu and choose Restore.
+        firstTrashed.rightClick()
+        let restoreMenuItem = app.menuItems["Restore"]
+        XCTAssertTrue(restoreMenuItem.waitForExistence(timeout: 3))
+        restoreMenuItem.click()
+
+        // Navigate back to All Items.
+        let allItemsRow = app.buttons["sidebar.allItems"]
+        XCTAssertTrue(allItemsRow.waitForExistence(timeout: 3))
+        allItemsRow.click()
+
+        // Verify the restored item appears in the active vault.
+        let restoredRow = app.tables["itemList.list"].cells.containing(.staticText, identifier: itemName).firstMatch
+        XCTAssertTrue(restoredRow.waitForExistence(timeout: 5), "Restored item should appear in active vault")
+    }
+
+    // MARK: - 7.3: Permanently delete a trashed item
+
+    /// Permanently deletes a trashed item via the context menu and verifies it is
+    /// removed from the Trash list entirely.
+    func testPermanentDelete_fromTrashContextMenu_itemDisappears() throws {
+        // Navigate to Trash.
+        let trashSidebarRow = app.buttons["sidebar.trash"]
+        XCTAssertTrue(trashSidebarRow.waitForExistence(timeout: 5))
+        trashSidebarRow.click()
+
+        let trashList = app.tables["itemList.list"]
+        let firstTrashed = trashList.cells.firstMatch
+        XCTAssertTrue(firstTrashed.waitForExistence(timeout: 5), "Trash must have at least one item")
+
+        let itemName = firstTrashed.staticTexts.firstMatch.label
+
+        // Right-click → "Delete Permanently".
+        firstTrashed.rightClick()
+        let permanentDeleteMenuItem = app.menuItems["Delete Permanently"]
+        XCTAssertTrue(permanentDeleteMenuItem.waitForExistence(timeout: 3))
+        permanentDeleteMenuItem.click()
+
+        // Confirm the destructive alert.
+        let confirmButton = app.buttons["Delete Permanently"]
+        XCTAssertTrue(confirmButton.waitForExistence(timeout: 3))
+        confirmButton.click()
+
+        // Verify the item is gone from Trash.
+        let stillPresent = app.tables["itemList.list"].cells.containing(.staticText, identifier: itemName).firstMatch
+        XCTAssertFalse(stillPresent.waitForExistence(timeout: 3), "Permanently deleted item should not appear in Trash")
+    }
+
+    // MARK: - 7.4: Empty Trash
+
+    /// Empties trash via the "Empty Trash" toolbar button and verifies the Trash list
+    /// shows the empty state.
+    func testEmptyTrash_clearsAllTrashedItems() throws {
+        // Navigate to Trash.
+        let trashSidebarRow = app.buttons["sidebar.trash"]
+        XCTAssertTrue(trashSidebarRow.waitForExistence(timeout: 5))
+        trashSidebarRow.click()
+
+        // Tap "Empty Trash".
+        let emptyTrashButton = app.buttons["trash.button.emptyTrash"]
+        XCTAssertTrue(emptyTrashButton.waitForExistence(timeout: 3))
+        XCTAssertTrue(emptyTrashButton.isEnabled, "Empty Trash should be enabled when trash has items")
+        emptyTrashButton.click()
+
+        // Confirm the destructive alert.
+        let confirmButton = app.buttons["Empty Trash"]
+        XCTAssertTrue(confirmButton.waitForExistence(timeout: 3))
+        confirmButton.click()
+
+        // Verify the empty state appears.
+        let emptyState = app.otherElements["trash.emptyState"]
+        XCTAssertTrue(emptyState.waitForExistence(timeout: 5), "Trash empty state should appear after emptying")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A native Bitwarden client for macOS. Connect to your self-hosted [Bitwarden](htt
 - **Connect to your server** — works with any self-hosted Bitwarden or Vaultwarden instance
 - **Browse everything** — Logins, Cards, Identities, Secure Notes, and SSH Keys
 - **Edit items** — update fields, names, notes, and custom fields; changes sync back to your server
+- **Delete and restore** — move items to Trash, restore accidental deletions, or permanently delete and empty Trash
 - **Find items fast** — real-time search across names, usernames, URIs, and more
 - **Native macOS** — built with SwiftUI, feels right at home
 

--- a/openspec/changes/delete-restore-items/.openspec.yaml
+++ b/openspec/changes/delete-restore-items/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-23

--- a/openspec/changes/delete-restore-items/design.md
+++ b/openspec/changes/delete-restore-items/design.md
@@ -1,0 +1,70 @@
+## Context
+
+Macwarden currently allows users to view and edit vault items but provides no way to delete or restore them. Bitwarden's server already implements a soft-delete model: deleting a cipher moves it to a trash collection (sets `deletedDate`); it can be restored or permanently purged. The macOS client needs to expose these actions through the existing `VaultRepository` abstraction, map the new `deletedDate` field, and surface trash management UI.
+
+The existing architecture — Domain use cases, Data repository implementations, and SwiftUI Presentation — is a clean fit for this change with no architectural deviation needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Soft-delete vault items via `DELETE /ciphers/{id}` (move to trash).
+- Permanently delete a single trashed item via `DELETE /ciphers/{id}` when already in trash.
+- Restore a trashed item via `PUT /ciphers/{id}/restore`.
+- Surface trashed items in a Trash sidebar section.
+- Provide empty-trash bulk action via `DELETE /ciphers/purge`.
+- Confirmation alerts before destructive actions (permanent delete, empty trash).
+- Full undo path: user can always restore before choosing permanent delete.
+
+**Non-Goals:**
+- Offline / queued delete (requires sync engine — future work).
+- Bulk soft-delete of multiple items in one action (single-item scope for this change).
+- Folder / collection delete (cipher-level only).
+- Attachment delete.
+
+## Decisions
+
+### D1: Reuse `VaultRepository` protocol — add three new methods
+
+Add `deleteItem(id:)`, `restoreItem(id:)`, and `emptyTrash()` to the existing `VaultRepository` protocol rather than creating a separate `TrashRepository`. The operations are semantically vault mutations, and keeping them co-located reduces protocol proliferation.
+
+*Alternative considered*: Separate `TrashRepository` protocol. Rejected — overkill for three closely related methods; the vault is the single source of truth.
+
+### D2: `deletedDate: Date?` on `VaultItem` entity to represent trash state
+
+Adding an optional `deletedDate` to the `VaultItem` Domain entity is the minimal change to convey trash state. Views filter or section by `deletedDate != nil`.
+
+*Alternative considered*: Separate `TrashedVaultItem` type. Rejected — doubles mapping code; a nil-able date is idiomatic Swift for optional presence.
+
+### D3: Soft-delete is the default; hard-delete requires a second confirmation
+
+Following Bitwarden's UX convention: the first Delete action is always a soft-delete to trash. Hard-delete (permanent) is a separate explicit action available only on trashed items. Empty-trash presents a confirmation alert before purging all.
+
+### D4: Trash shown as a sidebar section below the main vault list
+
+A dedicated "Trash" entry in the sidebar `NavigationSplitView` sidebar column keeps trash visually distinct without requiring a separate navigation stack. Selecting it shows a filtered list of items where `deletedDate != nil`.
+
+*Alternative considered*: A toolbar filter toggle. Rejected — trash is a fundamentally different state from filtered active items; a sidebar entry matches Bitwarden's web/desktop convention.
+
+### D5: Network errors surface as typed errors via existing error-handling pattern
+
+No new error types needed. Existing `VaultRepositoryError` (or equivalent) covers HTTP 4xx/5xx. The Presentation layer displays these via the standard alert mechanism already used for edit/unlock failures.
+
+## Risks / Trade-offs
+
+- **Stale local state after delete** → Mitigation: invalidate/refetch the in-memory vault cache after each mutating operation; navigate back to the list if the detail view's item is deleted.
+- **Empty trash is irreversible** → Mitigation: two-step confirmation alert with clear destructive wording ("Permanently delete all X items?").
+- **`deletedDate` absent from older cached sync responses** → Mitigation: treat missing field as `nil` (item is active); JSON decoder already uses optional mapping.
+- **Race between soft-delete and background sync** → Mitigation: local optimistic remove from active list on success; next sync reconciles server state.
+
+## Migration Plan
+
+1. Add `deletedDate: Date?` to `VaultItem` entity and update JSON mapper (additive, non-breaking).
+2. Add three methods to `VaultRepository` protocol; stub `VaultRepositoryImpl` to compile.
+3. Implement API calls in `VaultRepositoryImpl`.
+4. Implement Domain use cases (`DeleteVaultItemUseCase`, `RestoreVaultItemUseCase`, `EmptyTrashUseCase`).
+5. Update `VaultListViewModel` to split items by `deletedDate`.
+6. Add Trash sidebar entry and `TrashView`.
+7. Wire context-menu and toolbar actions.
+8. Write unit tests for use cases and mappers; XCUITest for delete/restore journey.
+
+No migration of persisted data — `deletedDate` is server-side state fetched on sync.

--- a/openspec/changes/delete-restore-items/proposal.md
+++ b/openspec/changes/delete-restore-items/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Users accumulate stale or unwanted entries in their vault and currently have no way to remove them from within Macwarden. Bitwarden's soft-delete model (trash / restore) already exists server-side — this change surfaces those actions in the app so users can clean up their vault and safely undo accidental deletions.
+
+## What Changes
+
+- Vault list items gain a context-menu **Delete** action that soft-deletes the item (moves to Bitwarden trash).
+- Detail view gains a **Delete** toolbar button with a confirmation alert.
+- A **Trash** section or filter appears in the sidebar so users can see soft-deleted items.
+- Trashed items in the list show a **Restore** action that moves them back to the active vault.
+- Trashed items show a **Delete Permanently** action for hard-delete (requires a second confirmation).
+- Empty-trash bulk action clears all trashed items permanently.
+
+## Capabilities
+
+### New Capabilities
+
+- `vault-item-delete`: Soft-delete a vault item by moving it to trash; hard-delete a trashed item permanently; empty trash (bulk hard-delete).
+- `vault-item-restore`: Restore a soft-deleted vault item from trash back to the active vault.
+
+### Modified Capabilities
+
+<!-- No existing spec-level behavior changes required -->
+
+## Impact
+
+- **Domain**: New use-case protocols (`DeleteVaultItemUseCase`, `RestoreVaultItemUseCase`, `EmptyTrashUseCase`); `VaultItem` entity needs a `deletedDate: Date?` field to represent trash state.
+- **Data**: Two new API calls — `DELETE /ciphers/{id}` (soft-delete) and `PUT /ciphers/{id}/restore`; plus `DELETE /ciphers/purge` for empty-trash. Existing `VaultRepository` protocol gains corresponding methods.
+- **Presentation**: `VaultListView` context menus, `ItemDetailView` toolbar, new `TrashView` (or sidebar filter), confirmation alerts.
+- **No new dependencies** — existing `URLSession` networking and Keychain/crypto stack unchanged.

--- a/openspec/changes/delete-restore-items/specs/vault-item-delete/spec.md
+++ b/openspec/changes/delete-restore-items/specs/vault-item-delete/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: User can soft-delete an active vault item
+The system SHALL allow the user to move an active vault item to trash via a Delete action available in the vault list context menu and in the item detail view toolbar. Soft-delete SHALL call `DELETE /ciphers/{id}` and set `deletedDate` on the item without permanently removing it from the server.
+
+#### Scenario: Soft-delete from list context menu
+- **WHEN** the user right-clicks an active item in the vault list and selects "Delete"
+- **THEN** a confirmation alert appears asking the user to confirm moving the item to trash
+
+#### Scenario: Soft-delete from detail view
+- **WHEN** the user clicks the "Delete" toolbar button in the item detail view
+- **THEN** a confirmation alert appears warning the item will be moved to trash
+
+#### Scenario: Soft-delete confirmed
+- **WHEN** the user confirms the delete alert
+- **THEN** the system calls `DELETE /ciphers/{id}`, the item is removed from the active list, and the detail pane returns to the empty state
+
+#### Scenario: Soft-delete cancelled
+- **WHEN** the user dismisses the delete confirmation alert
+- **THEN** no change is made and the item remains in the active vault
+
+#### Scenario: Soft-delete network failure
+- **WHEN** the API call fails (network error or non-2xx response)
+- **THEN** an error alert is shown and the item remains in the active vault list
+
+### Requirement: User can permanently delete a trashed vault item
+The system SHALL allow the user to permanently delete a single item that is already in trash. Permanent delete SHALL call `DELETE /ciphers/{id}` on a trashed item and remove it from the server entirely. A second confirmation alert with destructive styling SHALL be required.
+
+#### Scenario: Permanent delete action available only on trashed items
+- **WHEN** the user views the Trash list
+- **THEN** each item shows a "Delete Permanently" action in its context menu
+
+#### Scenario: Permanent delete confirmation required
+- **WHEN** the user selects "Delete Permanently" for a trashed item
+- **THEN** a confirmation alert with destructive button wording ("Delete Permanently") is shown before proceeding
+
+#### Scenario: Permanent delete confirmed
+- **WHEN** the user confirms the permanent delete alert
+- **THEN** the system removes the item from the server and the item disappears from the Trash list
+
+#### Scenario: Permanent delete network failure
+- **WHEN** the API call fails
+- **THEN** an error alert is shown and the item remains in the Trash list
+
+### Requirement: User can empty trash
+The system SHALL provide an "Empty Trash" action that permanently deletes all items in the trash via `DELETE /ciphers/purge`. A confirmation alert displaying the number of items to be deleted SHALL be required before proceeding.
+
+#### Scenario: Empty trash action is available when trash contains items
+- **WHEN** the Trash view is selected and there is at least one trashed item
+- **THEN** an "Empty Trash" button is visible in the toolbar
+
+#### Scenario: Empty trash action is disabled when trash is empty
+- **WHEN** the Trash view contains no items
+- **THEN** the "Empty Trash" button is absent or disabled
+
+#### Scenario: Empty trash confirmation required
+- **WHEN** the user clicks "Empty Trash"
+- **THEN** a confirmation alert states the number of items that will be permanently deleted
+
+#### Scenario: Empty trash confirmed
+- **WHEN** the user confirms empty-trash
+- **THEN** the system calls `DELETE /ciphers/purge`, all trashed items are removed, and the Trash list becomes empty
+
+#### Scenario: Empty trash network failure
+- **WHEN** the API call fails
+- **THEN** an error alert is shown and the Trash list is unchanged
+
+### Requirement: Trash sidebar section displays soft-deleted items
+The system SHALL display a "Trash" entry in the sidebar that, when selected, shows all vault items whose `deletedDate` is non-nil. Trashed items SHALL NOT appear in the main active vault list.
+
+#### Scenario: Trash entry in sidebar
+- **WHEN** the vault is unlocked
+- **THEN** a "Trash" entry appears in the sidebar below the main item categories
+
+#### Scenario: Active items exclude trashed items
+- **WHEN** the main vault list is displayed
+- **THEN** items with a non-nil `deletedDate` are NOT shown
+
+#### Scenario: Trash list shows only trashed items
+- **WHEN** the user selects the Trash sidebar entry
+- **THEN** only items with a non-nil `deletedDate` are shown
+
+#### Scenario: Empty trash view shows empty state
+- **WHEN** the user selects the Trash sidebar entry and no items are in trash
+- **THEN** the Trash view displays the message "No items in trash" as a heading and "Items you delete will appear here" as supporting text, with no list content
+
+> **Note on auto-purge copy**: Bitwarden (official cloud) permanently deletes trashed items after 30 days server-side. Vaultwarden (self-hosted) does **not** auto-purge by default — it requires the admin to set `TRASH_AUTO_DELETE_DAYS`, and the period is configurable. Because Macwarden targets both servers, the supporting text intentionally omits the "30 days" timeframe to avoid a misleading promise on self-hosted instances.

--- a/openspec/changes/delete-restore-items/specs/vault-item-restore/spec.md
+++ b/openspec/changes/delete-restore-items/specs/vault-item-restore/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: User can restore a trashed vault item
+The system SHALL allow the user to restore a trashed vault item back to the active vault via `PUT /ciphers/{id}/restore`. The Restore action SHALL be available in the Trash list context menu and in the detail view of a trashed item.
+
+#### Scenario: Restore action available on trashed items
+- **WHEN** the user views the Trash list
+- **THEN** each item shows a "Restore" action in its context menu
+
+#### Scenario: Restore from trash list
+- **WHEN** the user selects "Restore" from a trashed item's context menu
+- **THEN** the system calls `PUT /ciphers/{id}/restore`, the item's `deletedDate` is cleared, and the item disappears from the Trash list
+
+#### Scenario: Restored item reappears in active vault
+- **WHEN** an item is successfully restored
+- **THEN** it reappears in the main active vault list under its original category
+
+#### Scenario: Restore from detail view of trashed item
+- **WHEN** the user opens the detail view of a trashed item
+- **THEN** a "Restore" toolbar button is visible alongside "Delete Permanently"
+
+#### Scenario: Restore confirmed from detail view
+- **WHEN** the user clicks "Restore" in the detail view of a trashed item
+- **THEN** the system calls `PUT /ciphers/{id}/restore` and navigates back to the Trash list (now without that item)
+
+#### Scenario: Restore network failure
+- **WHEN** the API call fails (network error or non-2xx response)
+- **THEN** an error alert is shown and the item remains in the Trash list with its `deletedDate` intact
+
+### Requirement: Trashed item detail view indicates trash status
+The system SHALL visually indicate when a vault item is in trash so users understand its state before choosing to restore or permanently delete it.
+
+#### Scenario: Trash status banner in detail view
+- **WHEN** the user opens the detail view of a trashed item
+- **THEN** a banner or label is shown stating that the item is in trash and can be restored or permanently deleted
+
+#### Scenario: Edit is disabled for trashed items
+- **WHEN** the user views a trashed item's detail pane
+- **THEN** the Edit button is absent or disabled, since editing a trashed item is not permitted by the Bitwarden API

--- a/openspec/changes/delete-restore-items/tasks.md
+++ b/openspec/changes/delete-restore-items/tasks.md
@@ -1,0 +1,61 @@
+## 1. Domain Layer
+
+- [x] 1.1 Add `deletedDate: Date?` field to `VaultItem` entity
+- [x] 1.2 Add `deleteItem(id: String) async throws` to `VaultRepository` protocol
+- [x] 1.3 Add `restoreItem(id: String) async throws` to `VaultRepository` protocol
+- [x] 1.4 Add `emptyTrash() async throws` to `VaultRepository` protocol
+- [x] 1.5 Implement `DeleteVaultItemUseCase` (soft-delete; delegates to repository)
+- [x] 1.6 Implement `RestoreVaultItemUseCase` (delegates to repository)
+- [x] 1.7 Implement `EmptyTrashUseCase` (delegates to repository)
+- [x] 1.8 Write unit tests for `DeleteVaultItemUseCase`, `RestoreVaultItemUseCase`, and `EmptyTrashUseCase`
+
+## 2. Data Layer — Mapper & Repository
+
+- [x] 2.1 Update `VaultItemMapper` to decode `deletedDate` from JSON (`deletedDate` ISO-8601 string, nullable)
+- [x] 2.2 Write mapper unit tests for items with and without `deletedDate`
+- [x] 2.3 Implement `deleteItem(id:)` in `VaultRepositoryImpl` — calls `DELETE /ciphers/{id}`
+- [x] 2.4 Implement `restoreItem(id:)` in `VaultRepositoryImpl` — calls `PUT /ciphers/{id}/restore`
+- [x] 2.5 Implement `emptyTrash()` in `VaultRepositoryImpl` — calls `DELETE /ciphers/purge`
+- [x] 2.6 Write integration tests (or mock-URLSession tests) for all three API calls
+
+## 3. Presentation — Sidebar & Trash View
+
+- [x] 3.1 Add a "Trash" sidebar entry in `NavigationSplitView` sidebar column
+- [x] 3.2 Create `TrashView` (filtered list of items where `deletedDate != nil`)
+- [x] 3.3 Ensure active vault list excludes items with non-nil `deletedDate`
+- [x] 3.4 Add empty state to `TrashView`: heading "No items in trash" + body "Items you delete will appear here"
+- [x] 3.5 Add "Empty Trash" toolbar button to `TrashView` (disabled when list is empty)
+- [x] 3.6 Show confirmation alert for "Empty Trash" with item count and destructive button
+
+## 4. Presentation — Delete Actions
+
+- [x] 4.1 Add "Delete" context-menu action on active vault list rows
+- [x] 4.2 Add "Delete" toolbar button to `ItemDetailView` for active items
+- [x] 4.3 Show confirmation alert before soft-delete (with cancel / Move to Trash buttons)
+- [x] 4.4 On confirmed soft-delete: call use case, remove item from active list, navigate back to list
+- [x] 4.5 Show error alert on soft-delete failure
+- [x] 4.6 Add "Delete Permanently" context-menu action on Trash list rows
+- [x] 4.7 Show destructive confirmation alert before permanent delete
+- [x] 4.8 On confirmed permanent delete: call use case, remove item from Trash list
+- [x] 4.9 Show error alert on permanent delete failure
+
+## 5. Presentation — Restore Actions
+
+- [x] 5.1 Add "Restore" context-menu action on Trash list rows
+- [x] 5.2 On restore: call use case, move item back to active list, remove from Trash list
+- [x] 5.3 Show error alert on restore failure
+- [x] 5.4 Add "Restore" toolbar button to `ItemDetailView` when item is trashed
+- [x] 5.5 Show trash-status banner in `ItemDetailView` for trashed items
+- [x] 5.6 Disable Edit button in `ItemDetailView` for trashed items
+
+## 6. Observability & Security Review (§V / §III Constitution)
+
+- [x] 6.1 Add `os.Logger` (category: `vault`) calls for soft-delete, permanent delete, restore, and empty-trash operations — log item ID at `.info`, errors at `.error`; MUST NOT log item name or any secret fields
+- [x] 6.2 Constitution §III security review sign-off: confirm no secrets flow through delete/restore paths and API calls are HTTPS-only
+
+## 7. UI Tests
+
+- [x] 7.1 XCUITest: soft-delete an item from the list and verify it appears in Trash
+- [x] 7.2 XCUITest: restore an item from Trash and verify it reappears in active vault
+- [x] 7.3 XCUITest: permanently delete a trashed item and verify it is gone
+- [x] 7.4 XCUITest: empty trash and verify Trash list is empty


### PR DESCRIPTION
## Summary

- Implements soft-delete, permanent delete, restore, and empty-trash flows across all layers (Domain → Data → Presentation)
- Trash sidebar section shows deleted items with restore/purge actions
- Delete/restore actions available from list context menus and item detail toolbar
- Confirmation alerts before all destructive operations
- Error alerts surface API failures to the user

## Changes

**Domain:** `SidebarSelection.trash`, `VaultRepository` 3 new methods, `DeleteVaultItemUseCase` / `RestoreVaultItemUseCase` / `EmptyTrashUseCase` protocols + impls

**Data:** `MacwardenAPIClient` — `PUT /ciphers/{id}/delete` (soft-delete), `DELETE /ciphers/{id}` (permanent), `PUT /ciphers/{id}/restore`, `DELETE /ciphers/purge`; smart `VaultRepositoryImpl` cache updates

**Presentation:** `TrashView` (list + empty state + context menus + confirm alerts), Trash sidebar entry, delete/restore in `ItemListView` and `ItemDetailView`, trash status banner, `os.Logger` observability, `LocalizedError` on `APIError`

**Tests:** use case unit tests, `VaultRepositoryImpl` integration tests, 4 XCUITests

## Test plan

- [ ] Delete an active item → confirm it disappears from All Items and appears in Trash
- [ ] Restore a trashed item → confirm it reappears in All Items and is gone from Trash
- [ ] Permanently delete a trashed item → confirm it is gone from Trash
- [ ] Empty Trash → confirm empty state appears
- [ ] Trigger an API failure → confirm error alert appears with readable message
- [ ] Run `⌘U` — all unit and integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)