### PR TITLE
feat(vault): add, remove, and reorder URIs in Login edit form

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,6 @@ Keep PRs focused — one feature or fix per PR.
 
 ### What's Out of Scope (for now)
 
-- Write/edit operations (this is a read-only client)
 - Organisation vault support
 - Browser extension or iOS port
 

--- a/Macwarden/Domain/Entities/DraftVaultItem.swift
+++ b/Macwarden/Domain/Entities/DraftVaultItem.swift
@@ -11,6 +11,11 @@ nonisolated struct DraftLoginURI: Equatable {
     var uri: String
     var matchType: URIMatchType?
 
+    init(uri: String = "", matchType: URIMatchType? = nil) {
+        self.uri = uri
+        self.matchType = matchType
+    }
+
     init(_ source: LoginURI) {
         self.uri = source.uri
         self.matchType = source.matchType
@@ -49,7 +54,6 @@ nonisolated struct DraftCustomField: Equatable {
 nonisolated struct DraftLoginContent: Equatable {
     var username: String?
     var password: String?
-    /// URIs are editable in v1; adding/removing URIs is out of scope.
     var uris: [DraftLoginURI]
     /// TOTP seed is not editable in v1.
     let totp: String?

--- a/Macwarden/Domain/Entities/DraftVaultItem.swift
+++ b/Macwarden/Domain/Entities/DraftVaultItem.swift
@@ -7,7 +7,8 @@ import Foundation
 /// Why mutable mirror instead of mutating `LoginURI` directly: `LoginURI` is a value type with
 /// `let` fields, which prevents accidental mutation in read-only views. By introducing a separate
 /// `DraftLoginURI` we confine mutability to the edit sheet and keep the read path immutable.
-nonisolated struct DraftLoginURI: Equatable {
+nonisolated struct DraftLoginURI: Equatable, Identifiable {
+    let id = UUID()
     var uri: String
     var matchType: URIMatchType?
 
@@ -19,6 +20,11 @@ nonisolated struct DraftLoginURI: Equatable {
     init(_ source: LoginURI) {
         self.uri = source.uri
         self.matchType = source.matchType
+    }
+
+    // Exclude `id` from equality — two drafts with the same content are equal regardless of identity.
+    static func == (lhs: DraftLoginURI, rhs: DraftLoginURI) -> Bool {
+        lhs.uri == rhs.uri && lhs.matchType == rhs.matchType
     }
 }
 

--- a/Macwarden/MacwardenTests/DraftVaultItemTests.swift
+++ b/Macwarden/MacwardenTests/DraftVaultItemTests.swift
@@ -202,4 +202,53 @@ final class DraftVaultItemTests: XCTestCase {
         XCTAssertEqual(draftURI.uri, "https://example.com")
         XCTAssertNil(draftURI.matchType)
     }
+
+    // MARK: - DraftLoginURI empty initializer
+
+    func test_draftLoginURI_emptyInit_defaultsToEmptyStringAndNilMatchType() {
+        let uri = DraftLoginURI()
+        XCTAssertEqual(uri.uri, "")
+        XCTAssertNil(uri.matchType)
+    }
+
+    // MARK: - URI list mutations (add / remove / reorder)
+
+    func test_appendingBlankURI_increasesCount() {
+        var content = DraftLoginContent(LoginContent(
+            username: nil, password: nil,
+            uris: [LoginURI(uri: "https://a.com", matchType: nil)],
+            totp: nil, notes: nil, customFields: []
+        ))
+        content.uris.append(DraftLoginURI())
+        XCTAssertEqual(content.uris.count, 2)
+        XCTAssertEqual(content.uris[1].uri, "")
+    }
+
+    func test_removingURI_decreasesCount() {
+        var content = DraftLoginContent(LoginContent(
+            username: nil, password: nil,
+            uris: [
+                LoginURI(uri: "https://a.com", matchType: nil),
+                LoginURI(uri: "https://b.com", matchType: nil)
+            ],
+            totp: nil, notes: nil, customFields: []
+        ))
+        content.uris.remove(at: 0)
+        XCTAssertEqual(content.uris.count, 1)
+        XCTAssertEqual(content.uris[0].uri, "https://b.com")
+    }
+
+    func test_swappingAdjacentURIs_reorders() {
+        var content = DraftLoginContent(LoginContent(
+            username: nil, password: nil,
+            uris: [
+                LoginURI(uri: "https://first.com", matchType: nil),
+                LoginURI(uri: "https://second.com", matchType: nil)
+            ],
+            totp: nil, notes: nil, customFields: []
+        ))
+        content.uris.swapAt(0, 1)
+        XCTAssertEqual(content.uris[0].uri, "https://second.com")
+        XCTAssertEqual(content.uris[1].uri, "https://first.com")
+    }
 }

--- a/Macwarden/Presentation/Components/OptionKeyMonitor.swift
+++ b/Macwarden/Presentation/Components/OptionKeyMonitor.swift
@@ -5,7 +5,7 @@ import Observation
 @MainActor
 final class OptionKeyMonitor {
     private(set) var isOptionHeld = false
-    nonisolated(unsafe) private var monitor: Any?
+    @ObservationIgnored private var monitor: Any?
 
     init() {
         monitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in

--- a/Macwarden/Presentation/Vault/Edit/ItemEditView.swift
+++ b/Macwarden/Presentation/Vault/Edit/ItemEditView.swift
@@ -61,7 +61,6 @@ struct ItemEditView: View {
 
             // Per-type edit form.
             typeEditForm
-                .frame(maxHeight: .infinity)
         }
         .frame(minWidth: 480, minHeight: 400)
         .toolbar {

--- a/Macwarden/Presentation/Vault/Edit/ItemEditView.swift
+++ b/Macwarden/Presentation/Vault/Edit/ItemEditView.swift
@@ -61,6 +61,7 @@ struct ItemEditView: View {
 
             // Per-type edit form.
             typeEditForm
+                .frame(maxHeight: .infinity)
         }
         .frame(minWidth: 480, minHeight: 400)
         .toolbar {

--- a/Macwarden/Presentation/Vault/Edit/LoginEditForm.swift
+++ b/Macwarden/Presentation/Vault/Edit/LoginEditForm.swift
@@ -30,13 +30,22 @@ struct LoginEditForm: View {
                                 canMoveUp: index > 0,
                                 canMoveDown: index < draft.uris.count - 1,
                                 showReorderButtons: draft.uris.count > 1,
-                                onMoveUp: { draft.uris.swapAt(index, index - 1) },
-                                onMoveDown: { draft.uris.swapAt(index, index + 1) },
-                                onRemove: { draft.uris.remove(at: index) }
+                                onMoveUp: {
+                                    guard let i = draft.uris.firstIndex(where: { $0.id == uri.id }), i > 0 else { return }
+                                    draft.uris.swapAt(i, i - 1)
+                                },
+                                onMoveDown: {
+                                    guard let i = draft.uris.firstIndex(where: { $0.id == uri.id }), i < draft.uris.count - 1 else { return }
+                                    draft.uris.swapAt(i, i + 1)
+                                },
+                                onRemove: {
+                                    guard let i = draft.uris.firstIndex(where: { $0.id == uri.id }) else { return }
+                                    draft.uris.remove(at: i)
+                                }
                             )
                         }
                     }
-                    Divider()
+                    if !draft.uris.isEmpty { Divider() }
                     Button {
                         draft.uris.append(DraftLoginURI())
                     } label: {

--- a/Macwarden/Presentation/Vault/Edit/LoginEditForm.swift
+++ b/Macwarden/Presentation/Vault/Edit/LoginEditForm.swift
@@ -22,17 +22,19 @@ struct LoginEditForm: View {
                 }
 
                 DetailSectionCard("Websites") {
-                    ForEach(draft.uris.indices, id: \.self) { index in
-                        if index > 0 { Divider() }
-                        URIEditRow(
-                            uri: $draft.uris[index],
-                            canMoveUp: index > 0,
-                            canMoveDown: index < draft.uris.count - 1,
-                            showReorderButtons: draft.uris.count > 1,
-                            onMoveUp: { draft.uris.swapAt(index, index - 1) },
-                            onMoveDown: { draft.uris.swapAt(index, index + 1) },
-                            onRemove: { draft.uris.remove(at: index) }
-                        )
+                    ForEach(draft.uris) { uri in
+                        if let index = draft.uris.firstIndex(where: { $0.id == uri.id }) {
+                            if index > 0 { Divider() }
+                            URIEditRow(
+                                uri: $draft.uris[index],
+                                canMoveUp: index > 0,
+                                canMoveDown: index < draft.uris.count - 1,
+                                showReorderButtons: draft.uris.count > 1,
+                                onMoveUp: { draft.uris.swapAt(index, index - 1) },
+                                onMoveDown: { draft.uris.swapAt(index, index + 1) },
+                                onRemove: { draft.uris.remove(at: index) }
+                            )
+                        }
                     }
                     Divider()
                     Button {
@@ -40,6 +42,7 @@ struct LoginEditForm: View {
                     } label: {
                         Label("Add Website", systemImage: "plus")
                             .font(Typography.fieldValue)
+                            .foregroundStyle(.tint)
                     }
                     .buttonStyle(.borderless)
                     .padding(.vertical, Spacing.rowVertical)

--- a/Macwarden/Presentation/Vault/Edit/LoginEditForm.swift
+++ b/Macwarden/Presentation/Vault/Edit/LoginEditForm.swift
@@ -15,8 +15,6 @@ struct LoginEditForm: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
 
-
-
                 DetailSectionCard("Credentials") {
                     OptionalEditFieldRow(label: "Username", value: $draft.username)
                     Divider()
@@ -101,7 +99,9 @@ private struct URIEditRow: View {
                 EditFieldRow(label: "Website", text: $uri.uri)
 
                 Button {
-                    showMatchType.toggle()
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        showMatchType.toggle()
+                    }
                 } label: {
                     Image(systemName: "gearshape")
                         .foregroundStyle(showMatchType ? Color.accentColor : Color.secondary)

--- a/Macwarden/Presentation/Vault/Edit/LoginEditForm.swift
+++ b/Macwarden/Presentation/Vault/Edit/LoginEditForm.swift
@@ -99,9 +99,7 @@ private struct URIEditRow: View {
                 EditFieldRow(label: "Website", text: $uri.uri)
 
                 Button {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        showMatchType.toggle()
-                    }
+                    showMatchType.toggle()
                 } label: {
                     Image(systemName: "gearshape")
                         .foregroundStyle(showMatchType ? Color.accentColor : Color.secondary)

--- a/Macwarden/Presentation/Vault/Edit/LoginEditForm.swift
+++ b/Macwarden/Presentation/Vault/Edit/LoginEditForm.swift
@@ -72,6 +72,8 @@ private struct URIEditRow: View {
     let onMoveDown: () -> Void
     let onRemove: () -> Void
 
+    @State private var showMatchType = false
+
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             HStack {
@@ -96,6 +98,16 @@ private struct URIEditRow: View {
 
                 EditFieldRow(label: "Website", text: $uri.uri)
 
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        showMatchType.toggle()
+                    }
+                } label: {
+                    Image(systemName: "gearshape")
+                        .foregroundStyle(showMatchType ? Color.accentColor : Color.secondary)
+                }
+                .buttonStyle(.borderless)
+
                 Button(action: onRemove) {
                     Image(systemName: "minus.circle.fill")
                         .foregroundStyle(.red)
@@ -103,23 +115,26 @@ private struct URIEditRow: View {
                 .buttonStyle(.borderless)
                 .padding(.trailing, Spacing.rowHorizontal)
             }
-            Divider()
-            HStack {
-                Text("Match Type")
-                    .font(Typography.fieldLabel)
-                    .foregroundStyle(.secondary)
-                    .padding(.leading, Spacing.rowHorizontal)
-                Spacer()
-                Picker("Match Type", selection: $uri.matchType) {
-                    Text("Default").tag(URIMatchType?.none)
-                    ForEach(URIMatchType.allCases, id: \.self) { type in
-                        Text(type.displayName).tag(URIMatchType?.some(type))
+            if showMatchType {
+                Divider()
+                HStack {
+                    Text("Match Type")
+                        .font(Typography.fieldLabel)
+                        .foregroundStyle(.secondary)
+                        .padding(.leading, Spacing.rowHorizontal)
+                    Spacer()
+                    Picker("Match Type", selection: $uri.matchType) {
+                        Text("Default").tag(URIMatchType?.none)
+                        ForEach(URIMatchType.allCases, id: \.self) { type in
+                            Text(type.displayName).tag(URIMatchType?.some(type))
+                        }
                     }
+                    .labelsHidden()
+                    .padding(.trailing, Spacing.rowHorizontal)
                 }
-                .labelsHidden()
-                .padding(.trailing, Spacing.rowHorizontal)
+                .padding(.vertical, Spacing.rowVertical)
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
-            .padding(.vertical, Spacing.rowVertical)
         }
     }
 }

--- a/Macwarden/Presentation/Vault/Edit/LoginEditForm.swift
+++ b/Macwarden/Presentation/Vault/Edit/LoginEditForm.swift
@@ -15,6 +15,8 @@ struct LoginEditForm: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
 
+
+
                 DetailSectionCard("Credentials") {
                     OptionalEditFieldRow(label: "Username", value: $draft.username)
                     Divider()

--- a/Macwarden/Presentation/Vault/Edit/LoginEditForm.swift
+++ b/Macwarden/Presentation/Vault/Edit/LoginEditForm.swift
@@ -5,8 +5,8 @@ import SwiftUI
 /// Edit form for Login vault items.
 ///
 /// Mirrors the layout of `LoginDetailView`: Credentials card, Websites card,
-/// Notes card, Custom Fields card. All existing URI rows are editable (adding
-/// and removing URIs is out of scope for v1). Password is masked by default.
+/// Notes card, Custom Fields card. URIs can be added, removed, and reordered.
+/// Password is masked by default.
 struct LoginEditForm: View {
 
     @Binding var draft: DraftLoginContent
@@ -21,13 +21,29 @@ struct LoginEditForm: View {
                     MaskedEditFieldRow(label: "Password", value: $draft.password, generatorBinding: $draft.password)
                 }
 
-                if !draft.uris.isEmpty {
-                    DetailSectionCard("Websites") {
-                        ForEach(draft.uris.indices, id: \.self) { index in
-                            if index > 0 { Divider() }
-                            URIEditRow(uri: $draft.uris[index])
-                        }
+                DetailSectionCard("Websites") {
+                    ForEach(draft.uris.indices, id: \.self) { index in
+                        if index > 0 { Divider() }
+                        URIEditRow(
+                            uri: $draft.uris[index],
+                            canMoveUp: index > 0,
+                            canMoveDown: index < draft.uris.count - 1,
+                            showReorderButtons: draft.uris.count > 1,
+                            onMoveUp: { draft.uris.swapAt(index, index - 1) },
+                            onMoveDown: { draft.uris.swapAt(index, index + 1) },
+                            onRemove: { draft.uris.remove(at: index) }
+                        )
                     }
+                    Divider()
+                    Button {
+                        draft.uris.append(DraftLoginURI())
+                    } label: {
+                        Label("Add Website", systemImage: "plus")
+                            .font(Typography.fieldValue)
+                    }
+                    .buttonStyle(.borderless)
+                    .padding(.vertical, Spacing.rowVertical)
+                    .padding(.horizontal, Spacing.rowHorizontal)
                 }
 
                 DetailSectionCard("Notes") {
@@ -42,14 +58,48 @@ struct LoginEditForm: View {
 
 // MARK: - URIEditRow
 
-/// An editable row for a single LoginURI, with a match-type picker.
+/// An editable row for a single LoginURI, with match-type picker, reorder, and remove controls.
 private struct URIEditRow: View {
 
     @Binding var uri: DraftLoginURI
+    let canMoveUp: Bool
+    let canMoveDown: Bool
+    let showReorderButtons: Bool
+    let onMoveUp: () -> Void
+    let onMoveDown: () -> Void
+    let onRemove: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
-            EditFieldRow(label: "Website", text: $uri.uri)
+            HStack {
+                if showReorderButtons {
+                    VStack(spacing: 2) {
+                        Button(action: onMoveUp) {
+                            Image(systemName: "chevron.up")
+                                .font(Typography.utility)
+                        }
+                        .buttonStyle(.borderless)
+                        .disabled(!canMoveUp)
+
+                        Button(action: onMoveDown) {
+                            Image(systemName: "chevron.down")
+                                .font(Typography.utility)
+                        }
+                        .buttonStyle(.borderless)
+                        .disabled(!canMoveDown)
+                    }
+                    .padding(.leading, Spacing.rowHorizontal)
+                }
+
+                EditFieldRow(label: "Website", text: $uri.uri)
+
+                Button(action: onRemove) {
+                    Image(systemName: "minus.circle.fill")
+                        .foregroundStyle(.red)
+                }
+                .buttonStyle(.borderless)
+                .padding(.trailing, Spacing.rowHorizontal)
+            }
             Divider()
             HStack {
                 Text("Match Type")

--- a/openspec/changes/add-remove-reorder-uris/.openspec.yaml
+++ b/openspec/changes/add-remove-reorder-uris/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-24

--- a/openspec/changes/add-remove-reorder-uris/design.md
+++ b/openspec/changes/add-remove-reorder-uris/design.md
@@ -1,0 +1,47 @@
+## Context
+
+The Login edit form (`LoginEditForm`) uses a `ScrollView` > `VStack` > `DetailSectionCard` layout with custom `EditFieldRow` components. URI rows are rendered via `ForEach(draft.uris.indices)` with a `URIEditRow` that binds to each `DraftLoginURI`. The Websites section is conditionally shown only when `draft.uris` is non-empty.
+
+`DraftLoginURI` is a mutable mirror of the immutable `LoginURI` domain entity. It currently only has an `init(_ source: LoginURI)` initializer — no way to create a blank instance.
+
+The Bitwarden API accepts the full `uris` array on cipher update (full replacement), so adding/removing URIs requires no API-level changes. The `CipherMapper` already maps variable-length URI arrays in both directions.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Users can add new website URIs to a Login item
+- Users can remove existing URIs from a Login item
+- Users can reorder URIs (important because Bitwarden treats the first URI as the primary autofill match)
+- The Websites section is always visible in the edit form, even with zero URIs
+
+**Non-Goals:**
+- URI validation (Bitwarden itself accepts bare domains, IPs, etc.)
+- Migrating edit forms from card layout to native `Form` — keep existing `DetailSectionCard` pattern
+- Add/remove for custom fields (separate change)
+- Drag-to-reorder (using ▲▼ buttons instead for layout consistency)
+
+## Decisions
+
+**Decision 1: ▲▼ buttons for reordering instead of drag-to-reorder**
+
+The edit forms use `ScrollView` > `VStack` > `DetailSectionCard`. SwiftUI's native `onMove` requires `List`/`ForEach`, which would clash with the card-based styling. ▲▼ buttons keep the existing layout intact and are keyboard-accessible.
+
+Alternative considered: Migrating to `Form` + `onMove`. Rejected because it would require restyling all five edit forms for visual consistency — too large a scope for this change.
+
+**Decision 2: Inline remove button per row**
+
+Each URI row gets a [−] button. This matches Option A from exploration (inline controls) and is the most discoverable pattern within the card layout.
+
+**Decision 3: Memberwise initializer on DraftLoginURI**
+
+Add `init(uri: String = "", matchType: URIMatchType? = nil)` so blank URIs can be created for the "Add Website" action. The existing `init(_ source: LoginURI)` remains unchanged.
+
+**Decision 4: Always show Websites section**
+
+Remove the `if !draft.uris.isEmpty` guard so the section always renders. When empty, it shows only the "Add Website" button.
+
+## Risks / Trade-offs
+
+**[Risk] Accidental removal with no undo** → The edit sheet already has a Cancel button that discards all changes. Removing a URI is not persisted until Save. This is sufficient protection.
+
+**[Risk] ▲▼ buttons add visual noise to each row** → Buttons are disabled at boundaries (▲ on first, ▼ on last) and hidden when only one URI exists, reducing clutter.

--- a/openspec/changes/add-remove-reorder-uris/design.md
+++ b/openspec/changes/add-remove-reorder-uris/design.md
@@ -40,6 +40,14 @@ Add `init(uri: String = "", matchType: URIMatchType? = nil)` so blank URIs can b
 
 Remove the `if !draft.uris.isEmpty` guard so the section always renders. When empty, it shows only the "Add Website" button.
 
+**Decision 5: Gear icon toggle for match type**
+
+Match type picker is hidden by default to reduce visual noise. A gear icon button (left of the remove button) toggles it with an animated transition. Gear tints accent color when expanded, secondary when collapsed.
+
+**Decision 6: Identifiable conformance on DraftLoginURI**
+
+`DraftLoginURI` conforms to `Identifiable` with a `UUID` to provide stable identity for SwiftUI `ForEach`. Without this, using integer indices as identity caused out-of-bounds crashes when adding/removing URIs. The `id` is excluded from `Equatable` so existing round-trip tests remain unaffected.
+
 ## Risks / Trade-offs
 
 **[Risk] Accidental removal with no undo** → The edit sheet already has a Cancel button that discards all changes. Removing a URI is not persisted until Save. This is sufficient protection.

--- a/openspec/changes/add-remove-reorder-uris/proposal.md
+++ b/openspec/changes/add-remove-reorder-uris/proposal.md
@@ -9,6 +9,8 @@ Login vault items store one or more website URIs that serve two purposes: lettin
 - Add ▲▼ reorder buttons on each URI row to move it up/down in the list
 - Always show the Websites section in the edit form (even when no URIs exist yet)
 - Add an empty initializer to `DraftLoginURI` so blank rows can be created
+- Hide match type picker behind a gear icon toggle with animated reveal
+- Add `Identifiable` conformance to `DraftLoginURI` for stable SwiftUI ForEach identity
 
 ## Capabilities
 

--- a/openspec/changes/add-remove-reorder-uris/proposal.md
+++ b/openspec/changes/add-remove-reorder-uris/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Login vault items store one or more website URIs that serve two purposes: letting the user jump to a site to log in, and enabling Bitwarden browser extensions to match and prefill credentials. Currently the edit form only allows modifying existing URI text and match type — users cannot add new URIs, remove stale ones, or reorder them. Since Bitwarden treats the first URI as the primary match target, the inability to reorder also affects autofill behavior.
+
+## What Changes
+
+- Add an "Add Website" button to the Login edit form that appends a blank URI row
+- Add an inline remove button (−) on each URI row to delete it
+- Add ▲▼ reorder buttons on each URI row to move it up/down in the list
+- Always show the Websites section in the edit form (even when no URIs exist yet)
+- Add an empty initializer to `DraftLoginURI` so blank rows can be created
+
+## Capabilities
+
+### New Capabilities
+- `uri-add-remove-reorder`: Add, remove, and reorder website URIs on Login vault items in the edit form
+
+### Modified Capabilities
+
+## Impact
+
+- `Macwarden/Domain/Entities/DraftVaultItem.swift` — new initializer on `DraftLoginURI`, remove v1 scope comment
+- `Macwarden/Presentation/Vault/Edit/LoginEditForm.swift` — add/remove/reorder UI controls in the Websites section
+- No API changes needed — the Bitwarden API accepts the full `uris` array on save (full replacement)
+- No mapper changes — `CipherMapper` already handles variable-length URI arrays

--- a/openspec/changes/add-remove-reorder-uris/specs/uri-add-remove-reorder/spec.md
+++ b/openspec/changes/add-remove-reorder-uris/specs/uri-add-remove-reorder/spec.md
@@ -34,19 +34,23 @@ Each URI row in the Login edit form SHALL display an inline remove button. Click
 Each URI row in the Login edit form SHALL display move-up (▲) and move-down (▼) buttons. The move-up button on the first row SHALL be disabled. The move-down button on the last row SHALL be disabled. When only one URI exists, both buttons SHALL be hidden. Clicking a move button SHALL swap the URI with its neighbor in the indicated direction.
 
 #### Scenario: Reorder buttons shown when multiple URIs exist
-- **GIVEN** a Login item with two or more URIs in the edit form
+- **GIVEN** a Login item with two or more URIs
+- **WHEN** the edit form renders
 - **THEN** each URI row SHALL display ▲ and ▼ buttons
 
 #### Scenario: Reorder buttons hidden for single URI
-- **GIVEN** a Login item with exactly one URI in the edit form
+- **GIVEN** a Login item with exactly one URI
+- **WHEN** the edit form renders
 - **THEN** the ▲ and ▼ buttons SHALL NOT be displayed
 
 #### Scenario: First row move-up disabled
 - **GIVEN** a Login item with multiple URIs
+- **WHEN** the edit form renders
 - **THEN** the ▲ button on the first URI row SHALL be disabled
 
 #### Scenario: Last row move-down disabled
 - **GIVEN** a Login item with multiple URIs
+- **WHEN** the edit form renders
 - **THEN** the ▼ button on the last URI row SHALL be disabled
 
 #### Scenario: Moving a URI up

--- a/openspec/changes/add-remove-reorder-uris/specs/uri-add-remove-reorder/spec.md
+++ b/openspec/changes/add-remove-reorder-uris/specs/uri-add-remove-reorder/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: User can add a new website URI to a Login item
+The edit form for Login items SHALL always display a "Websites" section, even when no URIs exist. The section SHALL contain an "Add Website" button that appends a new blank URI row with an empty URI string and no match type (default). The new row SHALL be immediately editable.
+
+#### Scenario: Add Website button visible with no URIs
+- **WHEN** the user opens the edit form for a Login item with zero URIs
+- **THEN** the Websites section SHALL be visible with an "Add Website" button
+
+#### Scenario: Add Website button visible with existing URIs
+- **WHEN** the user opens the edit form for a Login item with one or more URIs
+- **THEN** the "Add Website" button SHALL appear below the existing URI rows
+
+#### Scenario: Adding a new URI
+- **WHEN** the user clicks "Add Website"
+- **THEN** a new URI row SHALL be appended with an empty URI field and match type set to Default
+
+### Requirement: User can remove a website URI from a Login item
+Each URI row in the Login edit form SHALL display an inline remove button. Clicking the remove button SHALL immediately remove that URI row from the list. Removal is not persisted until the user saves the edit form.
+
+#### Scenario: Remove button shown on each URI row
+- **WHEN** the edit form displays one or more URI rows
+- **THEN** each row SHALL have a visible remove button
+
+#### Scenario: Removing a URI
+- **WHEN** the user clicks the remove button on a URI row
+- **THEN** that URI row SHALL be removed from the list immediately
+
+#### Scenario: Removing all URIs
+- **WHEN** the user removes the last remaining URI
+- **THEN** the Websites section SHALL remain visible with only the "Add Website" button
+
+### Requirement: User can reorder website URIs on a Login item
+Each URI row in the Login edit form SHALL display move-up (▲) and move-down (▼) buttons. The move-up button on the first row SHALL be disabled. The move-down button on the last row SHALL be disabled. When only one URI exists, both buttons SHALL be hidden. Clicking a move button SHALL swap the URI with its neighbor in the indicated direction.
+
+#### Scenario: Reorder buttons shown when multiple URIs exist
+- **GIVEN** a Login item with two or more URIs in the edit form
+- **THEN** each URI row SHALL display ▲ and ▼ buttons
+
+#### Scenario: Reorder buttons hidden for single URI
+- **GIVEN** a Login item with exactly one URI in the edit form
+- **THEN** the ▲ and ▼ buttons SHALL NOT be displayed
+
+#### Scenario: First row move-up disabled
+- **GIVEN** a Login item with multiple URIs
+- **THEN** the ▲ button on the first URI row SHALL be disabled
+
+#### Scenario: Last row move-down disabled
+- **GIVEN** a Login item with multiple URIs
+- **THEN** the ▼ button on the last URI row SHALL be disabled
+
+#### Scenario: Moving a URI up
+- **WHEN** the user clicks ▲ on a URI row that is not the first
+- **THEN** that URI SHALL swap positions with the URI above it
+
+#### Scenario: Moving a URI down
+- **WHEN** the user clicks ▼ on a URI row that is not the last
+- **THEN** that URI SHALL swap positions with the URI below it

--- a/openspec/changes/add-remove-reorder-uris/specs/uri-add-remove-reorder/spec.md
+++ b/openspec/changes/add-remove-reorder-uris/specs/uri-add-remove-reorder/spec.md
@@ -60,3 +60,25 @@ Each URI row in the Login edit form SHALL display move-up (▲) and move-down (�
 #### Scenario: Moving a URI down
 - **WHEN** the user clicks ▼ on a URI row that is not the last
 - **THEN** that URI SHALL swap positions with the URI below it
+
+### Requirement: Match type is hidden behind a configure toggle
+Each URI row SHALL hide the match type picker by default. A gear icon button SHALL be displayed to the left of the remove button. Clicking the gear icon SHALL toggle the match type picker row with an animated transition. The gear icon SHALL be tinted with the accent color when the match type row is visible, and secondary color when hidden.
+
+#### Scenario: Match type hidden by default
+- **WHEN** the edit form displays a URI row
+- **THEN** the match type picker SHALL NOT be visible
+
+#### Scenario: Gear icon toggles match type visibility
+- **WHEN** the user clicks the gear icon on a URI row
+- **THEN** the match type picker row SHALL appear with an animated transition
+
+#### Scenario: Gear icon hides match type
+- **GIVEN** the match type row is visible
+- **WHEN** the user clicks the gear icon again
+- **THEN** the match type picker row SHALL hide with an animated transition
+
+#### Scenario: Gear icon tint reflects state
+- **WHEN** the match type row is visible
+- **THEN** the gear icon SHALL be tinted with the accent color
+- **WHEN** the match type row is hidden
+- **THEN** the gear icon SHALL be tinted with the secondary color

--- a/openspec/changes/add-remove-reorder-uris/tasks.md
+++ b/openspec/changes/add-remove-reorder-uris/tasks.md
@@ -1,0 +1,18 @@
+## 1. Domain Layer
+
+- [ ] 1.1 Add memberwise initializer `init(uri: String = "", matchType: URIMatchType? = nil)` to `DraftLoginURI` in `DraftVaultItem.swift`
+- [ ] 1.2 Remove the "adding/removing URIs is out of scope" comment from `DraftLoginContent`
+
+## 2. Domain Tests
+
+- [ ] 2.1 Add unit test for `DraftLoginURI()` empty initializer — verify defaults to empty string and nil match type
+- [ ] 2.2 Add unit test for appending a blank `DraftLoginURI` to `DraftLoginContent.uris`
+- [ ] 2.3 Add unit test for removing a URI from `DraftLoginContent.uris`
+- [ ] 2.4 Add unit test for swapping adjacent URIs in `DraftLoginContent.uris` (reorder)
+
+## 3. Edit Form UI
+
+- [ ] 3.1 Always show the Websites `DetailSectionCard` in `LoginEditForm` (remove `if !draft.uris.isEmpty` guard)
+- [ ] 3.2 Add "Add Website" button at the bottom of the Websites section that appends a blank `DraftLoginURI()`
+- [ ] 3.3 Add inline remove (−) button to each `URIEditRow`
+- [ ] 3.4 Add ▲▼ reorder buttons to each `URIEditRow` — disabled at boundaries, hidden when only one URI exists

--- a/openspec/changes/add-remove-reorder-uris/tasks.md
+++ b/openspec/changes/add-remove-reorder-uris/tasks.md
@@ -1,18 +1,18 @@
 ## 1. Domain Layer
 
-- [ ] 1.1 Add memberwise initializer `init(uri: String = "", matchType: URIMatchType? = nil)` to `DraftLoginURI` in `DraftVaultItem.swift`
-- [ ] 1.2 Remove the "adding/removing URIs is out of scope" comment from `DraftLoginContent`
+- [x] 1.1 Add memberwise initializer `init(uri: String = "", matchType: URIMatchType? = nil)` to `DraftLoginURI` in `DraftVaultItem.swift`
+- [x] 1.2 Remove the "adding/removing URIs is out of scope" comment from `DraftLoginContent`
 
 ## 2. Domain Tests
 
-- [ ] 2.1 Add unit test for `DraftLoginURI()` empty initializer — verify defaults to empty string and nil match type
-- [ ] 2.2 Add unit test for appending a blank `DraftLoginURI` to `DraftLoginContent.uris`
-- [ ] 2.3 Add unit test for removing a URI from `DraftLoginContent.uris`
-- [ ] 2.4 Add unit test for swapping adjacent URIs in `DraftLoginContent.uris` (reorder)
+- [x] 2.1 Add unit test for `DraftLoginURI()` empty initializer — verify defaults to empty string and nil match type
+- [x] 2.2 Add unit test for appending a blank `DraftLoginURI` to `DraftLoginContent.uris`
+- [x] 2.3 Add unit test for removing a URI from `DraftLoginContent.uris`
+- [x] 2.4 Add unit test for swapping adjacent URIs in `DraftLoginContent.uris` (reorder)
 
 ## 3. Edit Form UI
 
-- [ ] 3.1 Always show the Websites `DetailSectionCard` in `LoginEditForm` (remove `if !draft.uris.isEmpty` guard)
-- [ ] 3.2 Add "Add Website" button at the bottom of the Websites section that appends a blank `DraftLoginURI()`
-- [ ] 3.3 Add inline remove (−) button to each `URIEditRow`
-- [ ] 3.4 Add ▲▼ reorder buttons to each `URIEditRow` — disabled at boundaries, hidden when only one URI exists
+- [x] 3.1 Always show the Websites `DetailSectionCard` in `LoginEditForm` (remove `if !draft.uris.isEmpty` guard)
+- [x] 3.2 Add "Add Website" button at the bottom of the Websites section that appends a blank `DraftLoginURI()`
+- [x] 3.3 Add inline remove (−) button to each `URIEditRow`
+- [x] 3.4 Add ▲▼ reorder buttons to each `URIEditRow` — disabled at boundaries, hidden when only one URI exists

--- a/openspec/changes/add-remove-reorder-uris/tasks.md
+++ b/openspec/changes/add-remove-reorder-uris/tasks.md
@@ -16,3 +16,12 @@
 - [x] 3.2 Add "Add Website" button at the bottom of the Websites section that appends a blank `DraftLoginURI()`
 - [x] 3.3 Add inline remove (−) button to each `URIEditRow`
 - [x] 3.4 Add ▲▼ reorder buttons to each `URIEditRow` — disabled at boundaries, hidden when only one URI exists
+
+## 4. Match Type Toggle
+
+- [x] 4.1 Hide match type picker by default behind a gear icon button with animated reveal
+- [x] 4.2 Tint gear icon accent color when expanded, secondary when collapsed
+
+## 5. Stability Fix
+
+- [x] 5.1 Add `Identifiable` conformance with `UUID` to `DraftLoginURI` for stable ForEach identity


### PR DESCRIPTION
## Changes
- Add, remove, and reorder URIs in Login edit form
- Hide match type behind gear toggle with animation
- Use stable identity for URI ForEach to prevent index crash
- Fix sheet resize when toggling match type row