### PR TITLE
fix: SSH keys not appearing in vault

### DIFF
--- a/Macwarden/Data/Mappers/CipherMapper.swift
+++ b/Macwarden/Data/Mappers/CipherMapper.swift
@@ -213,11 +213,11 @@ nonisolated final class CipherMapper {
         fields: [CustomField],
         keys:   CryptoKeys
     ) throws -> ItemContent {
-        let ssh = data ?? RawSSHKeyData(privateKey: nil, publicKey: nil, fingerprint: nil)
+        let ssh = data ?? RawSSHKeyData(privateKey: nil, publicKey: nil, keyFingerprint: nil)
         return .sshKey(SSHKeyContent(
             privateKey:     try ssh.privateKey.map  { try decryptRequired($0, field: "privateKey",  keys: keys) },
             publicKey:      try ssh.publicKey.map   { try decryptRequired($0, field: "publicKey",   keys: keys) },
-            keyFingerprint: try ssh.fingerprint.map { try decryptRequired($0, field: "fingerprint", keys: keys) },
+            keyFingerprint: try ssh.keyFingerprint.map { try decryptRequired($0, field: "keyFingerprint", keys: keys) },
             notes:          notes,
             customFields:   fields
         ))
@@ -394,9 +394,9 @@ nonisolated final class CipherMapper {
     private func toRawSSHKey(_ c: DraftSSHKeyContent, keys: CryptoKeys) throws -> RawSSHKeyData {
         // keyFingerprint is auto-derived and not sent to the API — it is server-authoritative.
         RawSSHKeyData(
-            privateKey:  try c.privateKey.map  { try encryptString($0, keys: keys) },
-            publicKey:   try c.publicKey.map   { try encryptString($0, keys: keys) },
-            fingerprint: nil
+            privateKey:     try c.privateKey.map  { try encryptString($0, keys: keys) },
+            publicKey:      try c.publicKey.map   { try encryptString($0, keys: keys) },
+            keyFingerprint: nil
         )
     }
 

--- a/Macwarden/Data/Network/MacwardenAPIClient.swift
+++ b/Macwarden/Data/Network/MacwardenAPIClient.swift
@@ -221,7 +221,8 @@ extension APIError: LocalizedError {
 ///
 /// All requests include the required Bitwarden client identification headers:
 /// - `X-Client-Id: "desktop"`       (registered client identifier for third-party clients)
-/// - `X-Client-Version: "2024.12.0"` (version string; >= 2024.12.0 required for SSH key support)
+/// - `X-Client-Version: "2024.12.0"` (version string)
+/// - `Bitwarden-Client-Version: "2024.12.0"` (>= 2024.12.0 required for SSH key support on Vaultwarden)
 /// - `Device-Type: "7"`             (7 = macOS desktop, per Bitwarden DeviceType enum)
 ///
 /// Header requirements: https://contributing.bitwarden.com/architecture/adr/integration-identifiers/
@@ -601,6 +602,7 @@ actor MacwardenAPIClientImpl: MacwardenAPIClientProtocol {
         req.setValue(ClientHeaders.userAgent,     forHTTPHeaderField: "User-Agent")
         req.setValue("application/json",          forHTTPHeaderField: "Accept")
         req.setValue(ClientHeaders.clientVersion, forHTTPHeaderField: "X-Client-Version")
+        req.setValue(ClientHeaders.clientVersion, forHTTPHeaderField: "Bitwarden-Client-Version")
         return req
     }
 

--- a/Macwarden/Data/Network/MacwardenAPIClient.swift
+++ b/Macwarden/Data/Network/MacwardenAPIClient.swift
@@ -5,8 +5,8 @@ import os.log
 
 /// Bitwarden REST API client for auth and vault sync operations.
 ///
-/// All requests require the `X-Client-Id`, `X-Client-Version`, and `Device-Type` headers
-/// that Bitwarden mandates for all client integrations.
+/// All requests include the `X-Client-Version` and `Bitwarden-Client-Version` headers.
+/// The identity token request additionally sends `client_id` and `deviceType` as form parameters.
 /// Reference: https://contributing.bitwarden.com/architecture/adr/integration-identifiers/
 /// Missing or invalid headers result in `400 Bad Request` / `403 Forbidden` from the server.
 ///
@@ -220,10 +220,12 @@ extension APIError: LocalizedError {
 /// URLSession-backed Bitwarden API client.
 ///
 /// All requests include the required Bitwarden client identification headers:
-/// - `X-Client-Id: "desktop"`       (registered client identifier for third-party clients)
-/// - `X-Client-Version: "2024.12.0"` (version string)
+/// - `X-Client-Version: "2024.12.0"` (version string, required by upstream Bitwarden)
 /// - `Bitwarden-Client-Version: "2024.12.0"` (>= 2024.12.0 required for SSH key support on Vaultwarden)
-/// - `Device-Type: "7"`             (7 = macOS desktop, per Bitwarden DeviceType enum)
+///
+/// The identity token request additionally sends these as form body parameters:
+/// - `client_id: "desktop"`   (registered client identifier)
+/// - `deviceType: "7"`        (7 = macOS desktop, per Bitwarden DeviceType enum)
 ///
 /// Header requirements: https://contributing.bitwarden.com/architecture/adr/integration-identifiers/
 /// DeviceType enum values: https://github.com/bitwarden/server/blob/main/src/Core/Enums/DeviceType.cs

--- a/Macwarden/Data/Network/Models/RawCipher.swift
+++ b/Macwarden/Data/Network/Models/RawCipher.swift
@@ -97,6 +97,10 @@ nonisolated struct RawSSHKeyData: Codable {
     let privateKey:     String?    // EncString
     let publicKey:      String?    // EncString
     let keyFingerprint: String?    // EncString
+
+    private enum CodingKeys: String, CodingKey {
+        case privateKey, publicKey, keyFingerprint
+    }
 }
 
 // MARK: - Custom Field

--- a/Macwarden/Data/Network/Models/RawCipher.swift
+++ b/Macwarden/Data/Network/Models/RawCipher.swift
@@ -94,9 +94,9 @@ nonisolated struct RawSecureNoteData: Codable {
 // MARK: - SSH Key
 
 nonisolated struct RawSSHKeyData: Codable {
-    let privateKey:  String?    // EncString
-    let publicKey:   String?    // EncString
-    let fingerprint: String?    // EncString
+    let privateKey:     String?    // EncString
+    let publicKey:      String?    // EncString
+    let keyFingerprint: String?    // EncString
 }
 
 // MARK: - Custom Field

--- a/Macwarden/MacwardenTests/CipherMapperTests.swift
+++ b/Macwarden/MacwardenTests/CipherMapperTests.swift
@@ -178,9 +178,9 @@ final class CipherMapperTests: XCTestCase {
             type:   5,
             name:   try enc("My SSH Key"),
             sshKey: RawSSHKeyData(
-                privateKey:  try enc("-----BEGIN OPENSSH PRIVATE KEY-----\n..."),
-                publicKey:   try enc("ssh-ed25519 AAAA..."),
-                fingerprint: try enc("SHA256:abc123")
+                privateKey:     try enc("-----BEGIN OPENSSH PRIVATE KEY-----\n..."),
+                publicKey:      try enc("ssh-ed25519 AAAA..."),
+                keyFingerprint: try enc("SHA256:abc123")
             )
         )
 


### PR DESCRIPTION
## Problem

SSH key items never appear in the vault — the SSH Key sidebar section always shows an empty list.

## Root cause

Two issues:

### 1. Missing `Bitwarden-Client-Version` header

Vaultwarden's sync endpoint filters out SSH key ciphers (type 5) unless the client sends a `Bitwarden-Client-Version` header with a value `>= 2024.12.0`. Macwarden was only sending `X-Client-Version`, which Vaultwarden ignores for this check. Without the header, `show_ssh_keys` defaults to `false` and all SSH keys are silently stripped from the sync response.

Reference: [vaultwarden/src/api/core/ciphers.rs](https://github.com/dani-garcia/vaultwarden/blob/main/src/api/core/ciphers.rs) — `ClientVersion` guard reads `Bitwarden-Client-Version` ([src/auth.rs](https://github.com/dani-garcia/vaultwarden/blob/main/src/auth.rs)).

### 2. Wrong JSON key for SSH fingerprint

`RawSSHKeyData.fingerprint` didn't match the Bitwarden/Vaultwarden wire format, which uses `keyFingerprint`. Since `JSONDecoder` uses default key mapping, the property name must match exactly. This caused the fingerprint to always decode as `nil`.

Reference: [CipherSshKeyModel](https://sdk-api-docs.bitwarden.com/bitwarden_api_api/models/cipher_ssh_key_model/struct.CipherSshKeyModel.html) — field is `key_fingerprint`, serialized as `keyFingerprint`.

## Changes

- **MacwardenAPIClient.swift** — Add `Bitwarden-Client-Version` header to `baseRequest()`
- **RawCipher.swift** — Rename `fingerprint` → `keyFingerprint` on `RawSSHKeyData`
- **CipherMapper.swift** — Update `mapSSHKey` and `toRawSSHKey` for the renamed field
- **CipherMapperTests.swift** — Update test to match