### PR TITLE
fix: bump client version to 2024.12.0 for SSH key support

### DIFF
--- a/Macwarden/Data/Network/MacwardenAPIClient.swift
+++ b/Macwarden/Data/Network/MacwardenAPIClient.swift
@@ -221,7 +221,7 @@ extension APIError: LocalizedError {
 ///
 /// All requests include the required Bitwarden client identification headers:
 /// - `X-Client-Id: "desktop"`       (registered client identifier for third-party clients)
-/// - `X-Client-Version: "2024.1.0"` (version string matching tested server release)
+/// - `X-Client-Version: "2024.12.0"` (version string; >= 2024.12.0 required for SSH key support)
 /// - `Device-Type: "7"`             (7 = macOS desktop, per Bitwarden DeviceType enum)
 ///
 /// Header requirements: https://contributing.bitwarden.com/architecture/adr/integration-identifiers/
@@ -245,9 +245,10 @@ actor MacwardenAPIClientImpl: MacwardenAPIClientProtocol {
     // https://github.com/bitwarden/server/blob/main/src/Core/Enums/DeviceType.cs
     private enum ClientHeaders {
         static let clientId      = "desktop"
-        static let clientVersion = "2024.1.0"
+        // Vaultwarden gates SSH key ciphers (type 5) behind >= 2024.12.0.
+        static let clientVersion = "2024.12.0"
         static let deviceType    = "7"
-        static let userAgent     = "Macwarden/2024.1.0"
+        static let userAgent     = "Macwarden/2024.12.0"
     }
 
     // MARK: - Init


### PR DESCRIPTION
## Problem

SSH keys visible in the Vaultwarden web UI were not showing up in Macwarden.

## Root Cause

Vaultwarden gates SSH key ciphers (type 5) behind `X-Client-Version >= 2024.12.0` in the `/sync` endpoint. Macwarden was sending `2024.1.0`, so SSH keys were silently filtered out server-side before reaching the client.

Reference: [vaultwarden/src/api/core/ciphers.rs](https://github.com/dani-garcia/vaultwarden/blob/main/src/api/core/ciphers.rs) — `show_ssh_keys` version check.

## Fix

Bump `X-Client-Version` from `2024.1.0` to `2024.12.0`.