### PR TITLE
feat: add new vault item creation

### DIFF
--- a/Macwarden/App/AppContainer.swift
+++ b/Macwarden/App/AppContainer.swift
@@ -30,6 +30,7 @@ final class AppContainer: ObservableObject {
     let unlockUseCase:                   UnlockUseCaseImpl
     let searchVaultUseCase:              SearchVaultUseCaseImpl
     let editVaultItemUseCase:            EditVaultItemUseCaseImpl
+    let createVaultItemUseCase:          CreateVaultItemUseCaseImpl
     let deleteVaultItemUseCase:          DeleteVaultItemUseCaseImpl
     let permanentDeleteVaultItemUseCase: PermanentDeleteVaultItemUseCaseImpl
     let restoreVaultItemUseCase:         RestoreVaultItemUseCaseImpl
@@ -65,6 +66,7 @@ final class AppContainer: ObservableObject {
         self.unlockUseCase           = UnlockUseCaseImpl(auth: auth, sync: sync)
         self.searchVaultUseCase      = SearchVaultUseCaseImpl(vault: vault)
         self.editVaultItemUseCase            = EditVaultItemUseCaseImpl(repository: vault)
+        self.createVaultItemUseCase          = CreateVaultItemUseCaseImpl(repository: vault)
         self.deleteVaultItemUseCase          = DeleteVaultItemUseCaseImpl(repository: vault)
         self.permanentDeleteVaultItemUseCase = PermanentDeleteVaultItemUseCaseImpl(repository: vault)
         self.restoreVaultItemUseCase         = RestoreVaultItemUseCaseImpl(repository: vault)
@@ -97,5 +99,10 @@ final class AppContainer: ObservableObject {
     /// The caller is responsible for setting `onSaveSuccess` to update the UI after a save.
     func makeItemEditViewModel(for item: VaultItem) -> ItemEditViewModel {
         ItemEditViewModel(item: item, useCase: editVaultItemUseCase)
+    }
+
+    /// Creates an `ItemEditViewModel` in create mode for the given item type.
+    func makeItemCreateViewModel(for type: ItemType) -> ItemEditViewModel {
+        ItemEditViewModel(type: type, useCase: createVaultItemUseCase)
     }
 }

--- a/Macwarden/App/MacwardenApp.swift
+++ b/Macwarden/App/MacwardenApp.swift
@@ -95,6 +95,13 @@ struct MacwardenApp: App {
                         vaultBrowserVM?.handleItemSaved(updatedItem)
                     }
                     return vm
+                },
+                makeCreateViewModel: { [vaultBrowserVM = rootVM.vaultBrowserVM] type in
+                    let vm = container.makeItemCreateViewModel(for: type)
+                    vm.onSaveSuccess = { [weak vaultBrowserVM] item in
+                        vaultBrowserVM?.handleItemSaved(item)
+                    }
+                    return vm
                 }
             )
         }

--- a/Macwarden/Data/Network/MacwardenAPIClient.swift
+++ b/Macwarden/Data/Network/MacwardenAPIClient.swift
@@ -100,6 +100,13 @@ protocol MacwardenAPIClientProtocol: Actor {
     /// Reference: Bitwarden Server API PUT /api/ciphers/{id}/restore
     func restoreCipher(id: String) async throws
 
+    /// POST `/api/ciphers` — creates a new cipher with encrypted field values.
+    ///
+    /// Requires a valid `Authorization: Bearer <accessToken>` header.
+    /// The request body is a JSON-encoded `RawCipher`. The server assigns the ID and timestamps.
+    /// On success the server returns the created cipher, decoded back into `RawCipher`.
+    func createCipher(cipher: RawCipher) async throws -> RawCipher
+
 }
 
 // MARK: - Wire Models
@@ -567,6 +574,31 @@ actor MacwardenAPIClientImpl: MacwardenAPIClientProtocol {
     }
 
     // MARK: - refreshAccessToken
+
+    // MARK: - createCipher
+
+    func createCipher(cipher: RawCipher) async throws -> RawCipher {
+        guard let base = baseURL else { throw APIError.baseURLNotSet }
+        let url = base.appendingPathComponent("api/ciphers")
+
+        if DebugConfig.isEnabled {
+            logger.debug("[debug] createCipher → POST \(url.absoluteString, privacy: .public)")
+        }
+
+        var request = baseRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token = accessToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = try JSONEncoder().encode(cipher)
+
+        let created: RawCipher = try await perform(request: request)
+        if DebugConfig.isEnabled {
+            logger.debug("[debug] createCipher ← id=\(created.id, privacy: .public)")
+        }
+        return created
+    }
 
     func refreshAccessToken(refreshToken: String) async throws -> (accessToken: String, refreshToken: String?) {
         guard let base = baseURL else { throw APIError.baseURLNotSet }

--- a/Macwarden/Data/Repositories/VaultRepositoryImpl.swift
+++ b/Macwarden/Data/Repositories/VaultRepositoryImpl.swift
@@ -179,6 +179,26 @@ final class VaultRepositoryImpl: VaultRepository {
         return updatedItem
     }
 
+    // MARK: - Create (write path)
+
+    func create(_ draft: DraftVaultItem) async throws -> VaultItem {
+        let keys: CryptoKeys
+        do {
+            keys = try await crypto.currentKeys()
+        } catch MacwardenCryptoServiceError.vaultLocked {
+            throw VaultError.vaultLocked
+        }
+
+        let rawCipher = try mapper.toRawCipher(draft, encryptedWith: keys)
+        let createdRaw = try await apiClient.createCipher(cipher: rawCipher)
+        let createdItem = try mapper.map(raw: createdRaw, keys: keys)
+        items.append(createdItem)
+        // Note: sidebar counts are refreshed by the caller (VaultBrowserViewModel.handleItemSaved)
+        // via the onSaveSuccess callback — same pattern as update().
+        logger.info("Vault item created: \(createdItem.id, privacy: .public)")
+        return createdItem
+    }
+
     // MARK: - Delete / Restore / Empty Trash
 
     /// Soft-deletes the active item with `id` by calling `PUT /ciphers/{id}/delete`.

--- a/Macwarden/Data/UseCases/CreateVaultItemUseCaseImpl.swift
+++ b/Macwarden/Data/UseCases/CreateVaultItemUseCaseImpl.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Concrete implementation of `CreateVaultItemUseCase`.
+/// Delegates encryption and network I/O to `VaultRepository.create`.
+final class CreateVaultItemUseCaseImpl: CreateVaultItemUseCase {
+
+    private let repository: any VaultRepository
+
+    init(repository: any VaultRepository) {
+        self.repository = repository
+    }
+
+    func execute(draft: DraftVaultItem) async throws -> VaultItem {
+        try await repository.create(draft)
+    }
+}

--- a/Macwarden/Domain/Entities/DraftVaultItem.swift
+++ b/Macwarden/Domain/Entities/DraftVaultItem.swift
@@ -233,6 +233,41 @@ nonisolated struct DraftVaultItem: Equatable {
     /// round-trips it correctly. Not user-editable in v1.
     let reprompt: Int
 
+    /// Creates a blank draft for a new item of the given type.
+    static func blank(type: ItemType) -> DraftVaultItem {
+        let now = Date()
+        let content: DraftItemContent = switch type {
+        case .login:      .login(DraftLoginContent(LoginContent(username: nil, password: nil, uris: [], totp: nil, notes: nil, customFields: [])))
+        case .card:       .card(DraftCardContent(CardContent(cardholderName: nil, brand: nil, number: nil, expMonth: nil, expYear: nil, code: nil, notes: nil, customFields: [])))
+        case .identity:   .identity(DraftIdentityContent(IdentityContent(title: nil, firstName: nil, middleName: nil, lastName: nil, address1: nil, address2: nil, address3: nil, city: nil, state: nil, postalCode: nil, country: nil, company: nil, email: nil, phone: nil, ssn: nil, username: nil, passportNumber: nil, licenseNumber: nil, notes: nil, customFields: [])))
+        case .secureNote: .secureNote(DraftSecureNoteContent(SecureNoteContent(notes: nil, customFields: [])))
+        case .sshKey:     .sshKey(DraftSSHKeyContent(SSHKeyContent(privateKey: nil, publicKey: nil, keyFingerprint: nil, notes: nil, customFields: [])))
+        }
+        return DraftVaultItem(
+            id: UUID().uuidString,
+            name: "",
+            isFavorite: false,
+            isDeleted: false,
+            creationDate: now,
+            revisionDate: now,
+            content: content,
+            reprompt: 0
+        )
+    }
+
+    /// Memberwise initialiser for programmatic construction (blank drafts, tests).
+    init(id: String, name: String, isFavorite: Bool, isDeleted: Bool,
+         creationDate: Date, revisionDate: Date, content: DraftItemContent, reprompt: Int) {
+        self.id = id
+        self.name = name
+        self.isFavorite = isFavorite
+        self.isDeleted = isDeleted
+        self.creationDate = creationDate
+        self.revisionDate = revisionDate
+        self.content = content
+        self.reprompt = reprompt
+    }
+
     /// Converts an immutable `VaultItem` into a mutable draft ready for editing.
     init(_ item: VaultItem) {
         self.id = item.id

--- a/Macwarden/Domain/Entities/DraftVaultItem.swift
+++ b/Macwarden/Domain/Entities/DraftVaultItem.swift
@@ -237,7 +237,7 @@ nonisolated struct DraftVaultItem: Equatable {
     static func blank(type: ItemType) -> DraftVaultItem {
         let now = Date()
         let content: DraftItemContent = switch type {
-        case .login:      .login(DraftLoginContent(LoginContent(username: nil, password: nil, uris: [], totp: nil, notes: nil, customFields: [])))
+        case .login:      .login(DraftLoginContent(LoginContent(username: nil, password: nil, uris: [LoginURI(uri: "", matchType: nil)], totp: nil, notes: nil, customFields: [])))
         case .card:       .card(DraftCardContent(CardContent(cardholderName: nil, brand: nil, number: nil, expMonth: nil, expYear: nil, code: nil, notes: nil, customFields: [])))
         case .identity:   .identity(DraftIdentityContent(IdentityContent(title: nil, firstName: nil, middleName: nil, lastName: nil, address1: nil, address2: nil, address3: nil, city: nil, state: nil, postalCode: nil, country: nil, company: nil, email: nil, phone: nil, ssn: nil, username: nil, passportNumber: nil, licenseNumber: nil, notes: nil, customFields: [])))
         case .secureNote: .secureNote(DraftSecureNoteContent(SecureNoteContent(notes: nil, customFields: [])))

--- a/Macwarden/Domain/Entities/SidebarSelection.swift
+++ b/Macwarden/Domain/Entities/SidebarSelection.swift
@@ -4,12 +4,14 @@ import Foundation
 /// `CaseIterable` enables the sidebar to iterate all types without a hardcoded list.
 /// `Hashable` is required because `SidebarSelection.type(ItemType)` uses this as an
 /// associated value, and `[SidebarSelection: Int]` is used for item counts.
-nonisolated enum ItemType: String, Equatable, Hashable, CaseIterable {
+nonisolated enum ItemType: String, Equatable, Hashable, CaseIterable, Identifiable {
     case login
     case card
     case identity
     case secureNote
     case sshKey
+
+    var id: String { rawValue }
 
     var displayName: String {
         switch self {

--- a/Macwarden/Domain/Repositories/VaultRepository.swift
+++ b/Macwarden/Domain/Repositories/VaultRepository.swift
@@ -74,6 +74,10 @@ protocol VaultRepository: AnyObject, Sendable {
     /// - Throws: `Error` on network or HTTP failure.
     func restoreItem(id: String) async throws
 
+    /// Encrypts a new `draft`, calls `POST /api/ciphers`, inserts the server-confirmed item
+    /// into the in-memory cache, and returns it.
+    func create(_ draft: DraftVaultItem) async throws -> VaultItem
+
 }
 
 // MARK: - Errors

--- a/Macwarden/Domain/UseCases/CreateVaultItemUseCase.swift
+++ b/Macwarden/Domain/UseCases/CreateVaultItemUseCase.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// Creates a new vault item by encrypting and posting it to the Bitwarden API.
+protocol CreateVaultItemUseCase {
+    func execute(draft: DraftVaultItem) async throws -> VaultItem
+}

--- a/Macwarden/Macwarden.xcodeproj/project.pbxproj
+++ b/Macwarden/Macwarden.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		C290678FFC8F4FDDB215C261 /* LoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257FAE34CC064783806B6A5C /* LoginUseCase.swift */; };
 		C3D2E3F400A1B05B50607080 /* SecureNoteEditForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E3F400A1B2C06C60708090 /* SecureNoteEditForm.swift */; };
 		C3D4E5F607182940B5C6D7E8 /* EditVaultItemUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F6071829304AC6D7E8F9 /* EditVaultItemUseCase.swift */; };
+		AC3EC95F694247B5A5809233 /* CreateVaultItemUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A335CC7B3C743B59A7630D8 /* CreateVaultItemUseCase.swift */; };
 		C3D4E5F6A7B849C0D1E2F3A4 /* MacwardenCryptoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D710BEABBB4ADD9ADFCD1F /* MacwardenCryptoService.swift */; };
 		C3DDB598E8834E85833D86FE /* VaultBrowserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F177A6089741F69C02E285 /* VaultBrowserViewModel.swift */; };
 		C8951B673C224D76A33775A1 /* UnlockViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AFBFFDE4FCE4BD28D3C8E9A /* UnlockViewModel.swift */; };
@@ -84,6 +85,7 @@
 		E17D4DA652374B49BC2CD6B1 /* VaultBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D9916B5072420494DE6F9F /* VaultBrowserView.swift */; };
 		E5F400A1B2C3D07D70809000 /* SSHKeyEditForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = F600A1B2C3D4E08E80900A1B /* SSHKeyEditForm.swift */; };
 		E5F607182930405BD7E8F90A /* EditVaultItemUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = F607182930405A6CE8F90A1B /* EditVaultItemUseCaseImpl.swift */; };
+		A96C7D84DE3B404CA450285C /* CreateVaultItemUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B465482A0CFB4710AD4727CB /* CreateVaultItemUseCaseImpl.swift */; };
 		E5F6A7B8C9D04BE2F3A4B5C6 /* SyncResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F3A553820942CF9B3935FD /* SyncResponse.swift */; };
 		E7772DAF3F324B8A807B7491 /* ItemRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6631A93BC5EA4827BC497076 /* ItemRowView.swift */; };
 		EE11223344556677889900BB /* DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00112233445566778899AA /* DesignSystem.swift */; };
@@ -172,6 +174,7 @@
 		D4C3B2A1F6E54789D4C3B2A1 /* VerticalLabeledContentStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalLabeledContentStyle.swift; sourceTree = "<group>"; };
 		D4E3F400A1B2C06C60708090 /* SecureNoteEditForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureNoteEditForm.swift; sourceTree = "<group>"; };
 		D4E5F6071829304AC6D7E8F9 /* EditVaultItemUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditVaultItemUseCase.swift; sourceTree = "<group>"; };
+		5A335CC7B3C743B59A7630D8 /* CreateVaultItemUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateVaultItemUseCase.swift; sourceTree = "<group>"; };
 		D7044163F8FD4199B4925DD2 /* SidebarSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSelection.swift; sourceTree = "<group>"; };
 		D8D710BEABBB4ADD9ADFCD1F /* MacwardenCryptoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacwardenCryptoService.swift; sourceTree = "<group>"; };
 		DF8949A6D242488CBEC15CC0 /* ItemListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListView.swift; sourceTree = "<group>"; };
@@ -187,6 +190,7 @@
 		F5F177A6089741F69C02E285 /* VaultBrowserViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultBrowserViewModel.swift; sourceTree = "<group>"; };
 		F600A1B2C3D4E08E80900A1B /* SSHKeyEditForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHKeyEditForm.swift; sourceTree = "<group>"; };
 		F607182930405A6CE8F90A1B /* EditVaultItemUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditVaultItemUseCaseImpl.swift; sourceTree = "<group>"; };
+		B465482A0CFB4710AD4727CB /* CreateVaultItemUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateVaultItemUseCaseImpl.swift; sourceTree = "<group>"; };
 		F641DA62DF364B3C9D896204 /* TOTPPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOTPPromptView.swift; sourceTree = "<group>"; };
 		F8197007AA7E412D96A52B14 /* MaskedFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskedFieldView.swift; sourceTree = "<group>"; };
 		F95EFA050DE64617AC5076CD /* CustomFieldsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldsSection.swift; sourceTree = "<group>"; };
@@ -278,6 +282,7 @@
 				5EBA517603CA448A8F9106AF /* SyncUseCase.swift */,
 				09B93B56553644E49DE5C512 /* SearchVaultUseCase.swift */,
 				D4E5F6071829304AC6D7E8F9 /* EditVaultItemUseCase.swift */,
+				5A335CC7B3C743B59A7630D8 /* CreateVaultItemUseCase.swift */,
 				EDB0E4B753854AFF89FFFAA2 /* DeleteVaultItemUseCase.swift */,
 				4929412F2A6B4670960BFB53 /* RestoreVaultItemUseCase.swift */,
 				6A4F9E3B2C0D58F7B1A6E3C9 /* PermanentDeleteVaultItemUseCase.swift */,
@@ -611,6 +616,7 @@
 				8504983920144A92B0241CA9 /* SyncUseCaseImpl.swift */,
 				6B41D0A2F7E54938AE12C8B5 /* SearchVaultUseCaseImpl.swift */,
 				F607182930405A6CE8F90A1B /* EditVaultItemUseCaseImpl.swift */,
+				B465482A0CFB4710AD4727CB /* CreateVaultItemUseCaseImpl.swift */,
 				42858B188901413C9FD6C6E6 /* DeleteVaultItemUseCaseImpl.swift */,
 				75776838723C412E94327CDD /* RestoreVaultItemUseCaseImpl.swift */,
 				8C6B1A5D4E2F70B9D3C8A5EB /* PermanentDeleteVaultItemUseCaseImpl.swift */,
@@ -798,7 +804,9 @@
 				EE11223344556677889900BB /* DesignSystem.swift in Sources */,
 				A1C2D3E4F506172839A4B56C /* DraftVaultItem.swift in Sources */,
 				C3D4E5F607182940B5C6D7E8 /* EditVaultItemUseCase.swift in Sources */,
+				AC3EC95F694247B5A5809233 /* CreateVaultItemUseCase.swift in Sources */,
 				E5F607182930405BD7E8F90A /* EditVaultItemUseCaseImpl.swift in Sources */,
+				A96C7D84DE3B404CA450285C /* CreateVaultItemUseCaseImpl.swift in Sources */,
 				0718293040506070F90A1B2C /* ItemEditViewModel.swift in Sources */,
 				29304050607080F1B2C3D4E5 /* ItemEditView.swift in Sources */,
 				4B506070809000D3D4E5F607 /* EditFieldRow.swift in Sources */,

--- a/Macwarden/MacwardenTests/Mocks/MockMacwardenAPIClient.swift
+++ b/Macwarden/MacwardenTests/Mocks/MockMacwardenAPIClient.swift
@@ -122,6 +122,18 @@ actor MockMacwardenAPIClient: MacwardenAPIClientProtocol {
         return updateCipherResponse ?? cipher
     }
 
+    // MARK: - Stubs: createCipher
+
+    nonisolated(unsafe) var createCipherResponse: RawCipher?
+    nonisolated(unsafe) var createCipherShouldThrow: Error?
+    nonisolated(unsafe) var createCipherCallCount: Int = 0
+
+    func createCipher(cipher: RawCipher) async throws -> RawCipher {
+        createCipherCallCount += 1
+        if let err = createCipherShouldThrow { throw err }
+        return createCipherResponse ?? cipher
+    }
+
     // MARK: - Stubs: softDeleteCipher
 
     nonisolated(unsafe) var softDeleteShouldThrow: Error?

--- a/Macwarden/MacwardenTests/Mocks/MockVaultRepository.swift
+++ b/Macwarden/MacwardenTests/Mocks/MockVaultRepository.swift
@@ -76,6 +76,23 @@ final class MockVaultRepository: VaultRepository {
         return result
     }
 
+    // MARK: - create(_:) stubbing
+
+    var stubbedCreateResult: VaultItem?
+    var stubbedCreateError: Error?
+    private(set) var createCallCount: Int = 0
+    private(set) var lastCreatedDraft: DraftVaultItem?
+
+    func create(_ draft: DraftVaultItem) async throws -> VaultItem {
+        createCallCount += 1
+        lastCreatedDraft = draft
+        if let error = stubbedCreateError { throw error }
+        guard let result = stubbedCreateResult else {
+            return VaultItem(draft)
+        }
+        return result
+    }
+
     // MARK: - deleteItem stubbing
 
     var stubbedDeleteError: Error?

--- a/Macwarden/Presentation/AccessibilityIdentifiers.swift
+++ b/Macwarden/Presentation/AccessibilityIdentifiers.swift
@@ -130,8 +130,12 @@ nonisolated enum AccessibilityID {
     // MARK: - Create Item (add-vault-items)
 
     enum Create {
-        /// The "+" menu button in the content column toolbar used to create a new vault item.
+        /// The "+" button that opens the new-item type picker popover.
         static let newItemButton = "create.button.newItem"
+        /// The List inside the type picker popover.
+        static let pickerList    = "typePicker.list"
+        /// A row inside the type picker; `typeName` is the `ItemType.rawValue` (e.g. "login", "card").
+        static func pickerRow(_ typeName: String) -> String { "typePicker.row.\(typeName)" }
     }
 
     // MARK: - Password Generator (password-generator)

--- a/Macwarden/Presentation/AccessibilityIdentifiers.swift
+++ b/Macwarden/Presentation/AccessibilityIdentifiers.swift
@@ -127,6 +127,13 @@ nonisolated enum AccessibilityID {
         static let permanentDeleteButton = "trash.button.permanentDelete"
     }
 
+    // MARK: - Create Item (add-vault-items)
+
+    enum Create {
+        /// The "+" menu button in the content column toolbar used to create a new vault item.
+        static let newItemButton = "create.button.newItem"
+    }
+
     // MARK: - Password Generator (password-generator)
 
     enum Generator {

--- a/Macwarden/Presentation/Vault/Edit/EditFieldRow.swift
+++ b/Macwarden/Presentation/Vault/Edit/EditFieldRow.swift
@@ -100,9 +100,15 @@ struct MaskedEditFieldRow: View {
                     .font(Typography.fieldValue.monospaced())
                     .textFieldStyle(.plain)
                 } else {
-                    Text(MaskedFieldState.maskedPlaceholder)
-                        .font(Typography.fieldValue.monospaced())
-                        .foregroundStyle(.secondary)
+                    SecureField(
+                        label,
+                        text: Binding(
+                            get:  { value ?? "" },
+                            set:  { value = $0.isEmpty ? nil : $0 }
+                        )
+                    )
+                    .font(Typography.fieldValue.monospaced())
+                    .textFieldStyle(.plain)
                 }
             }
             Spacer()

--- a/Macwarden/Presentation/Vault/Edit/ItemEditViewModel.swift
+++ b/Macwarden/Presentation/Vault/Edit/ItemEditViewModel.swift
@@ -57,7 +57,8 @@ final class ItemEditViewModel: ObservableObject {
     /// Snapshot of the item as it was when the sheet opened — used for `hasChanges`.
     private let original: DraftVaultItem
 
-    private let useCase: any EditVaultItemUseCase
+    private let editUseCase: (any EditVaultItemUseCase)?
+    private let createUseCase: (any CreateVaultItemUseCase)?
     private let logger  = Logger(subsystem: "com.macwarden", category: "ItemEditViewModel")
 
     /// Called on save success with the server-confirmed `VaultItem` so the caller
@@ -69,11 +70,22 @@ final class ItemEditViewModel: ObservableObject {
 
     // MARK: - Init
 
+    /// Edit mode: initialised with an existing item.
     init(item: VaultItem, useCase: any EditVaultItemUseCase) {
         self.draft    = DraftVaultItem(item)
         self.original = DraftVaultItem(item)
-        self.useCase  = useCase
+        self.editUseCase  = useCase
+        self.createUseCase = nil
+        subscribeToVaultLock()
+    }
 
+    /// Create mode: initialised with a blank draft for the given type.
+    init(type: ItemType, useCase: any CreateVaultItemUseCase) {
+        let blank = DraftVaultItem.blank(type: type)
+        self.draft    = blank
+        self.original = blank
+        self.editUseCase  = nil
+        self.createUseCase = useCase
         subscribeToVaultLock()
     }
 
@@ -87,7 +99,14 @@ final class ItemEditViewModel: ObservableObject {
             isSaving  = true
             saveError = nil
             do {
-                let saved = try await useCase.execute(draft: draft)
+                let saved: VaultItem
+                if let createUseCase {
+                    saved = try await createUseCase.execute(draft: draft)
+                } else if let editUseCase {
+                    saved = try await editUseCase.execute(draft: draft)
+                } else {
+                    preconditionFailure("ItemEditViewModel: no use case configured")
+                }
                 onSaveSuccess?(saved)
                 clearDraft()
                 isDismissed = true

--- a/Macwarden/Presentation/Vault/VaultBrowserView.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserView.swift
@@ -76,7 +76,7 @@ struct VaultBrowserView: View {
                         // ⌘N opens the type picker from the keyboard. .disabled gates both the
                         // shortcut and the menu bar entry when Trash is active, so the greyed-out
                         // menu bar item reinforces the visual hidden state of the toolbar button.
-                        .keyboardShortcut(.n, modifiers: .command)
+                        .keyboardShortcut("n", modifiers: .command)
                         .disabled(viewModel.sidebarSelection == .trash)
                         // Hidden in Trash — creation is not allowed for deleted items.
                         // Opacity+allowsHitTesting keeps the ToolbarItem registered so placement

--- a/Macwarden/Presentation/Vault/VaultBrowserView.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserView.swift
@@ -45,55 +45,20 @@ struct VaultBrowserView: View {
                             onPermanentDelete: { id in await viewModel.performPermanentDelete(id: id) }
                         )
                     } else {
+                        // The + button is embedded in the view body (not a ToolbarItem) so its
+                        // position never shifts with NavigationSplitView column focus. macOS uses
+                        // a single unified NSToolbar for the entire window; ToolbarItem placements
+                        // like .primaryAction and .automatic resolve relative to whichever column
+                        // currently holds focus, so clicking a sidebar row would drift the button
+                        // to the search-bar area. Embedding it here makes it unconditionally above
+                        // the list. .keyboardShortcut still works on non-toolbar views.
+                        newItemBar
                         ItemListView(
                             items:        viewModel.displayedItems,
                             selection:    $viewModel.itemSelection,
                             faviconLoader: faviconLoader,
                             onDelete:     { id in await viewModel.performSoftDelete(id: id) }
                         )
-                    }
-                }
-                // .toolbar is on the always-present VStack so the ToolbarItem stays registered
-                // across all category switches — removing it from ItemListView (inside the else
-                // branch) caused SwiftUI to re-resolve the placement every time Trash was exited.
-                //
-                // Placement: .automatic rather than .primaryAction. .primaryAction follows the
-                // NavigationSplitView column that currently holds keyboard focus, so clicking a
-                // sidebar row moved the button to the search-bar area. .automatic resolves to a
-                // stable position in the content column's portion of the unified macOS toolbar
-                // regardless of which column is focused.
-                .toolbar {
-                    ToolbarItem(placement: .automatic) {
-                        // The ToolbarItem is always present (placement stays registered), but its
-                        // content switches based on Trash state. Using .disabled(true) on a macOS
-                        // Menu with an image-only label causes NSMenuButton to suppress the SF
-                        // Symbol while keeping the button frame visible — not truly hidden. Instead,
-                        // swap the content: show an invisible placeholder in Trash so the item
-                        // slot is kept, and show the real Menu with its ⌘N shortcut otherwise.
-                        if viewModel.sidebarSelection == .trash {
-                            // Zero-size placeholder keeps the ToolbarItem registered without
-                            // rendering anything visible or interactive.
-                            Color.clear
-                                .frame(width: 0, height: 0)
-                                .accessibilityHidden(true)
-                        } else {
-                            Menu {
-                                ForEach(ItemType.allCases) { type in
-                                    Button {
-                                        viewModel.createItemType = type
-                                    } label: {
-                                        Label(type.displayName, systemImage: type.sfSymbol)
-                                    }
-                                }
-                            } label: {
-                                Image(systemName: "plus")
-                            }
-                            .help("New Item")
-                            .accessibilityIdentifier(AccessibilityID.Create.newItemButton)
-                            // ⌘N shortcut is only registered when not in Trash — the conditional
-                            // above ensures it is never installed for Trash, so no .disabled needed.
-                            .keyboardShortcut("n", modifiers: .command)
-                        }
                     }
                 }
                 .navigationSplitViewColumnWidth(min: 220, ideal: 280)
@@ -146,6 +111,42 @@ struct VaultBrowserView: View {
     }
 
     // MARK: - Subviews
+
+    /// A thin action bar rendered immediately above the item list.
+    ///
+    /// Embedding this in the view body rather than as a ToolbarItem is intentional:
+    /// macOS NavigationSplitView uses a single unified NSToolbar, and ToolbarItem
+    /// placements shift based on which column holds focus — clicking a sidebar row
+    /// would drift the button next to the search field. A view-body button has a
+    /// fixed, stable position regardless of focus or selection state.
+    @ViewBuilder
+    private var newItemBar: some View {
+        HStack(spacing: 0) {
+            Spacer()
+            Menu {
+                ForEach(ItemType.allCases) { type in
+                    Button {
+                        viewModel.createItemType = type
+                    } label: {
+                        Label(type.displayName, systemImage: type.sfSymbol)
+                    }
+                }
+            } label: {
+                Image(systemName: "plus")
+                    .imageScale(.medium)
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .help("New Item (⌘N)")
+            .accessibilityIdentifier(AccessibilityID.Create.newItemButton)
+            // .keyboardShortcut works on any view — no ToolbarItem required.
+            .keyboardShortcut("n", modifiers: .command)
+            .padding(.trailing, Spacing.rowHorizontal)
+        }
+        .frame(height: 28)
+        .background(.bar)
+        Divider()
+    }
 
     @ViewBuilder
     private var syncErrorBanner: some View {

--- a/Macwarden/Presentation/Vault/VaultBrowserView.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserView.swift
@@ -23,6 +23,11 @@ struct VaultBrowserView: View {
     /// Notifies the ViewModel when the edit sheet opens/closes (for menu bar state).
     var onEditSheetState: ((Bool) -> Void)? = nil
 
+    /// Controls visibility of the type picker popover (opened by + click or ⌘N).
+    @State private var showingTypePicker = false
+    /// Tracks which item type is currently highlighted in the picker; pre-set to Login on open.
+    @State private var typePickerSelection: ItemType? = ItemType.allCases.first
+
     var body: some View {
         NavigationSplitView(
             sidebar: {
@@ -114,33 +119,37 @@ struct VaultBrowserView: View {
 
     /// A thin action bar rendered immediately above the item list.
     ///
-    /// Embedding this in the view body rather than as a ToolbarItem is intentional:
-    /// macOS NavigationSplitView uses a single unified NSToolbar, and ToolbarItem
-    /// placements shift based on which column holds focus — clicking a sidebar row
-    /// would drift the button next to the search field. A view-body button has a
-    /// fixed, stable position regardless of focus or selection state.
+    /// Embedding this in the view body (not a ToolbarItem) keeps the button's position
+    /// stable regardless of which NavigationSplitView column holds focus.
+    ///
+    /// The trigger is a plain Button + popover rather than a SwiftUI Menu. SwiftUI Menu
+    /// propagates .keyboardShortcut to every child Button, which would annotate each
+    /// item type row with "⌘N" — the shortcut would appear on Login, Card, Identity, etc.
+    /// A Button + popover keeps ⌘N on the trigger only. The popover's List provides
+    /// native macOS arrow-key navigation and Enter-to-confirm via .onKeyPress.
     @ViewBuilder
     private var newItemBar: some View {
         HStack(spacing: 0) {
             Spacer()
-            Menu {
-                ForEach(ItemType.allCases) { type in
-                    Button {
-                        viewModel.createItemType = type
-                    } label: {
-                        Label(type.displayName, systemImage: type.sfSymbol)
-                    }
-                }
+            Button {
+                // Reset to Login so the picker always opens with the first row selected.
+                typePickerSelection = ItemType.allCases.first
+                showingTypePicker = true
             } label: {
                 Image(systemName: "plus")
                     .imageScale(.medium)
             }
-            .menuStyle(.borderlessButton)
-            .fixedSize()
+            .buttonStyle(.borderless)
             .help("New Item (⌘N)")
             .accessibilityIdentifier(AccessibilityID.Create.newItemButton)
-            // .keyboardShortcut works on any view — no ToolbarItem required.
+            // ⌘N is on the button only — not propagated into the picker rows.
             .keyboardShortcut("n", modifiers: .command)
+            .popover(isPresented: $showingTypePicker, arrowEdge: .top) {
+                NewItemTypePickerView(selection: $typePickerSelection) { type in
+                    showingTypePicker = false
+                    viewModel.createItemType = type
+                }
+            }
             .padding(.trailing, Spacing.rowHorizontal)
         }
         .frame(height: 28)
@@ -192,4 +201,37 @@ struct VaultBrowserView: View {
         f.unitsStyle = .full
         return f
     }()
+}
+
+// MARK: - NewItemTypePickerView
+
+/// Popover content for the "+" / ⌘N type picker.
+///
+/// Uses a native List with a single-selection binding so ↑/↓ arrow navigation
+/// and visual highlight are handled by AppKit with no custom key handling needed.
+/// Enter confirms the current selection via .onKeyPress(.return).
+///
+/// This is separate from SwiftUI Menu intentionally: attaching .keyboardShortcut
+/// to a Menu propagates the shortcut annotation to every child Button, making
+/// ⌘N appear next to every item type in the dropdown. A plain Button + popover
+/// keeps the shortcut on the trigger only.
+private struct NewItemTypePickerView: View {
+
+    @Binding var selection: ItemType?
+    let onConfirm: (ItemType) -> Void
+
+    var body: some View {
+        List(ItemType.allCases, id: \.self, selection: $selection) { type in
+            Label(type.displayName, systemImage: type.sfSymbol)
+                .tag(type)
+        }
+        .frame(width: 220, height: CGFloat(ItemType.allCases.count) * 32 + 8)
+        // Confirm the highlighted row when the user presses Enter.
+        // .onKeyPress requires the List to be focused; macOS focuses popover
+        // content automatically on open, so no explicit .focusable() is needed.
+        .onKeyPress(.return) {
+            if let type = selection { onConfirm(type) }
+            return .handled
+        }
+    }
 }

--- a/Macwarden/Presentation/Vault/VaultBrowserView.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserView.swift
@@ -53,36 +53,47 @@ struct VaultBrowserView: View {
                         )
                     }
                 }
-                // The toolbar modifier is on the always-present VStack rather than on ItemListView
-                // so the ToolbarItem stays registered when switching between categories. Attaching it
-                // to ItemListView caused the item to leave and re-enter the hierarchy on every
-                // Trash ↔ non-Trash transition, which made SwiftUI resolve .primaryAction to the
-                // trailing window edge instead of the content column on the return trip.
+                // .toolbar is on the always-present VStack so the ToolbarItem stays registered
+                // across all category switches — removing it from ItemListView (inside the else
+                // branch) caused SwiftUI to re-resolve the placement every time Trash was exited.
+                //
+                // Placement: .automatic rather than .primaryAction. .primaryAction follows the
+                // NavigationSplitView column that currently holds keyboard focus, so clicking a
+                // sidebar row moved the button to the search-bar area. .automatic resolves to a
+                // stable position in the content column's portion of the unified macOS toolbar
+                // regardless of which column is focused.
                 .toolbar {
-                    ToolbarItem(placement: .primaryAction) {
-                        Menu {
-                            ForEach(ItemType.allCases) { type in
-                                Button {
-                                    viewModel.createItemType = type
-                                } label: {
-                                    Label(type.displayName, systemImage: type.sfSymbol)
+                    ToolbarItem(placement: .automatic) {
+                        // The ToolbarItem is always present (placement stays registered), but its
+                        // content switches based on Trash state. Using .disabled(true) on a macOS
+                        // Menu with an image-only label causes NSMenuButton to suppress the SF
+                        // Symbol while keeping the button frame visible — not truly hidden. Instead,
+                        // swap the content: show an invisible placeholder in Trash so the item
+                        // slot is kept, and show the real Menu with its ⌘N shortcut otherwise.
+                        if viewModel.sidebarSelection == .trash {
+                            // Zero-size placeholder keeps the ToolbarItem registered without
+                            // rendering anything visible or interactive.
+                            Color.clear
+                                .frame(width: 0, height: 0)
+                                .accessibilityHidden(true)
+                        } else {
+                            Menu {
+                                ForEach(ItemType.allCases) { type in
+                                    Button {
+                                        viewModel.createItemType = type
+                                    } label: {
+                                        Label(type.displayName, systemImage: type.sfSymbol)
+                                    }
                                 }
+                            } label: {
+                                Image(systemName: "plus")
                             }
-                        } label: {
-                            Image(systemName: "plus")
+                            .help("New Item")
+                            .accessibilityIdentifier(AccessibilityID.Create.newItemButton)
+                            // ⌘N shortcut is only registered when not in Trash — the conditional
+                            // above ensures it is never installed for Trash, so no .disabled needed.
+                            .keyboardShortcut("n", modifiers: .command)
                         }
-                        .help("New Item")
-                        .accessibilityIdentifier(AccessibilityID.Create.newItemButton)
-                        // ⌘N opens the type picker from the keyboard. .disabled gates both the
-                        // shortcut and the menu bar entry when Trash is active, so the greyed-out
-                        // menu bar item reinforces the visual hidden state of the toolbar button.
-                        .keyboardShortcut("n", modifiers: .command)
-                        .disabled(viewModel.sidebarSelection == .trash)
-                        // Hidden in Trash — creation is not allowed for deleted items.
-                        // Opacity+allowsHitTesting keeps the ToolbarItem registered so placement
-                        // never drifts; simply omitting the view here would re-introduce the bug.
-                        .opacity(viewModel.sidebarSelection == .trash ? 0 : 1)
-                        .allowsHitTesting(viewModel.sidebarSelection != .trash)
                     }
                 }
                 .navigationSplitViewColumnWidth(min: 220, ideal: 280)

--- a/Macwarden/Presentation/Vault/VaultBrowserView.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserView.swift
@@ -224,7 +224,11 @@ private struct NewItemTypePickerView: View {
         List(ItemType.allCases, id: \.self, selection: $selection) { type in
             Label(type.displayName, systemImage: type.sfSymbol)
                 .tag(type)
+                // Row identifier uses ItemType.rawValue ("login", "card", etc.) so
+                // XCUITests can query specific rows as app.cells["typePicker.row.login"].
+                .accessibilityIdentifier(AccessibilityID.Create.pickerRow(type.rawValue))
         }
+        .accessibilityIdentifier(AccessibilityID.Create.pickerList)
         .frame(width: 220, height: CGFloat(ItemType.allCases.count) * 32 + 8)
         // Confirm the highlighted row when the user presses Enter.
         // .onKeyPress requires the List to be focused; macOS focuses popover

--- a/Macwarden/Presentation/Vault/VaultBrowserView.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserView.swift
@@ -51,22 +51,38 @@ struct VaultBrowserView: View {
                             faviconLoader: faviconLoader,
                             onDelete:     { id in await viewModel.performSoftDelete(id: id) }
                         )
-                        .toolbar {
-                            ToolbarItem(placement: .primaryAction) {
-                                Menu {
-                                    ForEach(ItemType.allCases) { type in
-                                        Button {
-                                            viewModel.createItemType = type
-                                        } label: {
-                                            Label(type.displayName, systemImage: type.sfSymbol)
-                                        }
-                                    }
+                    }
+                }
+                // The toolbar modifier is on the always-present VStack rather than on ItemListView
+                // so the ToolbarItem stays registered when switching between categories. Attaching it
+                // to ItemListView caused the item to leave and re-enter the hierarchy on every
+                // Trash ↔ non-Trash transition, which made SwiftUI resolve .primaryAction to the
+                // trailing window edge instead of the content column on the return trip.
+                .toolbar {
+                    ToolbarItem(placement: .primaryAction) {
+                        Menu {
+                            ForEach(ItemType.allCases) { type in
+                                Button {
+                                    viewModel.createItemType = type
                                 } label: {
-                                    Image(systemName: "plus")
+                                    Label(type.displayName, systemImage: type.sfSymbol)
                                 }
-                                .help("New Item")
                             }
+                        } label: {
+                            Image(systemName: "plus")
                         }
+                        .help("New Item")
+                        .accessibilityIdentifier(AccessibilityID.Create.newItemButton)
+                        // ⌘N opens the type picker from the keyboard. .disabled gates both the
+                        // shortcut and the menu bar entry when Trash is active, so the greyed-out
+                        // menu bar item reinforces the visual hidden state of the toolbar button.
+                        .keyboardShortcut(.n, modifiers: .command)
+                        .disabled(viewModel.sidebarSelection == .trash)
+                        // Hidden in Trash — creation is not allowed for deleted items.
+                        // Opacity+allowsHitTesting keeps the ToolbarItem registered so placement
+                        // never drifts; simply omitting the view here would re-introduce the bug.
+                        .opacity(viewModel.sidebarSelection == .trash ? 0 : 1)
+                        .allowsHitTesting(viewModel.sidebarSelection != .trash)
                     }
                 }
                 .navigationSplitViewColumnWidth(min: 220, ideal: 280)

--- a/Macwarden/Presentation/Vault/VaultBrowserView.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserView.swift
@@ -18,6 +18,8 @@ struct VaultBrowserView: View {
     let faviconLoader: FaviconLoader
     /// Factory closure injected from `AppContainer` so the view layer stays decoupled from Data.
     let makeEditViewModel: (VaultItem) -> ItemEditViewModel
+    /// Factory closure for creating a new item edit view model in create mode.
+    let makeCreateViewModel: (ItemType) -> ItemEditViewModel
     /// Notifies the ViewModel when the edit sheet opens/closes (for menu bar state).
     var onEditSheetState: ((Bool) -> Void)? = nil
 
@@ -49,6 +51,22 @@ struct VaultBrowserView: View {
                             faviconLoader: faviconLoader,
                             onDelete:     { id in await viewModel.performSoftDelete(id: id) }
                         )
+                        .toolbar {
+                            ToolbarItem(placement: .primaryAction) {
+                                Menu {
+                                    ForEach(ItemType.allCases) { type in
+                                        Button {
+                                            viewModel.createItemType = type
+                                        } label: {
+                                            Label(type.displayName, systemImage: type.sfSymbol)
+                                        }
+                                    }
+                                } label: {
+                                    Image(systemName: "plus")
+                                }
+                                .help("New Item")
+                            }
+                        }
                     }
                 }
                 .navigationSplitViewColumnWidth(min: 220, ideal: 280)
@@ -88,6 +106,15 @@ struct VaultBrowserView: View {
             ToolbarItem(placement: .automatic) {
                 lastSyncedLabel
             }
+        }
+        .sheet(item: $viewModel.createItemType) { type in
+            ItemEditView(
+                viewModel: makeCreateViewModel(type),
+                isPresented: Binding(
+                    get: { viewModel.createItemType != nil },
+                    set: { if !$0 { viewModel.createItemType = nil } }
+                )
+            )
         }
     }
 

--- a/Macwarden/Presentation/Vault/VaultBrowserViewModel.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserViewModel.swift
@@ -48,6 +48,14 @@ final class VaultBrowserViewModel: ObservableObject {
     /// The Presentation layer surfaces this as an alert.
     @Published var actionError: String? = nil
 
+    /// Set to a non-nil `ItemType` to present the create sheet for that type.
+    /// Automatically cleared if the user switches to Trash.
+    @Published var createItemType: ItemType? = nil {
+        didSet {
+            if sidebarSelection == .trash { createItemType = nil }
+        }
+    }
+
     // MARK: - Dependencies
 
     private let vault:                  any VaultRepository

--- a/Macwarden/Tests/UITests/CreateItemJourneyTests.swift
+++ b/Macwarden/Tests/UITests/CreateItemJourneyTests.swift
@@ -38,16 +38,16 @@ final class CreateItemJourneyTests: XCTestCase {
 
     // MARK: - Button hidden in Trash
 
-    /// Verifies the "+" button is not hittable while Trash is selected.
+    /// Verifies the "+" button is completely absent from the hierarchy while Trash is selected.
+    /// The ToolbarItem slot is kept via a zero-size placeholder, but the interactive Menu
+    /// with its accessibility identifier is not installed.
     func testNewItemButton_hiddenInTrash() throws {
         let trashRow = app.buttons["sidebar.trash"]
         XCTAssertTrue(trashRow.waitForExistence(timeout: 5))
         trashRow.click()
 
         let newItemButton = app.buttons["create.button.newItem"]
-        // The button stays in the hierarchy (opacity 0) so waitForExistence still returns true,
-        // but it must not be hittable while Trash is active.
-        XCTAssertFalse(newItemButton.isHittable, "+ button must not be hittable while Trash is selected")
+        XCTAssertFalse(newItemButton.waitForExistence(timeout: 2), "+ button must not exist in hierarchy while Trash is selected")
     }
 
     // MARK: - Button reappears after leaving Trash

--- a/Macwarden/Tests/UITests/CreateItemJourneyTests.swift
+++ b/Macwarden/Tests/UITests/CreateItemJourneyTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+
+/// XCUITest: Create Vault Item Journey (add-vault-items)
+///
+/// Validates that the "+" button is permanently anchored in the content column toolbar,
+/// is hidden only while Trash is selected, and reappears in the correct position when
+/// the user leaves Trash — regardless of which category was visited before Trash.
+///
+/// Prerequisites: App launched with `--ui-testing`, `--inject-session`, `--inject-vault`,
+/// `--skip-sync` so a pre-populated vault is available without a network round-trip.
+final class CreateItemJourneyTests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments = ["--ui-testing", "--inject-session", "--inject-vault", "--skip-sync"]
+        app.launch()
+
+        let vaultNav = app.otherElements["vault.navigationSplit"]
+        XCTAssertTrue(vaultNav.waitForExistence(timeout: 30), "Vault browser must be visible")
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+    }
+
+    // MARK: - Button visible on launch
+
+    /// Verifies the "+" button is hittable when the vault browser first appears (any default
+    /// non-Trash category selected).
+    func testNewItemButton_visibleOnLaunch() throws {
+        let newItemButton = app.buttons["create.button.newItem"]
+        XCTAssertTrue(newItemButton.waitForExistence(timeout: 5), "+ button must exist in toolbar on launch")
+        XCTAssertTrue(newItemButton.isHittable, "+ button must be hittable on launch")
+    }
+
+    // MARK: - Button hidden in Trash
+
+    /// Verifies the "+" button is not hittable while Trash is selected.
+    func testNewItemButton_hiddenInTrash() throws {
+        let trashRow = app.buttons["sidebar.trash"]
+        XCTAssertTrue(trashRow.waitForExistence(timeout: 5))
+        trashRow.click()
+
+        let newItemButton = app.buttons["create.button.newItem"]
+        // The button stays in the hierarchy (opacity 0) so waitForExistence still returns true,
+        // but it must not be hittable while Trash is active.
+        XCTAssertFalse(newItemButton.isHittable, "+ button must not be hittable while Trash is selected")
+    }
+
+    // MARK: - Button reappears after leaving Trash
+
+    /// Selects Trash then navigates to All Items and verifies the "+" button is hittable
+    /// and positioned in the content column toolbar (above the item list).
+    ///
+    /// This is the regression scenario for the toolbar-drift bug: the button previously
+    /// stayed on the trailing window edge instead of the content column after a Trash visit.
+    func testNewItemButton_reappearsAfterLeavingTrash() throws {
+        // Go to Trash first.
+        let trashRow = app.buttons["sidebar.trash"]
+        XCTAssertTrue(trashRow.waitForExistence(timeout: 5))
+        trashRow.click()
+
+        // Leave Trash by selecting All Items.
+        let allItemsRow = app.buttons["sidebar.allItems"]
+        XCTAssertTrue(allItemsRow.waitForExistence(timeout: 5))
+        allItemsRow.click()
+
+        let newItemButton = app.buttons["create.button.newItem"]
+        XCTAssertTrue(newItemButton.waitForExistence(timeout: 5), "+ button must exist after leaving Trash")
+        XCTAssertTrue(newItemButton.isHittable, "+ button must be hittable after leaving Trash")
+
+        // Verify the button is above the item list and not on the trailing window edge.
+        // The item list table must also be visible; if the button drifted to the window toolbar
+        // its frame would be outside (to the right of) the content column.
+        let itemList = app.tables["itemList.list"]
+        XCTAssertTrue(itemList.waitForExistence(timeout: 5))
+        XCTAssertLessThanOrEqual(
+            newItemButton.frame.maxX,
+            itemList.frame.maxX + 60, // 60 pt tolerance for toolbar insets
+            "+ button must not have drifted outside the content column after leaving Trash"
+        )
+    }
+
+    // MARK: - ⌘N keyboard shortcut
+
+    /// Presses ⌘N and verifies the type picker menu opens with all item types listed.
+    func testCmdN_opensPicker_inNonTrashCategory() throws {
+        app.typeKey("n", modifierFlags: .command)
+
+        // The menu should appear with Login as one of its items.
+        let loginMenuItem = app.menuItems["Login"]
+        XCTAssertTrue(loginMenuItem.waitForExistence(timeout: 3), "⌘N must open the type picker with Login listed")
+
+        // Dismiss without creating.
+        app.typeKey(.escape, modifierFlags: [])
+    }
+
+    /// Selects Trash, presses ⌘N, and verifies the type picker does not open.
+    func testCmdN_isNoOp_inTrash() throws {
+        let trashRow = app.buttons["sidebar.trash"]
+        XCTAssertTrue(trashRow.waitForExistence(timeout: 5))
+        trashRow.click()
+
+        app.typeKey("n", modifierFlags: .command)
+
+        // No type picker or edit sheet should appear.
+        let loginMenuItem = app.menuItems["Login"]
+        XCTAssertFalse(loginMenuItem.waitForExistence(timeout: 2), "⌘N must not open the type picker in Trash")
+
+        let saveButton = app.buttons["edit.button.save"]
+        XCTAssertFalse(saveButton.waitForExistence(timeout: 2), "⌘N must not open the edit sheet in Trash")
+    }
+
+    /// Presses ⌘N then immediately Enter (no arrow key) and verifies the Login edit sheet opens.
+    /// macOS NSMenu pre-selects the first item when opened via keyboard, so Enter confirms Login.
+    func testCmdN_thenEnter_opensLoginSheet() throws {
+        app.typeKey("n", modifierFlags: .command)
+
+        // Wait for the menu to appear.
+        let loginMenuItem = app.menuItems["Login"]
+        XCTAssertTrue(loginMenuItem.waitForExistence(timeout: 3), "Type picker must appear after ⌘N")
+
+        app.typeKey(.return, modifierFlags: [])
+
+        // The Login edit sheet should now be open.
+        let saveButton = app.buttons["edit.button.save"]
+        XCTAssertTrue(saveButton.waitForExistence(timeout: 3), "Login edit sheet must open after ⌘N + Enter")
+
+        // Dismiss without saving.
+        app.typeKey(.escape, modifierFlags: [])
+    }
+
+    // MARK: - Button stable across multiple category switches
+
+    /// Visits a non-Login category (Card sidebar item) and returns to Login (All Items),
+    /// verifying the button stays hittable throughout.
+    func testNewItemButton_stableAcrossCategorySwitches() throws {
+        // Navigate to Card type.
+        let cardRow = app.buttons["sidebar.type.card"]
+        XCTAssertTrue(cardRow.waitForExistence(timeout: 5))
+        cardRow.click()
+
+        var newItemButton = app.buttons["create.button.newItem"]
+        XCTAssertTrue(newItemButton.isHittable, "+ button must be hittable in Card category")
+
+        // Navigate back to All Items.
+        let allItemsRow = app.buttons["sidebar.allItems"]
+        XCTAssertTrue(allItemsRow.waitForExistence(timeout: 5))
+        allItemsRow.click()
+
+        newItemButton = app.buttons["create.button.newItem"]
+        XCTAssertTrue(newItemButton.isHittable, "+ button must be hittable after returning to All Items")
+    }
+}

--- a/Macwarden/Tests/UITests/CreateItemJourneyTests.swift
+++ b/Macwarden/Tests/UITests/CreateItemJourneyTests.swift
@@ -38,16 +38,17 @@ final class CreateItemJourneyTests: XCTestCase {
 
     // MARK: - Button hidden in Trash
 
-    /// Verifies the "+" button is completely absent from the hierarchy while Trash is selected.
-    /// The ToolbarItem slot is kept via a zero-size placeholder, but the interactive Menu
-    /// with its accessibility identifier is not installed.
+    /// Verifies the "+" button is not rendered while Trash is selected.
+    /// The button is in the view body (not a toolbar item), so it is simply absent
+    /// from the else-branch when Trash is active — no frame, no icon, no chrome.
     func testNewItemButton_hiddenInTrash() throws {
         let trashRow = app.buttons["sidebar.trash"]
         XCTAssertTrue(trashRow.waitForExistence(timeout: 5))
         trashRow.click()
 
         let newItemButton = app.buttons["create.button.newItem"]
-        XCTAssertFalse(newItemButton.waitForExistence(timeout: 2), "+ button must not exist in hierarchy while Trash is selected")
+        XCTAssertFalse(newItemButton.waitForExistence(timeout: 2),
+                       "+ button must not exist in view hierarchy while Trash is selected")
     }
 
     // MARK: - Button reappears after leaving Trash

--- a/Macwarden/Tests/UITests/CreateItemJourneyTests.swift
+++ b/Macwarden/Tests/UITests/CreateItemJourneyTests.swift
@@ -87,13 +87,14 @@ final class CreateItemJourneyTests: XCTestCase {
 
     // MARK: - ⌘N keyboard shortcut
 
-    /// Presses ⌘N and verifies the type picker menu opens with all item types listed.
+    /// Presses ⌘N and verifies the type picker popover opens with Login pre-selected.
+    /// The picker is a SwiftUI List in a popover (not an NSMenu), so rows are queried
+    /// as List cells via their "typePicker.row.<rawValue>" accessibility identifiers.
     func testCmdN_opensPicker_inNonTrashCategory() throws {
         app.typeKey("n", modifierFlags: .command)
 
-        // The menu should appear with Login as one of its items.
-        let loginMenuItem = app.menuItems["Login"]
-        XCTAssertTrue(loginMenuItem.waitForExistence(timeout: 3), "⌘N must open the type picker with Login listed")
+        let loginRow = app.cells["typePicker.row.login"]
+        XCTAssertTrue(loginRow.waitForExistence(timeout: 3), "⌘N must open the type picker with Login row visible")
 
         // Dismiss without creating.
         app.typeKey(.escape, modifierFlags: [])
@@ -107,28 +108,51 @@ final class CreateItemJourneyTests: XCTestCase {
 
         app.typeKey("n", modifierFlags: .command)
 
-        // No type picker or edit sheet should appear.
-        let loginMenuItem = app.menuItems["Login"]
-        XCTAssertFalse(loginMenuItem.waitForExistence(timeout: 2), "⌘N must not open the type picker in Trash")
+        // The picker list must not appear, and no edit sheet must open.
+        let pickerList = app.tables["typePicker.list"]
+        XCTAssertFalse(pickerList.waitForExistence(timeout: 2), "⌘N must not open the type picker in Trash")
 
         let saveButton = app.buttons["edit.button.save"]
         XCTAssertFalse(saveButton.waitForExistence(timeout: 2), "⌘N must not open the edit sheet in Trash")
     }
 
     /// Presses ⌘N then immediately Enter (no arrow key) and verifies the Login edit sheet opens.
-    /// macOS NSMenu pre-selects the first item when opened via keyboard, so Enter confirms Login.
+    /// Login is pre-selected when the picker opens, so Enter confirms it without navigation.
     func testCmdN_thenEnter_opensLoginSheet() throws {
         app.typeKey("n", modifierFlags: .command)
 
-        // Wait for the menu to appear.
-        let loginMenuItem = app.menuItems["Login"]
-        XCTAssertTrue(loginMenuItem.waitForExistence(timeout: 3), "Type picker must appear after ⌘N")
+        // Wait for the picker to appear.
+        let loginRow = app.cells["typePicker.row.login"]
+        XCTAssertTrue(loginRow.waitForExistence(timeout: 3), "Type picker must appear after ⌘N")
 
         app.typeKey(.return, modifierFlags: [])
 
         // The Login edit sheet should now be open.
         let saveButton = app.buttons["edit.button.save"]
         XCTAssertTrue(saveButton.waitForExistence(timeout: 3), "Login edit sheet must open after ⌘N + Enter")
+
+        // Dismiss without saving.
+        app.typeKey(.escape, modifierFlags: [])
+    }
+
+    /// Presses ⌘N, navigates down once with ↓ to select Card, then confirms with Enter.
+    /// Verifies the Card edit sheet opens — covering the arrow-key navigation scenario.
+    func testCmdN_arrowDown_thenEnter_opensCardSheet() throws {
+        app.typeKey("n", modifierFlags: .command)
+
+        // Wait for the picker to appear with Login pre-selected.
+        let loginRow = app.cells["typePicker.row.login"]
+        XCTAssertTrue(loginRow.waitForExistence(timeout: 3), "Type picker must appear after ⌘N")
+
+        // Press ↓ to move selection from Login to Card (second item).
+        app.typeKey(.downArrow, modifierFlags: [])
+
+        // Confirm Card with Enter.
+        app.typeKey(.return, modifierFlags: [])
+
+        // The edit sheet must open — Card form is identified by the Save button.
+        let saveButton = app.buttons["edit.button.save"]
+        XCTAssertTrue(saveButton.waitForExistence(timeout: 3), "Card edit sheet must open after ⌘N + ↓ + Enter")
 
         // Dismiss without saving.
         app.typeKey(.escape, modifierFlags: [])

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A native Bitwarden client for macOS. Connect to your self-hosted [Bitwarden](htt
 
 - **Connect to your server** — works with any self-hosted Bitwarden or Vaultwarden instance
 - **Browse everything** — Logins, Cards, Identities, Secure Notes, and SSH Keys
+- **Create items** — add new Logins, Cards, Identities, Secure Notes, and SSH Keys directly from the vault browser; items sync to your server immediately
 - **Edit items** — update fields, names, notes, custom fields, and website URIs; changes sync back to your server
 - **Manage website URIs** — add, remove, and reorder URIs on Login items with inline match-type configuration
 - **Delete and restore** — move items to Trash, restore accidental deletions, or permanently delete individual items
@@ -24,6 +25,7 @@ A native Bitwarden client for macOS. Connect to your self-hosted [Bitwarden](htt
 
 | Shortcut | Action |
 |---|---|
+| ⌘N | New item — opens type picker; ↑ ↓ to navigate, ↩ to create |
 | ⌘E | Edit selected item |
 | ⌘S | Save edits |
 | ⇧⌘Q | Sign out |

--- a/openspec/changes/add-vault-items/.openspec.yaml
+++ b/openspec/changes/add-vault-items/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-24

--- a/openspec/changes/add-vault-items/design.md
+++ b/openspec/changes/add-vault-items/design.md
@@ -1,0 +1,36 @@
+## Context
+
+Macwarden already has a complete edit flow: `DraftVaultItem` → `CipherMapper.toRawCipher` → `PUT /api/ciphers/{id}` → cache splice. Item creation follows the same data path except:
+1. There is no existing `VaultItem` to initialise the draft from — a blank draft is needed.
+2. The API endpoint is `POST /api/ciphers` (no `{id}` in the path) and the server assigns the ID.
+3. The response item is appended to the cache rather than spliced in-place.
+
+The edit sheet (`ItemEditView`) and all per-type edit forms (`LoginEditForm`, `CardEditForm`, etc.) are fully reusable — they bind to `DraftVaultItem` and don't care whether it originated from an existing item or a blank factory.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow users to create new items of all five types from the vault browser
+- Reuse the existing edit sheet and cipher mapper — no duplication
+- Insert created items into the local cache immediately (no full re-sync)
+
+**Non-Goals:**
+- Folder/collection assignment (not supported in v1 edit either)
+- Organisation-owned items (personal vault only)
+- Offline creation queue (same limitation as edit)
+- Attachments or file uploads
+
+## Decisions
+
+- **Reuse `ItemEditView` in a "create" mode** rather than building a separate creation form. The view model receives an optional `VaultItem?` — `nil` means create mode. This avoids duplicating form UI and validation logic. Alternative: a separate `ItemCreateView` — rejected because the fields are identical.
+
+- **Blank draft factory on `DraftVaultItem`** (`DraftVaultItem.blank(type:)`) rather than on the view model. This keeps the domain layer responsible for default values and makes it testable without UI. The factory generates a temporary UUID as the `id` which is discarded when the server assigns the real one.
+
+- **New `CreateVaultItemUseCase`** rather than overloading `EditVaultItemUseCase`. Create and update are semantically different operations (POST vs PUT, no pre-existing ID). Keeping them separate follows the existing single-responsibility pattern.
+
+- **Type picker as a `+` button in the content column toolbar** (above the item list, alongside the search bar) rather than in the main window toolbar or a multi-step wizard. This keeps the action close to the list it affects. The button opens a menu listing all five types; selecting one opens the edit sheet immediately.
+
+## Risks / Trade-offs
+
+- [Low] `DraftVaultItem` currently requires an `id` at init. The blank factory will use `UUID().uuidString` as a placeholder. The server response provides the real ID. → The `create` method on `VaultRepository` must use the server-returned item (not the draft) when inserting into the cache, same as `update` already does.
+- [Low] The edit sheet's `hasChanges` logic compares draft to original. For create mode, the original is the blank draft, so any field edit triggers `hasChanges = true`. → This is correct behaviour — a blank unsaved item should prompt discard confirmation if the user typed anything.

--- a/openspec/changes/add-vault-items/design.md
+++ b/openspec/changes/add-vault-items/design.md
@@ -28,7 +28,7 @@ The edit sheet (`ItemEditView`) and all per-type edit forms (`LoginEditForm`, `C
 
 - **New `CreateVaultItemUseCase`** rather than overloading `EditVaultItemUseCase`. Create and update are semantically different operations (POST vs PUT, no pre-existing ID). Keeping them separate follows the existing single-responsibility pattern.
 
-- **Type picker as a `+` button in the content column toolbar** (above the item list, alongside the search bar) rather than in the main window toolbar or a multi-step wizard. This keeps the action close to the list it affects. The button opens a menu listing all five types; selecting one opens the edit sheet immediately.
+- **Type picker as a `+` button embedded in the content column view body** (not a `ToolbarItem`) immediately above the item list. macOS `NavigationSplitView` uses a single unified `NSToolbar`; `ToolbarItem` placements such as `.primaryAction` and `.automatic` resolve relative to whichever column currently holds keyboard focus, so clicking a sidebar row drifted the button to the search-bar area. Embedding it in the `VStack` view body keeps its position unconditionally stable. The button is a plain `Button` (not SwiftUI `Menu`) that opens a `popover` containing `NewItemTypePickerView` — a `List` with single-selection binding. Using `Menu` was rejected because SwiftUI propagates `.keyboardShortcut` to every child `Button` inside a `Menu`, which caused ⌘N to appear as a shortcut annotation on every item-type row. The `Button` + popover approach keeps ⌘N on the trigger only; `List` provides native ↑/↓ navigation and Enter-to-confirm via `.onKeyPress(.return)`.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/add-vault-items/design.md
+++ b/openspec/changes/add-vault-items/design.md
@@ -22,7 +22,7 @@ The edit sheet (`ItemEditView`) and all per-type edit forms (`LoginEditForm`, `C
 
 ## Decisions
 
-- **Reuse `ItemEditView` in a "create" mode** rather than building a separate creation form. The view model receives an optional `VaultItem?` — `nil` means create mode. This avoids duplicating form UI and validation logic. Alternative: a separate `ItemCreateView` — rejected because the fields are identical.
+- **Reuse `ItemEditView` in a "create" mode** rather than building a separate creation form. The view model has two initialisers — `init(item:useCase:)` for edit mode and `init(type:useCase:)` for create mode — so the type system enforces the correct use case at compile time. This avoids duplicating form UI and validation logic. Alternative: a separate `ItemCreateView` — rejected because the fields are identical.
 
 - **Blank draft factory on `DraftVaultItem`** (`DraftVaultItem.blank(type:)`) rather than on the view model. This keeps the domain layer responsible for default values and makes it testable without UI. The factory generates a temporary UUID as the `id` which is discarded when the server assigns the real one.
 

--- a/openspec/changes/add-vault-items/proposal.md
+++ b/openspec/changes/add-vault-items/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Users can browse and edit existing vault items but cannot create new ones. To save a new login, card, identity, secure note, or SSH key, users must use another Bitwarden client. Adding item creation completes the core CRUD lifecycle and makes Macwarden a self-sufficient vault manager.
+
+## What Changes
+
+- Add a "New Item" button to the vault toolbar that opens a type picker (Login, Card, Identity, Secure Note, SSH Key)
+- Reuse the existing edit sheet (`ItemEditView`) for the creation form — same fields, same validation, same save flow
+- Add a `POST /api/ciphers` endpoint to `MacwardenAPIClientProtocol`
+- Add a `create` method to `VaultRepository` that encrypts a new draft and posts it
+- Add a `CreateVaultItemUseCase` domain protocol and implementation
+- Extend `DraftVaultItem` with a factory initialiser for blank items of each type
+- Insert the server-confirmed item into the in-memory cache after creation (no full re-sync)
+
+## Capabilities
+
+### New Capabilities
+
+- `vault-item-create`: User can create new vault items of all five types (Login, Card, Identity, Secure Note, SSH Key) from the vault browser
+
+### Modified Capabilities
+
+None. The existing edit sheet, draft model, and cipher mapper are reused without spec-level changes.
+
+## Impact
+
+- `MacwardenAPIClientProtocol` / `MacwardenAPIClientImpl` — new `createCipher` method
+- `VaultRepository` / `VaultRepositoryImpl` — new `create` method
+- `Domain/UseCases/` — new `CreateVaultItemUseCase` protocol + impl
+- `DraftVaultItem` — new static factory for blank drafts
+- `VaultBrowserView` / `VaultBrowserViewModel` — new toolbar button + type picker
+- `ItemEditView` / `ItemEditViewModel` — minor adaptation to support create mode (no existing item)
+- `AppContainer` — new factory method for create-mode view model
+- `CipherMapper.toRawCipher` — already handles all five types; no changes expected

--- a/openspec/changes/add-vault-items/specs/vault-item-create/spec.md
+++ b/openspec/changes/add-vault-items/specs/vault-item-create/spec.md
@@ -1,11 +1,43 @@
 ## ADDED Requirements
 
 ### Requirement: User can create a new vault item from the vault browser
-The system SHALL provide a "+" button in the content column toolbar (above the item list, alongside the search bar) in `VaultBrowserView`. Clicking the button SHALL present a menu listing all five item types: Login, Card, Identity, Secure Note, and SSH Key. Selecting a type SHALL open the edit sheet pre-populated with a blank draft of that type. The edit sheet SHALL reuse the same form fields, validation, and save flow as the existing item edit feature.
+The system SHALL provide a "+" button permanently anchored in the content column toolbar (above the item list, alongside the search bar) in `VaultBrowserView`. The button SHALL never move to any other toolbar position regardless of which category is selected or how the user navigates. It SHALL be hidden only when the Trash category is active, and SHALL reappear in the same position when the user leaves Trash. Clicking the button OR pressing ⌘N SHALL present a menu listing all five item types: Login, Card, Identity, Secure Note, and SSH Key. Selecting a type SHALL open the edit sheet pre-populated with a blank draft of that type. The edit sheet SHALL reuse the same form fields, validation, and save flow as the existing item edit feature. Once the type picker is open, the user SHALL be able to navigate types with ↑/↓ arrow keys and confirm with Enter, without touching the mouse.
 
-#### Scenario: New Item button is visible in the content column toolbar
-- **WHEN** the vault browser is displayed
+#### Scenario: New Item button is always above the item list
+- **WHEN** the vault browser is displayed with any category selected except Trash
 - **THEN** a "+" button (SF Symbol `plus`) SHALL be visible in the content column toolbar above the item list
+- **AND** the button SHALL remain in that position regardless of category switches or navigation history
+
+#### Scenario: New Item button is hidden when Trash is selected
+- **WHEN** the user selects the Trash category
+- **THEN** the "+" button SHALL NOT be visible
+
+#### Scenario: New Item button reappears after leaving Trash
+- **GIVEN** the user has the Trash category selected
+- **WHEN** the user navigates to any non-Trash category
+- **THEN** the "+" button SHALL be visible in the content column toolbar above the item list
+
+#### Scenario: ⌘N opens the type picker in a non-Trash category
+- **WHEN** the user presses ⌘N with any non-Trash category selected
+- **THEN** the New Item type picker menu SHALL open, listing Login, Card, Identity, Secure Note, and SSH Key
+
+#### Scenario: ⌘N is a no-op in Trash
+- **WHEN** the user presses ⌘N with the Trash category selected
+- **THEN** nothing SHALL happen — the type picker SHALL NOT open
+
+#### Scenario: Arrow keys navigate the type picker, Enter confirms
+- **GIVEN** the type picker menu is open
+- **WHEN** the user presses ↓ to move the highlight then presses Enter
+- **THEN** the edit sheet for the highlighted item type SHALL open
+
+#### Scenario: ⌘N then immediate Enter opens the Login edit sheet
+- **WHEN** the user presses ⌘N and then immediately presses Enter without pressing any arrow key
+- **THEN** the Login edit sheet SHALL open (Login is the first type in the list)
+
+#### Scenario: Escape dismisses the type picker without creating an item
+- **GIVEN** the type picker menu is open
+- **WHEN** the user presses Escape
+- **THEN** the menu SHALL close and no edit sheet SHALL open
 
 #### Scenario: Type picker shows all five item types
 - **WHEN** the user clicks the New Item button

--- a/openspec/changes/add-vault-items/specs/vault-item-create/spec.md
+++ b/openspec/changes/add-vault-items/specs/vault-item-create/spec.md
@@ -1,17 +1,17 @@
 ## ADDED Requirements
 
 ### Requirement: User can create a new vault item from the vault browser
-The system SHALL provide a "+" button permanently anchored in the content column toolbar (above the item list) in `VaultBrowserView`. The button SHALL never move to any other toolbar position regardless of which sidebar category is selected, whether an item is selected in the item list, or how the user navigates. It SHALL be completely invisible (no button frame, no icon) only when the Trash category is active, and SHALL reappear in the same position when the user leaves Trash. Clicking the button OR pressing ⌘N SHALL present a menu listing all five item types: Login, Card, Identity, Secure Note, and SSH Key. Selecting a type SHALL open the edit sheet pre-populated with a blank draft of that type. The edit sheet SHALL reuse the same form fields, validation, and save flow as the existing item edit feature. Once the type picker is open, the user SHALL be able to navigate types with ↑/↓ arrow keys and confirm with Enter, without touching the mouse.
+The system SHALL provide a "+" button permanently anchored at the top of the content column, immediately above the item list rows, in `VaultBrowserView`. The button SHALL be embedded in the content column's view body — not in the window toolbar — so its position is completely fixed regardless of which sidebar category is selected, whether an item is selected in the item list, or which column holds keyboard focus. It SHALL not be rendered at all when the Trash category is active, and SHALL reappear in the same fixed position when the user leaves Trash. Clicking the button OR pressing ⌘N SHALL present a menu listing all five item types: Login, Card, Identity, Secure Note, and SSH Key. Selecting a type SHALL open the edit sheet pre-populated with a blank draft of that type. The edit sheet SHALL reuse the same form fields, validation, and save flow as the existing item edit feature. Once the type picker is open, the user SHALL be able to navigate types with ↑/↓ arrow keys and confirm with Enter, without touching the mouse.
 
-#### Scenario: New Item button is always above the item list regardless of selection state
+#### Scenario: New Item button is always above the item list regardless of selection or focus state
 - **WHEN** the vault browser is displayed with any category selected except Trash
-- **THEN** a "+" button (SF Symbol `plus`) SHALL be visible in the content column toolbar above the item list
+- **THEN** a "+" button (SF Symbol `plus`) SHALL be visible immediately above the item list rows
 - **AND** the button SHALL be in the same position whether or not an item is selected in the item list
-- **AND** the button SHALL be in the same position whether a sidebar category (All Items, Favorites, Login, etc.) or an item list row is the last-focused element
+- **AND** the button SHALL be in the same position whether a sidebar category (All Items, Favorites, Login, etc.) or an item list row was last clicked
 
-#### Scenario: New Item button is completely invisible when Trash is selected
+#### Scenario: New Item button is not rendered when Trash is selected
 - **WHEN** the user selects the Trash category
-- **THEN** the "+" button SHALL NOT be visible — no button frame, no icon, no chrome of any kind
+- **THEN** the "+" button SHALL NOT be rendered at all — no button frame, no icon, no chrome of any kind
 
 #### Scenario: New Item button reappears after leaving Trash
 - **GIVEN** the user has the Trash category selected

--- a/openspec/changes/add-vault-items/specs/vault-item-create/spec.md
+++ b/openspec/changes/add-vault-items/specs/vault-item-create/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: User can create a new vault item from the vault browser
+The system SHALL provide a "+" button in the content column toolbar (above the item list, alongside the search bar) in `VaultBrowserView`. Clicking the button SHALL present a menu listing all five item types: Login, Card, Identity, Secure Note, and SSH Key. Selecting a type SHALL open the edit sheet pre-populated with a blank draft of that type. The edit sheet SHALL reuse the same form fields, validation, and save flow as the existing item edit feature.
+
+#### Scenario: New Item button is visible in the content column toolbar
+- **WHEN** the vault browser is displayed
+- **THEN** a "+" button (SF Symbol `plus`) SHALL be visible in the content column toolbar above the item list
+
+#### Scenario: Type picker shows all five item types
+- **WHEN** the user clicks the New Item button
+- **THEN** a menu SHALL appear listing Login, Card, Identity, Secure Note, and SSH Key
+
+#### Scenario: Selecting a type opens a blank edit sheet
+- **WHEN** the user selects "Login" from the type picker
+- **THEN** the edit sheet SHALL open with an empty Login draft (blank name, blank username, blank password, no URIs, no notes, no custom fields)
+
+#### Scenario: Selecting Card opens a blank Card edit sheet
+- **WHEN** the user selects "Card" from the type picker
+- **THEN** the edit sheet SHALL open with an empty Card draft (blank cardholder name, blank number, no expiry, no CVV, no notes, no custom fields)
+
+#### Scenario: Selecting Identity opens a blank Identity edit sheet
+- **WHEN** the user selects "Identity" from the type picker
+- **THEN** the edit sheet SHALL open with an empty Identity draft (all identity fields blank, no notes, no custom fields)
+
+#### Scenario: Selecting Secure Note opens a blank Secure Note edit sheet
+- **WHEN** the user selects "Secure Note" from the type picker
+- **THEN** the edit sheet SHALL open with an empty Secure Note draft (blank notes, no custom fields)
+
+#### Scenario: Selecting SSH Key opens a blank SSH Key edit sheet
+- **WHEN** the user selects "SSH Key" from the type picker
+- **THEN** the edit sheet SHALL open with an empty SSH Key draft (blank private key, blank public key, no notes, no custom fields)
+
+---
+
+### Requirement: Saving a new item creates it on the server and adds it to the local vault
+The system SHALL encrypt all sensitive fields of the new item using the vault's symmetric keys and send a `POST /api/ciphers` request to the server. On success, the server-returned item (with server-assigned ID and timestamps) SHALL be inserted into the in-memory vault cache. The item list SHALL update immediately without requiring a full re-sync. The edit sheet SHALL dismiss on successful save.
+
+#### Scenario: Successful creation persists to server
+- **WHEN** the user fills in the Name field and clicks Save
+- **THEN** the system SHALL encrypt the draft, POST it to the server, insert the server-confirmed item into the cache, and dismiss the sheet
+
+#### Scenario: Created item appears in the item list immediately
+- **WHEN** a new item is successfully created
+- **THEN** the item SHALL appear in the vault item list sorted alphabetically without a manual refresh or re-sync
+
+#### Scenario: Name is required for creation
+- **WHEN** the user attempts to save a new item with a blank Name field
+- **THEN** the Save button SHALL be disabled and an inline validation message ("Name is required") SHALL be shown
+
+#### Scenario: Save failure shows inline error
+- **WHEN** the server returns an error during creation
+- **THEN** the edit sheet SHALL remain open with an inline error banner displaying the error message
+
+#### Scenario: Vault lock during creation dismisses the sheet
+- **WHEN** the vault locks while the create edit sheet is open
+- **THEN** the sheet SHALL dismiss immediately without a discard confirmation prompt and the draft SHALL be cleared from memory
+
+---
+
+### Requirement: Discarding an unsaved new item prompts for confirmation if changes were made
+The system SHALL track whether the user has modified any field from the blank default state. If changes exist and the user attempts to dismiss the sheet (Escape key, Discard button, or clicking outside), a confirmation alert SHALL be shown. If no changes were made, the sheet SHALL dismiss without confirmation.
+
+#### Scenario: Discard with changes shows confirmation
+- **WHEN** the user has typed into any field of a new item and presses Escape
+- **THEN** a confirmation alert SHALL ask whether to discard changes
+
+#### Scenario: Discard without changes dismisses silently
+- **WHEN** the user opens a new item sheet and immediately presses Escape without editing
+- **THEN** the sheet SHALL dismiss without a confirmation prompt
+
+#### Scenario: Confirming discard clears the draft from memory
+- **WHEN** the user confirms the discard prompt
+- **THEN** the draft's plaintext field values SHALL be cleared from memory and the sheet SHALL dismiss

--- a/openspec/changes/add-vault-items/specs/vault-item-create/spec.md
+++ b/openspec/changes/add-vault-items/specs/vault-item-create/spec.md
@@ -1,16 +1,17 @@
 ## ADDED Requirements
 
 ### Requirement: User can create a new vault item from the vault browser
-The system SHALL provide a "+" button permanently anchored in the content column toolbar (above the item list, alongside the search bar) in `VaultBrowserView`. The button SHALL never move to any other toolbar position regardless of which category is selected or how the user navigates. It SHALL be hidden only when the Trash category is active, and SHALL reappear in the same position when the user leaves Trash. Clicking the button OR pressing ⌘N SHALL present a menu listing all five item types: Login, Card, Identity, Secure Note, and SSH Key. Selecting a type SHALL open the edit sheet pre-populated with a blank draft of that type. The edit sheet SHALL reuse the same form fields, validation, and save flow as the existing item edit feature. Once the type picker is open, the user SHALL be able to navigate types with ↑/↓ arrow keys and confirm with Enter, without touching the mouse.
+The system SHALL provide a "+" button permanently anchored in the content column toolbar (above the item list) in `VaultBrowserView`. The button SHALL never move to any other toolbar position regardless of which sidebar category is selected, whether an item is selected in the item list, or how the user navigates. It SHALL be completely invisible (no button frame, no icon) only when the Trash category is active, and SHALL reappear in the same position when the user leaves Trash. Clicking the button OR pressing ⌘N SHALL present a menu listing all five item types: Login, Card, Identity, Secure Note, and SSH Key. Selecting a type SHALL open the edit sheet pre-populated with a blank draft of that type. The edit sheet SHALL reuse the same form fields, validation, and save flow as the existing item edit feature. Once the type picker is open, the user SHALL be able to navigate types with ↑/↓ arrow keys and confirm with Enter, without touching the mouse.
 
-#### Scenario: New Item button is always above the item list
+#### Scenario: New Item button is always above the item list regardless of selection state
 - **WHEN** the vault browser is displayed with any category selected except Trash
 - **THEN** a "+" button (SF Symbol `plus`) SHALL be visible in the content column toolbar above the item list
-- **AND** the button SHALL remain in that position regardless of category switches or navigation history
+- **AND** the button SHALL be in the same position whether or not an item is selected in the item list
+- **AND** the button SHALL be in the same position whether a sidebar category (All Items, Favorites, Login, etc.) or an item list row is the last-focused element
 
-#### Scenario: New Item button is hidden when Trash is selected
+#### Scenario: New Item button is completely invisible when Trash is selected
 - **WHEN** the user selects the Trash category
-- **THEN** the "+" button SHALL NOT be visible
+- **THEN** the "+" button SHALL NOT be visible — no button frame, no icon, no chrome of any kind
 
 #### Scenario: New Item button reappears after leaving Trash
 - **GIVEN** the user has the Trash category selected

--- a/openspec/changes/add-vault-items/specs/vault-item-create/spec.md
+++ b/openspec/changes/add-vault-items/specs/vault-item-create/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: User can create a new vault item from the vault browser
-The system SHALL provide a "+" button permanently anchored at the top of the content column, immediately above the item list rows, in `VaultBrowserView`. The button SHALL be embedded in the content column's view body — not in the window toolbar — so its position is completely fixed regardless of which sidebar category is selected, whether an item is selected in the item list, or which column holds keyboard focus. It SHALL not be rendered at all when the Trash category is active, and SHALL reappear in the same fixed position when the user leaves Trash. Clicking the button OR pressing ⌘N SHALL present a menu listing all five item types: Login, Card, Identity, Secure Note, and SSH Key. Selecting a type SHALL open the edit sheet pre-populated with a blank draft of that type. The edit sheet SHALL reuse the same form fields, validation, and save flow as the existing item edit feature. Once the type picker is open, the user SHALL be able to navigate types with ↑/↓ arrow keys and confirm with Enter, without touching the mouse.
+The system SHALL provide a "+" button permanently anchored at the top of the content column, immediately above the item list rows, in `VaultBrowserView`. The button SHALL be embedded in the content column's view body — not in the window toolbar — so its position is completely fixed regardless of which sidebar category is selected, whether an item is selected in the item list, or which column holds keyboard focus. It SHALL not be rendered at all when the Trash category is active, and SHALL reappear in the same fixed position when the user leaves Trash. Clicking the button OR pressing ⌘N SHALL open a type picker listing all five item types: Login, Card, Identity, Secure Note, and SSH Key. The ⌘N shortcut SHALL appear only on the "+" button itself — it SHALL NOT appear as an annotation on any individual item type inside the picker. When the picker opens, the first item (Login) SHALL be pre-selected. The user SHALL be able to navigate types with ↑/↓ arrow keys and confirm with Enter, without touching the mouse. Selecting a type SHALL open the edit sheet pre-populated with a blank draft of that type. The edit sheet SHALL reuse the same form fields, validation, and save flow as the existing item edit feature.
 
 #### Scenario: New Item button is always above the item list regardless of selection or focus state
 - **WHEN** the vault browser is displayed with any category selected except Trash
@@ -20,25 +20,37 @@ The system SHALL provide a "+" button permanently anchored at the top of the con
 
 #### Scenario: ⌘N opens the type picker in a non-Trash category
 - **WHEN** the user presses ⌘N with any non-Trash category selected
-- **THEN** the New Item type picker menu SHALL open, listing Login, Card, Identity, Secure Note, and SSH Key
+- **THEN** the type picker SHALL open with the first item (Login) pre-selected
+- **AND** ⌘N SHALL NOT appear as a keyboard shortcut label on any item inside the picker
 
 #### Scenario: ⌘N is a no-op in Trash
 - **WHEN** the user presses ⌘N with the Trash category selected
 - **THEN** nothing SHALL happen — the type picker SHALL NOT open
 
-#### Scenario: Arrow keys navigate the type picker, Enter confirms
-- **GIVEN** the type picker menu is open
-- **WHEN** the user presses ↓ to move the highlight then presses Enter
-- **THEN** the edit sheet for the highlighted item type SHALL open
+#### Scenario: First item is pre-selected when the picker opens
+- **GIVEN** the type picker is opened (via + click or ⌘N)
+- **THEN** Login SHALL be highlighted/selected immediately — the user does not need to press ↓ before pressing Enter
+
+#### Scenario: Arrow keys navigate the type picker
+- **GIVEN** the type picker is open
+- **WHEN** the user presses ↓ once
+- **THEN** Card SHALL become selected
+- **WHEN** the user presses ↑
+- **THEN** Login SHALL become selected again
+
+#### Scenario: Enter confirms the selected type
+- **GIVEN** the type picker is open and a type is selected
+- **WHEN** the user presses Enter
+- **THEN** the edit sheet for the selected type SHALL open
 
 #### Scenario: ⌘N then immediate Enter opens the Login edit sheet
 - **WHEN** the user presses ⌘N and then immediately presses Enter without pressing any arrow key
-- **THEN** the Login edit sheet SHALL open (Login is the first type in the list)
+- **THEN** the Login edit sheet SHALL open (Login is pre-selected when the picker opens)
 
 #### Scenario: Escape dismisses the type picker without creating an item
-- **GIVEN** the type picker menu is open
+- **GIVEN** the type picker is open
 - **WHEN** the user presses Escape
-- **THEN** the menu SHALL close and no edit sheet SHALL open
+- **THEN** the picker SHALL close and no edit sheet SHALL open
 
 #### Scenario: Type picker shows all five item types
 - **WHEN** the user clicks the New Item button

--- a/openspec/changes/add-vault-items/specs/vault-item-create/spec.md
+++ b/openspec/changes/add-vault-items/specs/vault-item-create/spec.md
@@ -13,7 +13,7 @@ The system SHALL provide a "+" button in the content column toolbar (above the i
 
 #### Scenario: Selecting a type opens a blank edit sheet
 - **WHEN** the user selects "Login" from the type picker
-- **THEN** the edit sheet SHALL open with an empty Login draft (blank name, blank username, blank password, no URIs, no notes, no custom fields)
+- **THEN** the edit sheet SHALL open with an empty Login draft (blank name, blank username, blank password, one empty URI row with match type hidden, no notes, no custom fields)
 
 #### Scenario: Selecting Card opens a blank Card edit sheet
 - **WHEN** the user selects "Card" from the type picker

--- a/openspec/changes/add-vault-items/tasks.md
+++ b/openspec/changes/add-vault-items/tasks.md
@@ -1,25 +1,25 @@
 ## 1. Domain layer
 
-- [ ] 1.1 Add `DraftVaultItem.blank(type: ItemType)` static factory that returns a blank draft with `UUID().uuidString` as placeholder ID, empty name, `isFavorite: false`, `isDeleted: false`, current date for creation/revision, `reprompt: 0`, and type-appropriate empty content (Login: blank username/password/no URIs/no TOTP; Card: all nil; Identity: all nil; SecureNote: nil notes; SSHKey: nil keys)
-- [ ] 1.2 Add `CreateVaultItemUseCase` protocol in `Domain/UseCases/` with `func execute(draft: DraftVaultItem) async throws -> VaultItem`
-- [ ] 1.3 Add `CreateVaultItemUseCaseImpl` in `Data/UseCases/` that delegates to `VaultRepository.create(_:)`
+- [x] 1.1 Add `DraftVaultItem.blank(type: ItemType)` static factory that returns a blank draft with `UUID().uuidString` as placeholder ID, empty name, `isFavorite: false`, `isDeleted: false`, current date for creation/revision, `reprompt: 0`, and type-appropriate empty content (Login: blank username/password/no URIs/no TOTP; Card: all nil; Identity: all nil; SecureNote: nil notes; SSHKey: nil keys)
+- [x] 1.2 Add `CreateVaultItemUseCase` protocol in `Domain/UseCases/` with `func execute(draft: DraftVaultItem) async throws -> VaultItem`
+- [x] 1.3 Add `CreateVaultItemUseCaseImpl` in `Data/UseCases/` that delegates to `VaultRepository.create(_:)`
 
 ## 2. Data layer
 
-- [ ] 2.1 Add `createCipher(cipher: RawCipher) async throws -> RawCipher` to `MacwardenAPIClientProtocol` — `POST /api/ciphers` with JSON body, returns the server-created cipher
-- [ ] 2.2 Implement `createCipher` in `MacwardenAPIClientImpl` — authenticated POST with `baseRequest`, JSON-encode the `RawCipher`, decode the response
-- [ ] 2.3 Add `create(_ draft: DraftVaultItem) async throws -> VaultItem` to `VaultRepository` protocol
-- [ ] 2.4 Implement `create` in `VaultRepositoryImpl` — obtain keys, call `mapper.toRawCipher`, call `apiClient.createCipher`, map response, append to cache, return server-confirmed item
+- [x] 2.1 Add `createCipher(cipher: RawCipher) async throws -> RawCipher` to `MacwardenAPIClientProtocol` — `POST /api/ciphers` with JSON body, returns the server-created cipher
+- [x] 2.2 Implement `createCipher` in `MacwardenAPIClientImpl` — authenticated POST with `baseRequest`, JSON-encode the `RawCipher`, decode the response
+- [x] 2.3 Add `create(_ draft: DraftVaultItem) async throws -> VaultItem` to `VaultRepository` protocol
+- [x] 2.4 Implement `create` in `VaultRepositoryImpl` — obtain keys, call `mapper.toRawCipher`, call `apiClient.createCipher`, map response, append to cache, return server-confirmed item
 
 ## 3. Presentation layer
 
-- [ ] 3.1 Add `+` button to `VaultBrowserView` content column toolbar (above the item list, next to the search bar) — `Menu` with SF Symbol `plus` listing Login, Card, Identity, Secure Note, SSH Key; hidden when `sidebarSelection == .trash`
-- [ ] 3.2 Add `createItem(type:)` method to `VaultBrowserViewModel` that creates a blank draft and presents the edit sheet in create mode
-- [ ] 3.3 Adapt `ItemEditViewModel` to accept an optional `VaultItem?` — when `nil`, use `CreateVaultItemUseCase` instead of `EditVaultItemUseCase` for save
-- [ ] 3.4 Add `makeItemCreateViewModel(for type: ItemType)` factory to `AppContainer`
+- [x] 3.1 Add `+` button to `VaultBrowserView` content column toolbar (above the item list, next to the search bar) — `Menu` with SF Symbol `plus` listing Login, Card, Identity, Secure Note, SSH Key; hidden when `sidebarSelection == .trash`
+- [x] 3.2 Add `createItem(type:)` method to `VaultBrowserViewModel` that creates a blank draft and presents the edit sheet in create mode
+- [x] 3.3 Adapt `ItemEditViewModel` to accept an optional `VaultItem?` — when `nil`, use `CreateVaultItemUseCase` instead of `EditVaultItemUseCase` for save
+- [x] 3.4 Add `makeItemCreateViewModel(for type: ItemType)` factory to `AppContainer`
 
 ## 4. Mock & wiring
 
-- [ ] 4.1 Add `createCipher` stub to `MockMacwardenAPIClient`
-- [ ] 4.2 Add `create` stub to `MockVaultRepository`
-- [ ] 4.3 Wire `CreateVaultItemUseCaseImpl` in `AppContainer`
+- [x] 4.1 Add `createCipher` stub to `MockMacwardenAPIClient`
+- [x] 4.2 Add `create` stub to `MockVaultRepository`
+- [x] 4.3 Wire `CreateVaultItemUseCaseImpl` in `AppContainer`

--- a/openspec/changes/add-vault-items/tasks.md
+++ b/openspec/changes/add-vault-items/tasks.md
@@ -34,8 +34,8 @@
 
 ## 7. ⌘N keyboard shortcut
 
-- [x] 7.1 Add `.keyboardShortcut(.n, modifiers: .command)` to the `Menu` in `VaultBrowserView` so ⌘N opens the type picker
-- [x] 7.2 Add `.disabled(viewModel.sidebarSelection == .trash)` to the same `Menu` so ⌘N is a no-op in Trash and the menu bar entry is greyed out
+- [x] 7.1 Replace `Menu` in `newItemBar` with `Button` + `.popover(NewItemTypePickerView)` so `.keyboardShortcut("n")` lives on the trigger only and does not annotate individual item-type rows
+- [x] 7.2 Add `NewItemTypePickerView` — `List` with single-selection binding, pre-selects Login on open, ↑/↓ via native List, Enter confirms via `.onKeyPress(.return)`
 - [x] 7.3 Add `testCmdN_opensPicker_inNonTrashCategory` to `CreateItemJourneyTests` — press ⌘N, assert the type picker menu appears (check for "Login" menu item)
 - [x] 7.4 Add `testCmdN_isNoOp_inTrash` to `CreateItemJourneyTests` — select Trash, press ⌘N, assert no type picker / edit sheet appears
 - [x] 7.5 Add `testCmdN_thenEnter_opensLoginSheet` to `CreateItemJourneyTests` — press ⌘N then Enter, assert the Login edit sheet opens (check for Save button)

--- a/openspec/changes/add-vault-items/tasks.md
+++ b/openspec/changes/add-vault-items/tasks.md
@@ -1,0 +1,25 @@
+## 1. Domain layer
+
+- [ ] 1.1 Add `DraftVaultItem.blank(type: ItemType)` static factory that returns a blank draft with `UUID().uuidString` as placeholder ID, empty name, `isFavorite: false`, `isDeleted: false`, current date for creation/revision, `reprompt: 0`, and type-appropriate empty content (Login: blank username/password/no URIs/no TOTP; Card: all nil; Identity: all nil; SecureNote: nil notes; SSHKey: nil keys)
+- [ ] 1.2 Add `CreateVaultItemUseCase` protocol in `Domain/UseCases/` with `func execute(draft: DraftVaultItem) async throws -> VaultItem`
+- [ ] 1.3 Add `CreateVaultItemUseCaseImpl` in `Data/UseCases/` that delegates to `VaultRepository.create(_:)`
+
+## 2. Data layer
+
+- [ ] 2.1 Add `createCipher(cipher: RawCipher) async throws -> RawCipher` to `MacwardenAPIClientProtocol` — `POST /api/ciphers` with JSON body, returns the server-created cipher
+- [ ] 2.2 Implement `createCipher` in `MacwardenAPIClientImpl` — authenticated POST with `baseRequest`, JSON-encode the `RawCipher`, decode the response
+- [ ] 2.3 Add `create(_ draft: DraftVaultItem) async throws -> VaultItem` to `VaultRepository` protocol
+- [ ] 2.4 Implement `create` in `VaultRepositoryImpl` — obtain keys, call `mapper.toRawCipher`, call `apiClient.createCipher`, map response, append to cache, return server-confirmed item
+
+## 3. Presentation layer
+
+- [ ] 3.1 Add `+` button to `VaultBrowserView` content column toolbar (above the item list, next to the search bar) — `Menu` with SF Symbol `plus` listing Login, Card, Identity, Secure Note, SSH Key; hidden when `sidebarSelection == .trash`
+- [ ] 3.2 Add `createItem(type:)` method to `VaultBrowserViewModel` that creates a blank draft and presents the edit sheet in create mode
+- [ ] 3.3 Adapt `ItemEditViewModel` to accept an optional `VaultItem?` — when `nil`, use `CreateVaultItemUseCase` instead of `EditVaultItemUseCase` for save
+- [ ] 3.4 Add `makeItemCreateViewModel(for type: ItemType)` factory to `AppContainer`
+
+## 4. Mock & wiring
+
+- [ ] 4.1 Add `createCipher` stub to `MockMacwardenAPIClient`
+- [ ] 4.2 Add `create` stub to `MockVaultRepository`
+- [ ] 4.3 Wire `CreateVaultItemUseCaseImpl` in `AppContainer`

--- a/openspec/changes/add-vault-items/tasks.md
+++ b/openspec/changes/add-vault-items/tasks.md
@@ -23,3 +23,7 @@
 - [x] 4.1 Add `createCipher` stub to `MockMacwardenAPIClient`
 - [x] 4.2 Add `create` stub to `MockVaultRepository`
 - [x] 4.3 Wire `CreateVaultItemUseCaseImpl` in `AppContainer`
+
+## 5. Blank Login URI
+
+- [x] 5.1 Change `DraftVaultItem.blank(type: .login)` to include one empty `DraftLoginURI` (blank URI, nil match type) so the Website field is pre-expanded with match type hidden

--- a/openspec/changes/add-vault-items/tasks.md
+++ b/openspec/changes/add-vault-items/tasks.md
@@ -13,7 +13,7 @@
 
 ## 3. Presentation layer
 
-- [x] 3.1 Add `+` button to `VaultBrowserView` content column toolbar (above the item list, next to the search bar) — `Menu` with SF Symbol `plus` listing Login, Card, Identity, Secure Note, SSH Key; permanently anchored on the always-present `VStack` (not on `ItemListView`) so the `ToolbarItem` stays registered across category switches; hidden in Trash via `.opacity(0)` + `.allowsHitTesting(false)` to avoid toolbar placement drift
+- [x] 3.1 Add `newItemBar` to `VaultBrowserView` view body (not a ToolbarItem) — a `Button` + `.popover(NewItemTypePickerView)` embedded in the `else` branch of the Trash conditional so it is simply not rendered in Trash; stable position regardless of column focus because it is a plain view, not a toolbar item
 - [x] 3.2 Add `createItem(type:)` method to `VaultBrowserViewModel` that creates a blank draft and presents the edit sheet in create mode
 - [x] 3.3 Adapt `ItemEditViewModel` to accept an optional `VaultItem?` — when `nil`, use `CreateVaultItemUseCase` instead of `EditVaultItemUseCase` for save
 - [x] 3.4 Add `makeItemCreateViewModel(for type: ItemType)` factory to `AppContainer`

--- a/openspec/changes/add-vault-items/tasks.md
+++ b/openspec/changes/add-vault-items/tasks.md
@@ -13,7 +13,7 @@
 
 ## 3. Presentation layer
 
-- [x] 3.1 Add `+` button to `VaultBrowserView` content column toolbar (above the item list, next to the search bar) — `Menu` with SF Symbol `plus` listing Login, Card, Identity, Secure Note, SSH Key; hidden when `sidebarSelection == .trash`
+- [x] 3.1 Add `+` button to `VaultBrowserView` content column toolbar (above the item list, next to the search bar) — `Menu` with SF Symbol `plus` listing Login, Card, Identity, Secure Note, SSH Key; permanently anchored on the always-present `VStack` (not on `ItemListView`) so the `ToolbarItem` stays registered across category switches; hidden in Trash via `.opacity(0)` + `.allowsHitTesting(false)` to avoid toolbar placement drift
 - [x] 3.2 Add `createItem(type:)` method to `VaultBrowserViewModel` that creates a blank draft and presents the edit sheet in create mode
 - [x] 3.3 Adapt `ItemEditViewModel` to accept an optional `VaultItem?` — when `nil`, use `CreateVaultItemUseCase` instead of `EditVaultItemUseCase` for save
 - [x] 3.4 Add `makeItemCreateViewModel(for type: ItemType)` factory to `AppContainer`
@@ -31,3 +31,11 @@
 ## 6. Password field focus and input
 
 - [x] 6.1 Replace static `Text` placeholder in `MaskedEditFieldRow` with `SecureField` when masked, so the password field is focusable via Tab and accepts direct keyboard input
+
+## 7. ⌘N keyboard shortcut
+
+- [x] 7.1 Add `.keyboardShortcut(.n, modifiers: .command)` to the `Menu` in `VaultBrowserView` so ⌘N opens the type picker
+- [x] 7.2 Add `.disabled(viewModel.sidebarSelection == .trash)` to the same `Menu` so ⌘N is a no-op in Trash and the menu bar entry is greyed out
+- [x] 7.3 Add `testCmdN_opensPicker_inNonTrashCategory` to `CreateItemJourneyTests` — press ⌘N, assert the type picker menu appears (check for "Login" menu item)
+- [x] 7.4 Add `testCmdN_isNoOp_inTrash` to `CreateItemJourneyTests` — select Trash, press ⌘N, assert no type picker / edit sheet appears
+- [x] 7.5 Add `testCmdN_thenEnter_opensLoginSheet` to `CreateItemJourneyTests` — press ⌘N then Enter, assert the Login edit sheet opens (check for Save button)

--- a/openspec/changes/add-vault-items/tasks.md
+++ b/openspec/changes/add-vault-items/tasks.md
@@ -27,3 +27,7 @@
 ## 5. Blank Login URI
 
 - [x] 5.1 Change `DraftVaultItem.blank(type: .login)` to include one empty `DraftLoginURI` (blank URI, nil match type) so the Website field is pre-expanded with match type hidden
+
+## 6. Password field focus and input
+
+- [x] 6.1 Replace static `Text` placeholder in `MaskedEditFieldRow` with `SecureField` when masked, so the password field is focusable via Tab and accepts direct keyboard input


### PR DESCRIPTION
## Summary

Adds the ability to create new vault items (Login, Card, Identity, Secure Note, SSH Key) directly from the vault browser, completing the core CRUD lifecycle.

## Changes

### Domain
- `DraftVaultItem.blank(type:)` static factory for blank drafts of each item type
- `CreateVaultItemUseCase` protocol + `CreateVaultItemUseCaseImpl`

### Data
- `createCipher(cipher:)` on `MacwardenAPIClientProtocol` — `POST /api/ciphers`
- `VaultRepository.create(_:)` — encrypt → POST → append to cache

### Presentation
- `+` menu button in the content column toolbar (above item list) with all 5 types
- `ItemEditViewModel` dual-mode: separate inits for edit vs create, dispatches to the correct use case
- Sheet presentation driven by `VaultBrowserViewModel.createItemType`
- Button hidden in Trash view; `createItemType` auto-clears if set while in Trash

### Mocks & Wiring
- `createCipher` / `create` stubs on mock API client and repository
- `CreateVaultItemUseCaseImpl` wired in `AppContainer`

## Testing

Build succeeds, all existing unit tests pass. Includes openspec change artifacts (proposal, design, specs, tasks).