### PR TITLE
feat: liquid glass toolbar and scrollable detail pane

### DIFF
--- a/Macwarden/App/MacwardenApp.swift
+++ b/Macwarden/App/MacwardenApp.swift
@@ -31,7 +31,8 @@ struct MacwardenApp: App {
                 .containerBackground(.thinMaterial, for: .window)
                 .environment(optionKeyMonitor)
         }
-        .windowStyle(.hiddenTitleBar)
+        .windowStyle(.titleBar)
+        .windowToolbarStyle(.unified(showsTitle: false))
         .commands {
             CommandGroup(after: .appInfo) {
                 Button("Sign Out…") {

--- a/Macwarden/App/MacwardenApp.swift
+++ b/Macwarden/App/MacwardenApp.swift
@@ -28,7 +28,6 @@ struct MacwardenApp: App {
         WindowGroup {
             rootView
                 .frame(minWidth: 480, minHeight: 360)
-                .containerBackground(.thinMaterial, for: .window)
                 .environment(optionKeyMonitor)
         }
         .windowStyle(.titleBar)

--- a/Macwarden/App/MacwardenApp.swift
+++ b/Macwarden/App/MacwardenApp.swift
@@ -31,7 +31,7 @@ struct MacwardenApp: App {
                 .environment(optionKeyMonitor)
         }
         .windowStyle(.titleBar)
-        .windowToolbarStyle(.unified(showsTitle: false))
+        .windowToolbarStyle(.unified)
         .commands {
             CommandGroup(after: .appInfo) {
                 Button("Sign Out…") {

--- a/Macwarden/App/MacwardenApp.swift
+++ b/Macwarden/App/MacwardenApp.swift
@@ -31,7 +31,7 @@ struct MacwardenApp: App {
                 .environment(optionKeyMonitor)
         }
         .windowStyle(.titleBar)
-        .windowToolbarStyle(.unified)
+        .windowToolbarStyle(.unified(showsTitle: false))
         .commands {
             CommandGroup(after: .appInfo) {
                 Button("Sign Out…") {

--- a/Macwarden/Presentation/Vault/Detail/ItemDetailView.swift
+++ b/Macwarden/Presentation/Vault/Detail/ItemDetailView.swift
@@ -2,95 +2,35 @@ import SwiftUI
 
 // MARK: - ItemDetailView
 
-/// Routes to the correct type-specific detail view and shows item metadata footer.
-///
-/// FR-031: creation + revision dates in the footer.
-/// FR-034: "No item selected" empty state when `item` is nil.
-/// edit-vault-items: Edit toolbar button + sheet presentation.
+/// Detail pane: type-specific content, metadata footer, edit sheet.
 struct ItemDetailView: View {
 
     let item:              VaultItem?
     let faviconLoader:     FaviconLoader
     let onCopy:            (String) -> Void
-    /// Factory that creates an `ItemEditViewModel` for the given item.
-    /// Passed from `VaultBrowserView` so this view stays decoupled from `AppContainer`.
     let makeEditViewModel: (VaultItem) -> ItemEditViewModel
-    /// Called when the edit sheet opens (`true`) or closes (`false`).
-    /// Drives `MenuBarViewModel.canEdit` / `canSave` state (task 9.5).
     var onEditSheetChanged: ((Bool) -> Void)? = nil
-    /// Called to soft-delete the current active item (moves it to Trash).
-    /// Nil when the detail pane does not support delete (e.g. unit-test stubs).
     var onSoftDelete: ((String) async -> Void)? = nil
-    /// Called to restore the current trashed item back to the active vault.
     var onRestore: ((String) async -> Void)? = nil
-    /// Called to permanently delete the current trashed item.
     var onPermanentDelete: ((String) async -> Void)? = nil
-
-    /// Incremented by `VaultBrowserViewModel.triggerEdit()` when the "Item > Edit" menu bar
-    /// action fires (spec §9.3). `.onChange` opens the edit sheet for the current item.
     var editTrigger: Int = 0
-
-    /// Incremented by `VaultBrowserViewModel.triggerSave()` when the "Item > Save" menu bar
-    /// action fires (spec §9.4). `.onChange` calls `save()` on the active edit ViewModel.
     var saveTrigger: Int = 0
 
-    /// Tracks whether the edit sheet is currently presented.
     @State private var isEditSheetPresented = false
-    /// The ViewModel for the active edit session. Created on Edit button press and
-    /// released (nil'd) when the sheet is dismissed to clear the draft from memory (§III).
     @State private var editViewModel: ItemEditViewModel?
 
     var body: some View {
         if let item {
-            VStack(spacing: 0) {
-                // Trash status banner — shown when the item is soft-deleted.
-                // Editing is disabled for trashed items (the Bitwarden API rejects PUT on
-                // a deleted cipher); the user must restore before editing.
-                if item.isDeleted {
-                    trashBanner(for: item)
+            ScrollView {
+                VStack(spacing: 0) {
+                    if item.isDeleted { trashBanner(for: item) }
+
+                    itemHeader(for: item)
+                    typeDetailView(for: item)
+
+                    Divider()
+                    metadataFooter(for: item)
                 }
-
-                // Item name header with favicon/type icon
-                HStack(alignment: .center, spacing: 12) {
-                    FaviconView(
-                        domain:   primaryDomain(for: item),
-                        itemType: itemType(for: item),
-                        loader:   faviconLoader,
-                        size:     36
-                    )
-                    Text(item.name.isEmpty ? " " : item.name)
-                        .font(Typography.pageTitle)
-                        .accessibilityIdentifier(AccessibilityID.Detail.itemName)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.top, Spacing.pageTop)
-                .padding(.horizontal, Spacing.pageMargin)
-                .padding(.bottom, Spacing.pageHeaderBottom)
-
-                // Type-specific content
-                typeDetailView(for: item)
-
-                Divider()
-
-                // Metadata footer (FR-031)
-                HStack {
-                    Label(
-                        "Created \(item.creationDate.formatted(date: .abbreviated, time: .omitted))",
-                        systemImage: "calendar"
-                    )
-                    .font(Typography.utility)
-                    .foregroundStyle(.secondary)
-
-                    Spacer()
-
-                    Label(
-                        "Updated \(item.revisionDate.formatted(date: .abbreviated, time: .omitted))",
-                        systemImage: "clock"
-                    )
-                    .font(Typography.utility)
-                    .foregroundStyle(.secondary)
-                }
-                .padding(12)
             }
             .sheet(isPresented: $isEditSheetPresented, onDismiss: {
                 editViewModel = nil
@@ -100,13 +40,8 @@ struct ItemDetailView: View {
                     ItemEditView(viewModel: vm, isPresented: $isEditSheetPresented)
                 }
             }
-            // Menu bar "Edit" action — mirrors the toolbar Edit button (spec §9.3).
-            // Guard against trashed items: edit is not permitted while in trash.
-            .onChangeCompat(of: editTrigger) { if !item.isDeleted { openEditSheet(for: item) } }
-            // Menu bar "Save" action — mirrors the in-sheet Save button (spec §9.4).
-            // `ItemEditViewModel.save()` is a no-op if `canSave` is false, so this is safe
-            // even when called while the name is blank or a save is already in-flight.
-            .onChangeCompat(of: saveTrigger) { editViewModel?.save() }
+            .onChange(of: editTrigger) { if !item.isDeleted { openEditSheet(for: item) } }
+            .onChange(of: saveTrigger) { editViewModel?.save() }
         } else {
             ContentUnavailableView(
                 "No Item Selected",
@@ -117,18 +52,44 @@ struct ItemDetailView: View {
         }
     }
 
-    // MARK: - Trash banner
+    // MARK: - Subviews
 
-    /// Banner shown at the top of the detail pane when the item is in Trash.
-    /// Communicates that the item is not editable and can be restored or permanently deleted.
+    @ViewBuilder
+    private func itemHeader(for item: VaultItem) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            FaviconView(
+                domain:   primaryDomain(for: item),
+                itemType: itemType(for: item),
+                loader:   faviconLoader,
+                size:     36
+            )
+            Text(item.name.isEmpty ? " " : item.name)
+                .font(Typography.pageTitle)
+                .accessibilityIdentifier(AccessibilityID.Detail.itemName)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.top, Spacing.pageTop)
+        .padding(.horizontal, Spacing.pageMargin)
+        .padding(.bottom, Spacing.pageHeaderBottom)
+    }
+
+    @ViewBuilder
+    private func metadataFooter(for item: VaultItem) -> some View {
+        HStack {
+            Label("Created \(item.creationDate.formatted(date: .abbreviated, time: .omitted))", systemImage: "calendar")
+                .font(Typography.utility).foregroundStyle(.secondary)
+            Spacer()
+            Label("Updated \(item.revisionDate.formatted(date: .abbreviated, time: .omitted))", systemImage: "clock")
+                .font(Typography.utility).foregroundStyle(.secondary)
+        }
+        .padding(12)
+    }
+
     @ViewBuilder
     private func trashBanner(for item: VaultItem) -> some View {
         HStack(spacing: Spacing.headerGap) {
-            Image(systemName: "trash")
-                .foregroundStyle(.secondary)
-            Text("This item is in Trash.")
-                .font(Typography.bannerText)
-                .foregroundStyle(.secondary)
+            Image(systemName: "trash").foregroundStyle(.secondary)
+            Text("This item is in Trash.").font(Typography.bannerText).foregroundStyle(.secondary)
             Spacer()
         }
         .padding(.horizontal, Spacing.pageMargin)
@@ -141,66 +102,36 @@ struct ItemDetailView: View {
 
     private func openEditSheet(for item: VaultItem) {
         guard !isEditSheetPresented else { return }
-        let vm = makeEditViewModel(item)
-        editViewModel = vm
+        editViewModel = makeEditViewModel(item)
         isEditSheetPresented = true
         onEditSheetChanged?(true)
     }
 
-    // MARK: - Favicon helpers
+    // MARK: - Helpers
 
     private func primaryDomain(for item: VaultItem) -> String? {
-        guard case .login(let l) = item.content,
-              let first = l.uris.first else { return nil }
+        guard case .login(let l) = item.content, let first = l.uris.first else { return nil }
         return URL(string: first.uri)?.host
     }
 
     private func itemType(for item: VaultItem) -> ItemType {
         switch item.content {
-        case .login:      return .login
-        case .card:       return .card
-        case .identity:   return .identity
-        case .secureNote: return .secureNote
-        case .sshKey:     return .sshKey
+        case .login:      .login
+        case .card:       .card
+        case .identity:   .identity
+        case .secureNote: .secureNote
+        case .sshKey:     .sshKey
         }
     }
 
-    // MARK: - Type dispatcher
     @ViewBuilder
     private func typeDetailView(for item: VaultItem) -> some View {
         switch item.content {
-        case .login(let l):
-            LoginDetailView(item: item, login: l, onCopy: onCopy)
-
-        case .card(let c):
-            CardDetailView(item: item, card: c, onCopy: onCopy)
-
-        case .identity(let i):
-            IdentityDetailView(item: item, identity: i, onCopy: onCopy)
-
-        case .secureNote(let n):
-            SecureNoteDetailView(item: item, secureNote: n, onCopy: onCopy)
-
-        case .sshKey(let k):
-            SSHKeyDetailView(item: item, sshKey: k, onCopy: onCopy)
-        }
-    }
-}
-
-// MARK: - macOS version compat
-
-private extension View {
-    /// Calls `action` when `value` changes, without deprecation warnings on either target OS.
-    ///
-    /// macOS 14 deprecated `onChange(of:perform:)` (single-arg closure) in favour of a
-    /// zero-arg form. macOS 13 only has the single-arg form. Branching on `#available`
-    /// keeps both OS versions happy at the two call sites in this file.
-    @ViewBuilder
-    func onChangeCompat<T: Equatable>(of value: T, action: @escaping () -> Void) -> some View {
-        if #available(macOS 14, *) {
-            self.onChange(of: value, action)
-        } else {
-            self.onChange(of: value) { _ in action() }
+        case .login(let l):      LoginDetailView(item: item, login: l, onCopy: onCopy)
+        case .card(let c):       CardDetailView(item: item, card: c, onCopy: onCopy)
+        case .identity(let i):   IdentityDetailView(item: item, identity: i, onCopy: onCopy)
+        case .secureNote(let n): SecureNoteDetailView(item: item, secureNote: n, onCopy: onCopy)
+        case .sshKey(let k):     SSHKeyDetailView(item: item, sshKey: k, onCopy: onCopy)
         }
     }
 }

--- a/Macwarden/Presentation/Vault/VaultBrowserView.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserView.swift
@@ -51,29 +51,28 @@ struct VaultBrowserView: View {
                     }
                 }
                 .navigationTitle(viewModel.sidebarSelection.displayName)
+                .navigationSubtitle("\(viewModel.displayedItems.count) Items")
                 .toolbar {
                     ToolbarItem(placement: .primaryAction) {
-                        if viewModel.sidebarSelection != .trash {
-                            Menu {
-                                ForEach(ItemType.allCases) { type in
-                                    Button {
-                                        viewModel.createItemType = type
-                                    } label: {
-                                        Label(type.displayName, systemImage: type.sfSymbol)
-                                    }
+                        Menu {
+                            ForEach(ItemType.allCases) { type in
+                                Button {
+                                    viewModel.createItemType = type
+                                } label: {
+                                    Label(type.displayName, systemImage: type.sfSymbol)
                                 }
-                            } label: {
-                                Image(systemName: "plus")
                             }
-                            .help("New Item (⌘N)")
-                            .accessibilityIdentifier(AccessibilityID.Create.newItemButton)
-                            .menuIndicator(.visible)
-                            .background {
-                                Button("") { viewModel.createItemType = .login }
-                                    .keyboardShortcut("n", modifiers: .command)
-                                    .frame(width: 0, height: 0)
-                                    .opacity(0)
-                            }
+                        } label: {
+                            Image(systemName: "plus")
+                        }
+                        .help("New Item (⌘N)")
+                        .accessibilityIdentifier(AccessibilityID.Create.newItemButton)
+                        .menuIndicator(.visible)
+                        .background {
+                            Button("") { viewModel.createItemType = .login }
+                                .keyboardShortcut("n", modifiers: .command)
+                                .frame(width: 0, height: 0)
+                                .opacity(0)
                         }
                     }
                 }

--- a/Macwarden/Presentation/Vault/VaultBrowserView.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserView.swift
@@ -50,11 +50,7 @@ struct VaultBrowserView: View {
                         )
                     }
                 }
-                .searchable(
-                    text: $viewModel.searchQuery,
-                    placement: .sidebar,
-                    prompt: "Search vault"
-                )
+                .navigationTitle(viewModel.sidebarSelection.displayName)
                 .toolbar {
                     ToolbarItem(placement: .primaryAction) {
                         if viewModel.sidebarSelection != .trash {
@@ -131,6 +127,11 @@ struct VaultBrowserView: View {
                         }
                     }
                 }
+                .searchable(
+                    text: $viewModel.searchQuery,
+                    placement: .toolbar,
+                    prompt: "Search vault"
+                )
             }
         )
         .navigationSplitViewStyle(.balanced)

--- a/Macwarden/Presentation/Vault/VaultBrowserView.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserView.swift
@@ -50,8 +50,6 @@ struct VaultBrowserView: View {
                         )
                     }
                 }
-                .navigationTitle(viewModel.sidebarSelection.displayName)
-                .navigationSubtitle("\(viewModel.displayedItems.count) Items")
                 .toolbar {
                     ToolbarItem(placement: .primaryAction) {
                         Menu {


### PR DESCRIPTION
## Summary

- Adopts macOS 26 Liquid Glass toolbar by switching from `.hiddenTitleBar` to `.titleBar + .unified(showsTitle: false)` — the system renders the toolbar in glass automatically
- Removes `.containerBackground(.thinMaterial)` that was blocking glass rendering
- Moves `.searchable` to the detail column toolbar and adds `.navigationTitle` on the content column
- Wraps the detail pane content in `ScrollView` to eliminate the toolbar separator line
- Simplifies `ItemDetailView`: removes the `onChangeCompat` compatibility shim (no longer needed on macOS 26+) and extracts inline view blocks into named `@ViewBuilder` subviews

## Test plan

- [ ] Launch app and confirm toolbar renders with Liquid Glass appearance on macOS 26
- [ ] Confirm search field appears in the detail column toolbar
- [ ] Confirm `+` button is always visible and opens the create sheet for all item types
- [ ] Confirm `⌘N` shortcut works from any column focus
- [ ] Confirm detail pane scrolls correctly for long items (Identity, SSH Key)
- [ ] Confirm Edit / Delete / Restore / Permanent Delete toolbar buttons still appear correctly
- [ ] Confirm Trash view still shows Restore / Delete Permanently buttons (not Edit/Delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)