### PR TITLE
fix: remove space from password generator symbol set

### DIFF
--- a/Macwarden/Domain/Utilities/PasswordGenerator.swift
+++ b/Macwarden/Domain/Utilities/PasswordGenerator.swift
@@ -9,7 +9,7 @@ struct PasswordGenerator {
     private static let uppercaseChars = Array("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
     private static let lowercaseChars = Array("abcdefghijklmnopqrstuvwxyz")
     private static let digitChars     = Array("0123456789")
-    private static let symbolChars    = Array("!@#$%^&*()_+-=[]{}|;':\",.< >?/")
+    private static let symbolChars    = Array("!@#$%^&*()_+-=[]{}|;':\",.<>?/")
     private static let ambiguousChars: Set<Character> = ["0", "O", "I", "l", "1", "|"]
 
     // MARK: - EFF word list (loaded once, cached)

--- a/Macwarden/MacwardenTests/PasswordGeneratorTests.swift
+++ b/Macwarden/MacwardenTests/PasswordGeneratorTests.swift
@@ -92,6 +92,19 @@ final class PasswordGeneratorTests: XCTestCase {
         }
     }
 
+    func testPassword_noWhitespace_withSymbolsEnabled() throws {
+        var config = PasswordGeneratorConfig()
+        config.length = 128
+        for seed in [Array<UInt8>(repeating: 0, count: 256),
+                     Array<UInt8>(repeating: 127, count: 256),
+                     Array<UInt8>(repeating: 255, count: 256),
+                     Array<UInt8>(0...255)] {
+            let p = MockRandomnessProvider(seed: seed)
+            let result = try generator.generatePassword(config: config, provider: p)
+            XCTAssertFalse(result.contains(where: { $0.isWhitespace }), "Password contains whitespace: \(result)")
+        }
+    }
+
     func testPassword_lastSetLock_preventsEmptyPool() throws {
         // All sets disabled — generator should fall back to lowercase.
         var config = PasswordGeneratorConfig()

--- a/openspec/changes/fix-password-generator-whitespace/.openspec.yaml
+++ b/openspec/changes/fix-password-generator-whitespace/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-24

--- a/openspec/changes/fix-password-generator-whitespace/design.md
+++ b/openspec/changes/fix-password-generator-whitespace/design.md
@@ -1,0 +1,21 @@
+## Context
+
+`PasswordGenerator.symbolChars` is defined as `Array("!@#$%^&*()_+-=[]{}|;':\",.< >?/")`. The space between `<` and `>` is a typo — the intended set (per the `password-generator` spec) is `!@#$%^&*()_+-=[]{}|;':",.<>?/` with no whitespace. This is a one-line constant fix.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove the space character from `symbolChars` so generated passwords never contain whitespace
+
+**Non-Goals:**
+- Changing the symbol set composition beyond removing the space
+- Adding a "custom symbols" configuration option
+- Regenerating or invalidating previously generated passwords
+
+## Decisions
+
+- **Fix the constant, not the generation logic.** The bug is in the data (`symbolChars`), not the algorithm. Alternatives: adding a post-generation whitespace strip, or filtering the pool — both add unnecessary complexity for a data typo.
+
+## Risks / Trade-offs
+
+- [Low] Users who relied on spaces in generated passwords will see different output. → Acceptable; spaces in passwords are a defect, not a feature.

--- a/openspec/changes/fix-password-generator-whitespace/proposal.md
+++ b/openspec/changes/fix-password-generator-whitespace/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The password generator's symbol character set contains a literal space character (`",.< >?/"`), causing generated passwords to include spaces when symbols are enabled. Spaces in passwords cause usability issues (hard to see, easy to mis-copy, rejected by some services) and violate user expectations — the spec defines the symbol set as `!@#$%^&*()_+-=[]{}|;':",.<>?/` with no whitespace.
+
+## What Changes
+
+- Remove the space character from the symbol character set in `PasswordGenerator.swift`
+- No new features; this is a correctness fix to match the existing spec
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `password-generator`: The symbol character set definition in the spec already excludes spaces; this change fixes the implementation to match. No spec-level requirement change needed — the spec is correct, the code is wrong.
+
+## Impact
+
+- `Macwarden/Domain/Utilities/PasswordGenerator.swift` — `symbolChars` constant
+- All passwords generated with symbols enabled are affected (default configuration)
+- No API, persistence, or dependency changes

--- a/openspec/changes/fix-password-generator-whitespace/specs/password-generator/spec.md
+++ b/openspec/changes/fix-password-generator-whitespace/specs/password-generator/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: User can generate a random password with configurable options
+The system SHALL provide a password generator that produces cryptographically random character-based passwords. The generator SHALL support the following configuration options: length (integer, 5–128 inclusive, default 16), uppercase letters toggle (A–Z, default on), lowercase letters toggle (a–z, default on), digits toggle (0–9, default on), symbols toggle (`!@#$%^&*()_+-=[]{}|;':",.<>?/`, default on), and avoid-ambiguous-characters toggle (excludes `0`, `O`, `I`, `l`, `1`, `|` from all enabled sets, default off). The generated password SHALL contain at least one character from each enabled character set. The generated password SHALL NOT contain whitespace characters (space, tab, newline). The system SHALL prevent the user from disabling all character sets simultaneously — the last remaining enabled set's toggle SHALL be locked and non-interactive.
+
+#### Scenario: Default configuration produces a 16-character password
+- **WHEN** the generator opens in Password mode with default settings
+- **THEN** it SHALL produce a 16-character password containing characters from uppercase, lowercase, digits, and symbols sets
+
+#### Scenario: Disabling a character set excludes those characters
+- **WHEN** the user disables the symbols toggle
+- **THEN** subsequent generated passwords SHALL contain no symbol characters
+
+#### Scenario: At least one character from each enabled set is present
+- **WHEN** a password is generated with multiple sets enabled
+- **THEN** the result SHALL contain at least one character from each enabled set
+
+#### Scenario: Avoid-ambiguous excludes specified characters
+- **WHEN** the avoid-ambiguous toggle is enabled
+- **THEN** the generated password SHALL not contain any of the characters `0`, `O`, `I`, `l`, `1`, `|`
+
+#### Scenario: Length slider is clamped to valid range
+- **WHEN** the user adjusts the length slider
+- **THEN** the length SHALL be constrained to the range 5–128 inclusive
+
+#### Scenario: Last enabled character set cannot be disabled
+- **WHEN** only one character set toggle remains enabled
+- **THEN** that toggle SHALL be non-interactive and the other disabled toggles SHALL remain operable
+
+#### Scenario: Generated password contains no whitespace
+- **WHEN** a password is generated with any combination of enabled character sets
+- **THEN** the result SHALL NOT contain any whitespace characters (space, tab, newline, or carriage return)

--- a/openspec/changes/fix-password-generator-whitespace/tasks.md
+++ b/openspec/changes/fix-password-generator-whitespace/tasks.md
@@ -1,0 +1,5 @@
+## 1. Fix symbol character set
+
+- [x] 1.1 Remove the space character from `symbolChars` in `PasswordGenerator.swift` (change `",.< >?/"` to `",.<>?/"`)
+- [x] 1.2 Verify the updated `symbolChars` array matches the spec set exactly: `!@#$%^&*()_+-=[]{}|;':",.<>?/`
+- [x] 1.3 Add `testPassword_noWhitespace_withSymbolsEnabled` to `PasswordGeneratorTests.swift` — generate 128-char passwords with symbols enabled across multiple seeds, assert none contain whitespace


### PR DESCRIPTION
## Problem

The `symbolChars` constant in `PasswordGenerator.swift` contained a literal space character between `<` and `>`:

```
"!@#$%^&*()_+-=[]{}|;':",.< >?/"
                            ^
```

This caused generated passwords to include spaces when symbols were enabled (the default), leading to usability issues and violating the spec.

## Fix

- Removed the space from `symbolChars` so it matches the spec exactly: `!@#$%^&*()_+-=[]{}|;':",.<>?/`
- Added `testPassword_noWhitespace_withSymbolsEnabled` to `PasswordGeneratorTests`

## Testing

All 19 password generator tests pass, including the new whitespace assertion.