### PR TITLE
chore: code review — security hardening, design system tokens, test reliability

### DIFF
--- a/Macwarden/Data/Crypto/CryptoKeys.swift
+++ b/Macwarden/Data/Crypto/CryptoKeys.swift
@@ -13,9 +13,11 @@ import CommonCrypto
 /// authentication are independent (per NIST SP 800-107 §5.3).
 nonisolated struct CryptoKeys {
     /// 32-byte AES-256-CBC encryption key.
-    let encryptionKey: Data
+    /// `var` so `lockVault()` can zero the bytes before releasing (Constitution §III).
+    var encryptionKey: Data
     /// 32-byte HMAC-SHA256 MAC key (used for authenticated encryption).
-    let macKey: Data
+    /// `var` so `lockVault()` can zero the bytes before releasing (Constitution §III).
+    var macKey: Data
 }
 
 // MARK: - Static HMAC helper

--- a/Macwarden/Data/Crypto/CryptoKeys.swift
+++ b/Macwarden/Data/Crypto/CryptoKeys.swift
@@ -40,8 +40,10 @@ nonisolated extension CryptoKeys {
 
     /// Performs a constant-time comparison of two HMAC-SHA256 MACs.
     ///
-    /// CryptoKit's `HMAC.isValidAuthenticationCode` uses a constant-time algorithm
-    /// to prevent timing side-channel attacks (per NIST SP 800-107 §5.3.1).
+    /// Uses `HMAC<SHA256>.isValidAuthenticationCode(_:authenticating:using:)` which
+    /// performs a constant-time comparison to prevent timing side-channel attacks —
+    /// an attacker who can measure verification time must not be able to infer how
+    /// many bytes of a forged MAC matched before rejection (NIST SP 800-107 §5.3.1).
     ///
     /// - Parameters:
     ///   - key:      32-byte MAC key.
@@ -50,7 +52,6 @@ nonisolated extension CryptoKeys {
     /// - Returns: `true` if the computed MAC equals `expected`.
     static func verifyHmacSHA256(key: Data, data: Data, expected: Data) -> Bool {
         let symmetricKey = SymmetricKey(data: key)
-        let mac = HMAC<SHA256>.authenticationCode(for: data, using: symmetricKey)
-        return Data(mac) == expected
+        return HMAC<SHA256>.isValidAuthenticationCode(expected, authenticating: data, using: symmetricKey)
     }
 }

--- a/Macwarden/Data/Crypto/EncString.swift
+++ b/Macwarden/Data/Crypto/EncString.swift
@@ -31,6 +31,8 @@ nonisolated enum EncStringError: Error, Equatable {
     case macMismatch
     /// AES decryption failed (CommonCrypto returned an error status).
     case decryptionFailed
+    /// AES encryption or IV generation failed.
+    case encryptionFailed
     /// Encrypted data is shorter than the required IV length (16 bytes).
     case invalidIVLength
 }
@@ -184,11 +186,12 @@ nonisolated struct EncString {
     ///   - keys: Symmetric key pair.
     /// - Returns: A new `EncString` of type `.aes256Cbc_HmacSha256_B64`.
     static func encrypt(data: Data, keys: CryptoKeys) throws -> EncString {
-        // Random IV (16 bytes)
+        // Random IV (16 bytes) — SecRandomCopyBytes is backed by /dev/urandom and is
+        // the correct API for generating cryptographic IVs on Apple platforms.
         var ivBytes = [UInt8](repeating: 0, count: 16)
         let status = SecRandomCopyBytes(kSecRandomDefault, 16, &ivBytes)
         guard status == errSecSuccess else {
-            throw EncStringError.decryptionFailed
+            throw EncStringError.encryptionFailed
         }
         let iv = Data(ivBytes)
 
@@ -270,7 +273,7 @@ nonisolated struct EncString {
         }
 
         guard status == kCCSuccess else {
-            throw EncStringError.decryptionFailed
+            throw EncStringError.encryptionFailed
         }
         outData.removeSubrange(outLength...)
         return outData

--- a/Macwarden/Data/Crypto/MacwardenCryptoService.swift
+++ b/Macwarden/Data/Crypto/MacwardenCryptoService.swift
@@ -180,7 +180,7 @@ actor MacwardenCryptoServiceImpl: MacwardenCryptoService {
                 }
             } catch {
                 failedCount += 1
-                logger.debug("decryptList: Cipher skipped at index \(index)")
+                logger.error("decryptList: Cipher decryption failed at index \(index, privacy: .public)")
                 if DebugConfig.isEnabled {
                     logger.debug("[debug] cipher[\(index, privacy: .public)] FAILED — type=\(cipher.type, privacy: .public) error=\(error, privacy: .public)")
                 }

--- a/Macwarden/Data/Crypto/MacwardenCryptoService.swift
+++ b/Macwarden/Data/Crypto/MacwardenCryptoService.swift
@@ -38,12 +38,17 @@ protocol MacwardenCryptoService: Actor {
     /// Per the Bitwarden Security Whitepaper §4: the master key is the root secret
     /// from which all other keys are derived.  It is **never** sent to the server.
     ///
+    /// - Security goal: accepting `Data` (not `String`) lets the caller zero the
+    ///   password bytes after the KDF call returns, reducing the window during which
+    ///   plaintext password bytes live in the heap (Constitution §III). `String` is
+    ///   immutable and cannot be reliably zeroed.
+    ///
     /// - Parameters:
-    ///   - password: The user's master password (UTF-8 encoded).
+    ///   - password: The user's master password as UTF-8 bytes.
     ///   - email:    The user's lowercase email address (used as the PBKDF2 salt).
     ///   - kdf:      KDF parameters (algorithm, iterations, optional memory/parallelism).
     /// - Returns: 32-byte master key `Data`.
-    func makeMasterKey(password: String, email: String, kdf: KdfParams) async throws -> Data
+    func makeMasterKey(password: Data, email: String, kdf: KdfParams) async throws -> Data
 
     /// Stretches a 32-byte master key into a 64-byte `CryptoKeys` pair using HKDF
     /// (RFC 5869) with independent "enc" and "mac" info labels.
@@ -66,9 +71,9 @@ protocol MacwardenCryptoService: Actor {
     ///
     /// - Parameters:
     ///   - masterKey: 32-byte derived master key.
-    ///   - password:  The user's master password (used as the PBKDF2 "salt" in this step).
+    ///   - password:  The user's master password as UTF-8 bytes (used as the PBKDF2 "salt").
     /// - Returns: Base64-encoded 32-byte hash string (44 chars with padding).
-    func makeServerHash(masterKey: Data, password: String) async throws -> String
+    func makeServerHash(masterKey: Data, password: Data) async throws -> String
 
     /// Decrypts the `encUserKey` EncString (from the sync response profile) using the
     /// stretched master keys, and returns the 64-byte vault symmetric `CryptoKeys`.
@@ -198,9 +203,8 @@ actor MacwardenCryptoServiceImpl: MacwardenCryptoService {
 
     // MARK: - makeMasterKey
 
-    func makeMasterKey(password: String, email: String, kdf: KdfParams) async throws -> Data {
-        guard let passwordData = password.data(using: .utf8),
-              let emailData    = email.lowercased().data(using: .utf8) else {
+    func makeMasterKey(password: Data, email: String, kdf: KdfParams) async throws -> Data {
+        guard let emailData = email.lowercased().data(using: .utf8) else {
             throw MacwardenCryptoServiceError.kdfFailed
         }
 
@@ -209,7 +213,7 @@ actor MacwardenCryptoServiceImpl: MacwardenCryptoService {
         switch kdf.type {
         case .pbkdf2:
             return try pbkdf2SHA256(
-                password: passwordData,
+                password: password,
                 salt:     emailData,
                 rounds:   UInt32(kdf.iterations),
                 keyLen:   32
@@ -221,7 +225,7 @@ actor MacwardenCryptoServiceImpl: MacwardenCryptoService {
                 throw MacwardenCryptoServiceError.kdfFailed
             }
             return try argon2idDerive(
-                password:    passwordData,
+                password:    password,
                 salt:        emailData,
                 iterations:  kdf.iterations,
                 memory:      memory,
@@ -263,13 +267,10 @@ actor MacwardenCryptoServiceImpl: MacwardenCryptoService {
 
     // MARK: - makeServerHash
 
-    func makeServerHash(masterKey: Data, password: String) async throws -> String {
-        guard let passwordData = password.data(using: .utf8) else {
-            throw MacwardenCryptoServiceError.kdfFailed
-        }
+    func makeServerHash(masterKey: Data, password: Data) async throws -> String {
         // serverHash = PBKDF2-SHA256(masterKey, password, 1 iteration, 32 bytes)
         // Per Bitwarden Security Whitepaper §4: "Local Password Hash"
-        let hash = try pbkdf2SHA256(password: masterKey, salt: passwordData, rounds: 1, keyLen: 32)
+        let hash = try pbkdf2SHA256(password: masterKey, salt: password, rounds: 1, keyLen: 32)
         return hash.base64EncodedString()
     }
 

--- a/Macwarden/Data/Crypto/MacwardenCryptoService.swift
+++ b/Macwarden/Data/Crypto/MacwardenCryptoService.swift
@@ -140,10 +140,16 @@ actor MacwardenCryptoServiceImpl: MacwardenCryptoService {
     }
 
     func lockVault() {
-        // Overwrite with zeros before releasing (best-effort; Swift ARC may still
-        // retain copies elsewhere, but this reduces the window during which the
-        // key is readable in a memory dump).
-        self.keys = nil
+        // Zero both key buffers in the actor's stored property before releasing.
+        // `self.keys` is the primary reference — zeroing it reduces the window during
+        // which key material exists in a heap dump (Constitution §III). Any Data copies
+        // passed to in-flight decryption tasks retain their own CoW buffers until those
+        // tasks complete; those copies cannot be zeroed here.
+        if keys != nil {
+            keys!.encryptionKey.resetBytes(in: 0..<keys!.encryptionKey.count)
+            keys!.macKey.resetBytes(in: 0..<keys!.macKey.count)
+        }
+        keys = nil
         logger.info("Vault locked — key material zeroed")
     }
 

--- a/Macwarden/Data/Network/MacwardenAPIClient.swift
+++ b/Macwarden/Data/Network/MacwardenAPIClient.swift
@@ -22,6 +22,12 @@ protocol MacwardenAPIClientProtocol: Actor {
     /// Stores the access token used for subsequent authenticated requests.
     func setAccessToken(_ token: String)
 
+    /// Clears the in-memory access token.
+    ///
+    /// - Security goal: removes the bearer token from memory on sign-out so it cannot
+    ///   be read from a heap dump after the session ends (Constitution §III).
+    func clearAccessToken()
+
     /// POST `/accounts/prelogin` — returns KDF parameters for the given email.
     /// Used to derive the master key before posting credentials to `/connect/token`.
     ///
@@ -275,6 +281,10 @@ actor MacwardenAPIClientImpl: MacwardenAPIClientProtocol {
 
     func setAccessToken(_ token: String) {
         accessToken = token
+    }
+
+    func clearAccessToken() {
+        accessToken = nil
     }
 
     // MARK: - preLogin

--- a/Macwarden/Data/Repositories/AuthRepositoryImpl.swift
+++ b/Macwarden/Data/Repositories/AuthRepositoryImpl.swift
@@ -37,11 +37,13 @@ final class AuthRepositoryImpl: AuthRepository {
     // Set by loginWithPassword when the server requests 2FA; consumed by loginWithTOTP.
 
     private struct PendingTwoFactor {
-        let email:        String
-        let passwordHash: String
-        let kdfParams:    KdfParams
-        let stretchedKeys: CryptoKeys
-        let deviceId:     String
+        let email:         String
+        let passwordHash:  String
+        let kdfParams:     KdfParams
+        // `var` so cancelTwoFactor() can zero the key buffers before releasing the struct
+        // (Constitution §III). Swift ARC does not guarantee immediate deallocation on nil.
+        var stretchedKeys: CryptoKeys
+        let deviceId:      String
     }
     private var pendingTwoFactor: PendingTwoFactor?
 
@@ -230,11 +232,21 @@ final class AuthRepositoryImpl: AuthRepository {
     // MARK: - Unlock
 
     func cancelTwoFactor() {
-        // Zero the stretched keys held in pendingTwoFactor before releasing the struct.
-        // This reduces the window during which the derived key material lives in the heap
-        // after the user cancels the TOTP prompt (Constitution §III).
+        // Explicitly zero the stretched key buffers before releasing the struct.
+        // Setting pendingTwoFactor = nil alone does not guarantee immediate deallocation —
+        // ARC may defer it. Zeroing the Data buffers in-place reduces the window during
+        // which derived key material lives in the heap (Constitution §III).
+        // Note: passwordHash (String) cannot be zeroed — String storage is immutable.
+        if pendingTwoFactor != nil {
+            pendingTwoFactor!.stretchedKeys.encryptionKey.resetBytes(
+                in: 0..<pendingTwoFactor!.stretchedKeys.encryptionKey.count
+            )
+            pendingTwoFactor!.stretchedKeys.macKey.resetBytes(
+                in: 0..<pendingTwoFactor!.stretchedKeys.macKey.count
+            )
+        }
         pendingTwoFactor = nil
-        logger.info("Pending 2FA state cleared")
+        logger.info("Pending 2FA state cleared — stretched keys zeroed")
     }
 
     func unlockWithPassword(_ masterPassword: Data) async throws -> Account {
@@ -312,7 +324,11 @@ final class AuthRepositoryImpl: AuthRepository {
 
             // The stored access token may be expired. Attempt a refresh using the stored
             // refresh token so the post-unlock sync doesn't fail with 401.
-            if let refreshToken = try? readString(key: KeychainKey.user(userId, "refreshToken")) {
+            let refreshTokenOpt = try? readString(key: KeychainKey.user(userId, "refreshToken"))
+            if refreshTokenOpt == nil {
+                logger.debug("Unlock: no refresh token in Keychain — skipping token refresh")
+            }
+            if let refreshToken = refreshTokenOpt {
                 do {
                     let tokens = try await apiClient.refreshAccessToken(refreshToken: refreshToken)
                     do {

--- a/Macwarden/Data/Repositories/AuthRepositoryImpl.swift
+++ b/Macwarden/Data/Repositories/AuthRepositoryImpl.swift
@@ -79,7 +79,7 @@ final class AuthRepositoryImpl: AuthRepository {
 
     // MARK: - Login
 
-    func loginWithPassword(email: String, masterPassword: String) async throws -> LoginResult {
+    func loginWithPassword(email: String, masterPassword: Data) async throws -> LoginResult {
         logger.info("Login attempt for \(email, privacy: .private)")
         guard let env = serverEnvironment else {
             throw AuthError.serverUnreachable
@@ -94,6 +94,7 @@ final class AuthRepositoryImpl: AuthRepository {
         }
 
         // Step 2: Derive master key locally — never sent to server.
+        // `masterPassword` is `Data` so we can zero it after the KDF call (Constitution §III).
         logger.info("Step 2: deriving master key (KDF)")
         let masterKey  = try await crypto.makeMasterKey(
             password: masterPassword,
@@ -228,7 +229,15 @@ final class AuthRepositoryImpl: AuthRepository {
 
     // MARK: - Unlock
 
-    func unlockWithPassword(_ masterPassword: String) async throws -> Account {
+    func cancelTwoFactor() {
+        // Zero the stretched keys held in pendingTwoFactor before releasing the struct.
+        // This reduces the window during which the derived key material lives in the heap
+        // after the user cancels the TOTP prompt (Constitution §III).
+        pendingTwoFactor = nil
+        logger.info("Pending 2FA state cleared")
+    }
+
+    func unlockWithPassword(_ masterPassword: Data) async throws -> Account {
         logger.info("Unlock attempt")
         let userId: String
         do {
@@ -277,6 +286,7 @@ final class AuthRepositoryImpl: AuthRepository {
         if DebugConfig.isEnabled {
             logger.debug("[debug] unlock: KDF type=\(String(describing: kdfParams.type), privacy: .public) iterations=\(kdfParams.iterations, privacy: .public) encUserKey prefix=\(String(encUserKey.prefix(2)), privacy: .public)")
         }
+        // `masterPassword` is already `Data`; pass directly to KDF (Constitution §III).
         let masterKey  = try await crypto.makeMasterKey(
             password: masterPassword,
             email:    restoredAccount.email.lowercased(),
@@ -378,6 +388,11 @@ final class AuthRepositoryImpl: AuthRepository {
         // .vaultDidLock notification is posted — ItemEditViewModel observes it to
         // dismiss any open edit sheet and clear the plaintext DraftVaultItem (§III).
         await lockVault()
+
+        // Clear the bearer token from the API client's memory so it cannot be read
+        // from a heap dump after sign-out (Constitution §III).
+        await apiClient.clearAccessToken()
+
         serverEnvironment = nil
         pendingTwoFactor  = nil
     }

--- a/Macwarden/Data/Repositories/AuthRepositoryImpl.swift
+++ b/Macwarden/Data/Repositories/AuthRepositoryImpl.swift
@@ -305,9 +305,15 @@ final class AuthRepositoryImpl: AuthRepository {
             if let refreshToken = try? readString(key: KeychainKey.user(userId, "refreshToken")) {
                 do {
                     let tokens = try await apiClient.refreshAccessToken(refreshToken: refreshToken)
-                    try? writeString(tokens.accessToken, key: KeychainKey.user(userId, "accessToken"))
-                    if let newRefresh = tokens.refreshToken {
-                        try? writeString(newRefresh, key: KeychainKey.user(userId, "refreshToken"))
+                    do {
+                        try writeString(tokens.accessToken, key: KeychainKey.user(userId, "accessToken"))
+                        if let newRefresh = tokens.refreshToken {
+                            try writeString(newRefresh, key: KeychainKey.user(userId, "refreshToken"))
+                        }
+                    } catch {
+                        // Persisting the refreshed token failed — the next launch will use
+                        // the old (expired) token and the user may be signed out unexpectedly.
+                        logger.error("Unlock: failed to persist refreshed tokens — next launch may require re-auth: \(error.localizedDescription, privacy: .public)")
                     }
                     if DebugConfig.isEnabled {
                         logger.debug("[debug] unlock: access token refreshed successfully")

--- a/Macwarden/Data/Repositories/AuthRepositoryImpl.swift
+++ b/Macwarden/Data/Repositories/AuthRepositoryImpl.swift
@@ -237,12 +237,16 @@ final class AuthRepositoryImpl: AuthRepository {
         // ARC may defer it. Zeroing the Data buffers in-place reduces the window during
         // which derived key material lives in the heap (Constitution §III).
         // Note: passwordHash (String) cannot be zeroed — String storage is immutable.
-        if pendingTwoFactor != nil {
+        // `pendingTwoFactor!` is used for the mutations rather than the local `pending`
+        // copy produced by `if let` — zeroing `pending` would only zero the copy's CoW
+        // buffer, not the stored struct's. In-place mutation through `pendingTwoFactor!`
+        // is safe here because we verified non-nil one line above.
+        if let pending = pendingTwoFactor {
             pendingTwoFactor!.stretchedKeys.encryptionKey.resetBytes(
-                in: 0..<pendingTwoFactor!.stretchedKeys.encryptionKey.count
+                in: 0..<pending.stretchedKeys.encryptionKey.count
             )
             pendingTwoFactor!.stretchedKeys.macKey.resetBytes(
-                in: 0..<pendingTwoFactor!.stretchedKeys.macKey.count
+                in: 0..<pending.stretchedKeys.macKey.count
             )
         }
         pendingTwoFactor = nil

--- a/Macwarden/Data/Repositories/AuthRepositoryImpl.swift
+++ b/Macwarden/Data/Repositories/AuthRepositoryImpl.swift
@@ -62,9 +62,11 @@ final class AuthRepositoryImpl: AuthRepository {
     func validateServerURL(_ urlString: String) throws {
         // Strip trailing slash for normalisation.
         let trimmed = urlString.hasSuffix("/") ? String(urlString.dropLast()) : urlString
+        // Only HTTPS is permitted — Constitution §III requires all vault communication
+        // to use TLS. Allowing http:// would expose the master password hash and tokens
+        // to network interception even on "trusted" local networks.
         guard let url = URL(string: trimmed),
-              let scheme = url.scheme,
-              (scheme == "https" || scheme == "http"),
+              url.scheme == "https",
               url.host != nil else {
             throw AuthError.invalidURL
         }

--- a/Macwarden/Data/Repositories/SyncRepositoryImpl.swift
+++ b/Macwarden/Data/Repositories/SyncRepositoryImpl.swift
@@ -12,7 +12,9 @@ import os.log
 /// private key needed to decrypt per-org symmetric keys is present in the token response
 /// (`PrivateKey` field) but RSA decryption is not yet implemented.
 // TODO: support organisation ciphers — requires RSA private-key decryption of the
-// per-org symmetric key wrapped in the account's RSA keypair. No issue filed yet.
+// per-org symmetric key wrapped in the account's RSA keypair.
+// Deferred: Security.framework RSA-OAEP + the user's private key (from tokenResponse.privateKey)
+// must be decrypted with the vault symmetric key before org ciphers can be read.
 ///
 /// Individual cipher decryption failures are non-fatal — they are counted and logged
 /// but the remaining ciphers are still stored.

--- a/Macwarden/Data/Repositories/VaultRepositoryImpl.swift
+++ b/Macwarden/Data/Repositories/VaultRepositoryImpl.swift
@@ -63,19 +63,12 @@ final class VaultRepositoryImpl: VaultRepository {
         case .trash:
             // Trash shows only soft-deleted items; the isDeleted filter is inverted here.
             return sorted(items.filter(\.isDeleted))
-        default:
-            let base = items.filter { !$0.isDeleted }
-            switch selection {
-            case .allItems:
-                return sorted(base)
-            case .favorites:
-                return sorted(base.filter(\.isFavorite))
-            case .type(let itemType):
-                return sorted(base.filter { $0.content.matchesItemType(itemType) })
-            case .trash:
-                // Handled above — unreachable, but required for exhaustive switch.
-                return []
-            }
+        case .allItems:
+            return sorted(items.filter { !$0.isDeleted })
+        case .favorites:
+            return sorted(items.filter { !$0.isDeleted && $0.isFavorite })
+        case .type(let itemType):
+            return sorted(items.filter { !$0.isDeleted && $0.content.matchesItemType(itemType) })
         }
     }
 

--- a/Macwarden/Data/UseCases/LoginUseCaseImpl.swift
+++ b/Macwarden/Data/UseCases/LoginUseCaseImpl.swift
@@ -23,7 +23,7 @@ final class LoginUseCaseImpl: LoginUseCase {
         self.sync = sync
     }
 
-    func execute(serverURL: String, email: String, masterPassword: String) async throws -> LoginResult {
+    func execute(serverURL: String, email: String, masterPassword: Data) async throws -> LoginResult {
         // Step 1: Validate URL (throws AuthError.invalidURL on failure).
         try auth.validateServerURL(serverURL)
 
@@ -71,5 +71,9 @@ final class LoginUseCaseImpl: LoginUseCase {
             logger.error("Post-TOTP sync failed (non-fatal): \(error.localizedDescription, privacy: .public)")
         }
         return account
+    }
+
+    func cancelTOTP() {
+        auth.cancelTwoFactor()
     }
 }

--- a/Macwarden/Data/UseCases/UnlockUseCaseImpl.swift
+++ b/Macwarden/Data/UseCases/UnlockUseCaseImpl.swift
@@ -25,7 +25,7 @@ final class UnlockUseCaseImpl: UnlockUseCase {
         self.sync = sync
     }
 
-    func execute(masterPassword: String) async throws -> Account {
+    func execute(masterPassword: Data) async throws -> Account {
         // Step 1: Derive master key locally and unlock the crypto service.
         logger.info("Attempting vault unlock")
         let account = try await auth.unlockWithPassword(masterPassword)

--- a/Macwarden/Domain/Repositories/AuthRepository.swift
+++ b/Macwarden/Domain/Repositories/AuthRepository.swift
@@ -24,9 +24,11 @@ protocol AuthRepository: AnyObject {
     /// 3. POST `/connect/token` → obtain access + refresh tokens.
     /// 4. Persist tokens + encrypted user key in Keychain.
     ///
+    /// - Security goal: `masterPassword` is `Data` so the caller can zero the bytes
+    ///   after the call returns, reducing heap exposure (Constitution §III).
     /// - Returns: `.success(Account)` or `.requiresTwoFactor(method:)`.
     /// - Throws: `AuthError` on network or credential failure.
-    func loginWithPassword(email: String, masterPassword: String) async throws -> LoginResult
+    func loginWithPassword(email: String, masterPassword: Data) async throws -> LoginResult
 
     /// Completes a pending TOTP two-factor challenge.
     /// - Parameters:
@@ -36,13 +38,24 @@ protocol AuthRepository: AnyObject {
     /// - Throws: `AuthError.invalidTwoFactorCode` on wrong code.
     func loginWithTOTP(code: String, rememberDevice: Bool) async throws -> Account
 
+    /// Cancels a pending TOTP challenge and discards the in-memory `PendingTwoFactor`
+    /// state (stretched keys + password hash) held from the initial password login step.
+    ///
+    /// - Security goal: without this call the derived key material lives in memory until
+    ///   the next login attempt or app restart (Constitution §III). Call this whenever the
+    ///   user dismisses the TOTP prompt without submitting a code.
+    func cancelTwoFactor()
+
     // MARK: - Unlock
 
     /// Re-derives the symmetric key from `masterPassword` using stored KDF params.
     /// No network request is made — purely local crypto.
+    ///
+    /// - Security goal: `masterPassword` is `Data` so the caller can zero the bytes
+    ///   after the call returns (Constitution §III).
     /// - Returns: The unlocked `Account`.
     /// - Throws: `AuthError.invalidCredentials` on wrong password.
-    func unlockWithPassword(_ masterPassword: String) async throws -> Account
+    func unlockWithPassword(_ masterPassword: Data) async throws -> Account
 
     // MARK: - Session
 

--- a/Macwarden/Domain/UseCases/LoginUseCase.swift
+++ b/Macwarden/Domain/UseCases/LoginUseCase.swift
@@ -6,8 +6,12 @@ protocol LoginUseCase {
     func execute(
         serverURL: String,
         email: String,
-        masterPassword: String
+        masterPassword: Data
     ) async throws -> LoginResult
 
     func completeTOTP(code: String, rememberDevice: Bool) async throws -> Account
+
+    /// Cancels a pending TOTP challenge and clears in-memory key material held from
+    /// the initial password-login step (see `AuthRepository.cancelTwoFactor`).
+    func cancelTOTP()
 }

--- a/Macwarden/Domain/UseCases/UnlockUseCase.swift
+++ b/Macwarden/Domain/UseCases/UnlockUseCase.swift
@@ -4,5 +4,7 @@ import Foundation
 /// No network request — purely local KDF. Followed by `SyncUseCase` to re-populate
 /// the vault (in-memory store is cleared on app quit).
 protocol UnlockUseCase {
-    func execute(masterPassword: String) async throws -> Account
+    /// - Security goal: `masterPassword` is `Data` so the caller can zero the bytes after
+    ///   the KDF call, reducing heap exposure (Constitution §III).
+    func execute(masterPassword: Data) async throws -> Account
 }

--- a/Macwarden/MacwardenTests/AuthRepositoryImplTests.swift
+++ b/Macwarden/MacwardenTests/AuthRepositoryImplTests.swift
@@ -196,6 +196,33 @@ final class AuthRepositoryImplTests: XCTestCase {
         }
     }
 
+    // MARK: - cancelTwoFactor
+
+    /// cancelTwoFactor clears pendingTwoFactor so a subsequent loginWithTOTP throws .invalidCredentials.
+    func testCancelTwoFactor_clearsPendingState() async throws {
+        let serverEnv = ServerEnvironment(
+            base: URL(string: "https://vault.example.com")!,
+            overrides: nil
+        )
+        try await sut.setServerEnvironment(serverEnv)
+        mockAPI.preLoginResponse       = PreLoginResponse(kdf: 0, kdfIterations: 600_000, kdfMemory: nil, kdfParallelism: nil)
+        mockAPI.tokenTwoFactorProviders = [0]
+        mockCrypto.stubbedServerHash   = "hash=="
+        _ = try await sut.loginWithPassword(email: "alice@example.com", masterPassword: Data("pw!".utf8))
+
+        // Cancel before entering the TOTP code.
+        sut.cancelTwoFactor()
+
+        // A subsequent TOTP attempt must fail because pending state was cleared.
+        let sut = self.sut!
+        await XCTAssertThrowsErrorAsync(
+            try await sut.loginWithTOTP(code: "123456", rememberDevice: false)
+        ) { error in
+            XCTAssertEqual(error as? AuthError, .invalidCredentials,
+                           "loginWithTOTP must throw .invalidCredentials when no pending state exists")
+        }
+    }
+
     // MARK: - storedAccount
 
     /// storedAccount returns nil when no activeUserId is in Keychain.

--- a/Macwarden/MacwardenTests/AuthRepositoryImplTests.swift
+++ b/Macwarden/MacwardenTests/AuthRepositoryImplTests.swift
@@ -37,9 +37,11 @@ final class AuthRepositoryImplTests: XCTestCase {
         XCTAssertNoThrow(try sut.validateServerURL("https://vault.example.com/"))
     }
 
-    /// validateServerURL accepts http:// (for local dev).
-    func testValidateServerURL_validHTTP_succeeds() throws {
-        XCTAssertNoThrow(try sut.validateServerURL("http://192.168.1.100"))
+    /// validateServerURL rejects http:// — HTTPS only (Constitution §III).
+    func testValidateServerURL_httpURL_throws() throws {
+        XCTAssertThrowsError(try sut.validateServerURL("http://192.168.1.100")) { error in
+            XCTAssertEqual(error as? AuthError, .invalidURL)
+        }
     }
 
     /// Full loginWithPassword: preLogin → hashPassword → identityToken → initializeUserCrypto.
@@ -76,7 +78,7 @@ final class AuthRepositoryImplTests: XCTestCase {
 
         let result = try await sut.loginWithPassword(
             email: "alice@example.com",
-            masterPassword: "masterPassword1!"
+            masterPassword: Data("masterPassword1!".utf8)
         )
 
         guard case .success(let account) = result else {
@@ -103,7 +105,7 @@ final class AuthRepositoryImplTests: XCTestCase {
 
         let result = try await sut.loginWithPassword(
             email: "alice@example.com",
-            masterPassword: "masterPassword1!"
+            masterPassword: Data("masterPassword1!".utf8)
         )
 
         guard case .requiresTwoFactor(let method) = result else {
@@ -130,7 +132,7 @@ final class AuthRepositoryImplTests: XCTestCase {
 
         let result = try await sut.loginWithPassword(
             email: "alice@example.com",
-            masterPassword: "masterPassword1!"
+            masterPassword: Data("masterPassword1!".utf8)
         )
 
         guard case .requiresTwoFactor(let method) = result else {
@@ -157,7 +159,7 @@ final class AuthRepositoryImplTests: XCTestCase {
         )
         mockAPI.tokenTwoFactorProviders = [0]
         mockCrypto.stubbedServerHash = "hash=="
-        _ = try await sut.loginWithPassword(email: "alice@example.com", masterPassword: "pw!")
+        _ = try await sut.loginWithPassword(email: "alice@example.com", masterPassword: Data("pw!".utf8))
 
         // Now provide the TOTP code
         mockAPI.tokenResponse = TokenResponse(
@@ -182,7 +184,7 @@ final class AuthRepositoryImplTests: XCTestCase {
         mockAPI.preLoginResponse = PreLoginResponse(kdf: 0, kdfIterations: 600_000, kdfMemory: nil, kdfParallelism: nil)
         mockAPI.tokenTwoFactorProviders = [0]
         mockCrypto.stubbedServerHash = "hash=="
-        _ = try await sut.loginWithPassword(email: "alice@example.com", masterPassword: "pw!")
+        _ = try await sut.loginWithPassword(email: "alice@example.com", masterPassword: Data("pw!".utf8))
 
         mockAPI.tokenShouldThrow = AuthError.invalidTwoFactorCode
 
@@ -231,7 +233,7 @@ final class AuthRepositoryImplTests: XCTestCase {
         mockKeychain.seed(key: "bw.macos:\(userId):serverEnvironment",
                           value: String(data: try JSONEncoder().encode(env), encoding: .utf8)!)
 
-        let account = try await sut.unlockWithPassword("masterPassword1!")
+        let account = try await sut.unlockWithPassword(Data("masterPassword1!".utf8))
 
         XCTAssertEqual(account.email, "alice@example.com")
         XCTAssertEqual(account.userId, userId)
@@ -254,7 +256,7 @@ final class AuthRepositoryImplTests: XCTestCase {
         mockKeychain.seed(key: "bw.macos:\(userId):serverEnvironment",
                           value: String(data: try JSONEncoder().encode(env), encoding: .utf8)!)
 
-        _ = try await sut.unlockWithPassword("masterPassword1!")
+        _ = try await sut.unlockWithPassword(Data("masterPassword1!".utf8))
 
         let emailKey   = "bw.macos:\(userId):email"
         let emailReads = mockKeychain.readKeys.filter { $0 == emailKey }.count
@@ -265,7 +267,7 @@ final class AuthRepositoryImplTests: XCTestCase {
     func testUnlockWithPassword_noSession_throws() async throws {
         let sut = self.sut!
         await XCTAssertThrowsErrorAsync(
-            try await sut.unlockWithPassword("any")
+            try await sut.unlockWithPassword(Data("any".utf8))
         ) { error in
             XCTAssertEqual(error as? AuthError, .invalidCredentials)
         }

--- a/Macwarden/MacwardenTests/LoginUseCaseTests.swift
+++ b/Macwarden/MacwardenTests/LoginUseCaseTests.swift
@@ -10,9 +10,9 @@ final class LoginUseCaseTests: XCTestCase {
     private var mockAuth: MockAuthRepository!
     private var mockSync: MockSyncRepository!
 
-    private let serverURL     = "https://vault.example.com"
-    private let email         = "alice@example.com"
-    private let masterPassword = "masterPassword1!"
+    private let serverURL      = "https://vault.example.com"
+    private let email          = "alice@example.com"
+    private let masterPassword = Data("masterPassword1!".utf8)
 
     override func setUp() async throws {
         try await super.setUp()
@@ -115,6 +115,23 @@ final class LoginUseCaseTests: XCTestCase {
             return
         }
         XCTAssertTrue(mockSync.syncCalled, "Sync should still be attempted")
+    }
+
+    // MARK: - cancelTOTP
+
+    /// cancelTOTP delegates to auth.cancelTwoFactor() — clears pending in-memory key material.
+    func testCancelTOTP_callsCancelTwoFactor() async throws {
+        mockAuth.stubbedLoginResult = .requiresTwoFactor(.authenticatorApp)
+        _ = try await sut.execute(
+            serverURL:      serverURL,
+            email:          email,
+            masterPassword: masterPassword
+        )
+
+        sut.cancelTOTP()
+
+        XCTAssertTrue(mockAuth.cancelTwoFactorCalled,
+                      "cancelTOTP must forward to auth.cancelTwoFactor to clear pending key material")
     }
 
     // MARK: - Helpers

--- a/Macwarden/MacwardenTests/LoginViewModelTests.swift
+++ b/Macwarden/MacwardenTests/LoginViewModelTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import Macwarden
+
+@MainActor
+final class LoginViewModelTests: XCTestCase {
+
+    private var sut:           LoginViewModel!
+    private var mockUseCase:   MockLoginUseCase!
+
+    private func makeAccount() -> Account {
+        Account(
+            userId:            "user-001",
+            email:             "alice@example.com",
+            name:              nil,
+            serverEnvironment: ServerEnvironment(
+                base:      URL(string: "https://vault.example.com")!,
+                overrides: nil
+            )
+        )
+    }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        mockUseCase = MockLoginUseCase()
+        sut         = LoginViewModel(loginUseCase: mockUseCase)
+    }
+
+    // MARK: - signIn: password cleared on success
+
+    /// signIn() clears the password field after a successful login (Constitution §III).
+    func testSignIn_success_clearsPasswordField() async throws {
+        mockUseCase.stubbedResult = .success(makeAccount())
+        sut.serverURL = "https://vault.example.com"
+        sut.email     = "alice@example.com"
+        sut.password  = "SuperSecret1!"
+
+        sut.signIn()
+
+        // Allow the Task to complete.
+        await Task.yield()
+        try await Task.sleep(nanoseconds: 10_000_000)
+
+        XCTAssertEqual(sut.password, "", "Password field must be cleared after successful login")
+    }
+
+    /// signIn() clears the password field when the server returns .requiresTwoFactor (Constitution §III).
+    func testSignIn_requiresTwoFactor_clearsPasswordField() async throws {
+        mockUseCase.stubbedResult = .requiresTwoFactor(.authenticatorApp)
+        sut.serverURL = "https://vault.example.com"
+        sut.email     = "alice@example.com"
+        sut.password  = "SuperSecret1!"
+
+        sut.signIn()
+
+        await Task.yield()
+        try await Task.sleep(nanoseconds: 10_000_000)
+
+        XCTAssertEqual(sut.password, "", "Password field must be cleared on 2FA prompt transition")
+    }
+
+    /// signIn() with an invalid password encoding does not call the use case.
+    func testSignIn_emptyPassword_disabledState_doesNotCallUseCase() {
+        sut.serverURL = "https://vault.example.com"
+        sut.email     = "alice@example.com"
+        sut.password  = ""   // empty — button would be disabled
+
+        // signIn() is guarded by isSignInDisabled, so call it directly to confirm
+        // the use case is never reached when the button should be disabled.
+        sut.signIn()
+        XCTAssertEqual(mockUseCase.executeCallCount, 0,
+                       "execute must not be called when inputs are incomplete")
+    }
+
+    // MARK: - cancelTOTP
+
+    /// cancelTOTP() delegates to the use case and resets flow state to .login.
+    func testCancelTOTP_callsUseCaseAndResetsState() {
+        sut.cancelTOTP()
+
+        XCTAssertTrue(mockUseCase.cancelTOTPCalled,
+                      "cancelTOTP must forward to loginUseCase.cancelTOTP()")
+        XCTAssertEqual(sut.flowState, .login,
+                       "flowState must return to .login after cancelling TOTP")
+    }
+}

--- a/Macwarden/MacwardenTests/LoginViewModelTests.swift
+++ b/Macwarden/MacwardenTests/LoginViewModelTests.swift
@@ -1,11 +1,13 @@
 import XCTest
+import Combine
 @testable import Macwarden
 
 @MainActor
 final class LoginViewModelTests: XCTestCase {
 
-    private var sut:           LoginViewModel!
-    private var mockUseCase:   MockLoginUseCase!
+    private var sut:          LoginViewModel!
+    private var mockUseCase:  MockLoginUseCase!
+    private var cancellables: Set<AnyCancellable> = []
 
     private func makeAccount() -> Account {
         Account(
@@ -25,6 +27,11 @@ final class LoginViewModelTests: XCTestCase {
         sut         = LoginViewModel(loginUseCase: mockUseCase)
     }
 
+    override func tearDown() async throws {
+        cancellables.removeAll()
+        try await super.tearDown()
+    }
+
     // MARK: - signIn: password cleared on success
 
     /// signIn() clears the password field after a successful login (Constitution §III).
@@ -34,12 +41,17 @@ final class LoginViewModelTests: XCTestCase {
         sut.email     = "alice@example.com"
         sut.password  = "SuperSecret1!"
 
+        let exp = expectation(description: "password cleared after sign-in")
+        sut.$password
+            .dropFirst()
+            .filter { $0.isEmpty }
+            .first()
+            .sink { _ in exp.fulfill() }
+            .store(in: &cancellables)
+
         sut.signIn()
 
-        // Allow the Task to complete.
-        await Task.yield()
-        try await Task.sleep(nanoseconds: 10_000_000)
-
+        await fulfillment(of: [exp], timeout: 2.0)
         XCTAssertEqual(sut.password, "", "Password field must be cleared after successful login")
     }
 
@@ -50,25 +62,30 @@ final class LoginViewModelTests: XCTestCase {
         sut.email     = "alice@example.com"
         sut.password  = "SuperSecret1!"
 
+        let exp = expectation(description: "flow transitions to 2FA prompt")
+        sut.$flowState
+            .dropFirst()
+            .filter { $0 == .totpPrompt }
+            .first()
+            .sink { _ in exp.fulfill() }
+            .store(in: &cancellables)
+
         sut.signIn()
 
-        await Task.yield()
-        try await Task.sleep(nanoseconds: 10_000_000)
-
+        await fulfillment(of: [exp], timeout: 2.0)
         XCTAssertEqual(sut.password, "", "Password field must be cleared on 2FA prompt transition")
     }
 
-    /// signIn() with an invalid password encoding does not call the use case.
-    func testSignIn_emptyPassword_disabledState_doesNotCallUseCase() {
+    /// signIn() does not call the use case when password is empty (matches UI disabled-button guard).
+    func testSignIn_emptyPassword_doesNotCallUseCase() {
         sut.serverURL = "https://vault.example.com"
         sut.email     = "alice@example.com"
-        sut.password  = ""   // empty — button would be disabled
+        sut.password  = ""   // empty — guarded before Task is spawned
 
-        // signIn() is guarded by isSignInDisabled, so call it directly to confirm
-        // the use case is never reached when the button should be disabled.
         sut.signIn()
+
         XCTAssertEqual(mockUseCase.executeCallCount, 0,
-                       "execute must not be called when inputs are incomplete")
+                       "execute must not be called when password is empty")
     }
 
     // MARK: - cancelTOTP

--- a/Macwarden/MacwardenTests/Mocks/MockAuthRepository.swift
+++ b/Macwarden/MacwardenTests/Mocks/MockAuthRepository.swift
@@ -9,6 +9,7 @@ final class MockAuthRepository: AuthRepository {
     private(set) var setServerEnvironmentCalled:   Bool = false
     private(set) var loginWithPasswordCalled:      Bool = false
     private(set) var unlockWithPasswordCalled:     Bool = false
+    private(set) var cancelTwoFactorCalled:        Bool = false
     private(set) var signOutCalled:                Bool = false
     var             lockVaultCalledCount:           Int  = 0
 
@@ -49,7 +50,7 @@ final class MockAuthRepository: AuthRepository {
         setServerEnvironmentCalled   = true
     }
 
-    func loginWithPassword(email: String, masterPassword: String) async throws -> LoginResult {
+    func loginWithPassword(email: String, masterPassword: Data) async throws -> LoginResult {
         loginWithPasswordCalled = true
         if let err = loginWithPasswordError { throw err }
         return stubbedLoginResult
@@ -62,7 +63,11 @@ final class MockAuthRepository: AuthRepository {
         return account
     }
 
-    func unlockWithPassword(_ masterPassword: String) async throws -> Account {
+    func cancelTwoFactor() {
+        cancelTwoFactorCalled = true
+    }
+
+    func unlockWithPassword(_ masterPassword: Data) async throws -> Account {
         unlockWithPasswordCalled = true
         if let err = unlockWithPasswordError { throw err }
         guard case .success(let account) = stubbedLoginResult else {

--- a/Macwarden/MacwardenTests/Mocks/MockLoginUseCase.swift
+++ b/Macwarden/MacwardenTests/Mocks/MockLoginUseCase.swift
@@ -1,0 +1,50 @@
+import Foundation
+@testable import Macwarden
+
+/// Test double for `LoginUseCase`.
+@MainActor
+final class MockLoginUseCase: LoginUseCase {
+
+    // MARK: - Call tracking
+
+    private(set) var executeCallCount:    Int  = 0
+    private(set) var cancelTOTPCalled:    Bool = false
+    private(set) var completeTOTPCalled:  Bool = false
+
+    // MARK: - Stubs
+
+    var stubbedResult: LoginResult = .success(
+        Account(
+            userId:            "stub-user",
+            email:             "stub@example.com",
+            name:              nil,
+            serverEnvironment: ServerEnvironment(
+                base:      URL(string: "https://stub.example.com")!,
+                overrides: nil
+            )
+        )
+    )
+    var executeError: Error?
+    var completeTOTPError: Error?
+
+    // MARK: - LoginUseCase
+
+    func execute(serverURL: String, email: String, masterPassword: Data) async throws -> LoginResult {
+        executeCallCount += 1
+        if let err = executeError { throw err }
+        return stubbedResult
+    }
+
+    func completeTOTP(code: String, rememberDevice: Bool) async throws -> Account {
+        completeTOTPCalled = true
+        if let err = completeTOTPError { throw err }
+        guard case .success(let account) = stubbedResult else {
+            throw AuthError.invalidTwoFactorCode
+        }
+        return account
+    }
+
+    func cancelTOTP() {
+        cancelTOTPCalled = true
+    }
+}

--- a/Macwarden/MacwardenTests/Mocks/MockMacwardenAPIClient.swift
+++ b/Macwarden/MacwardenTests/Mocks/MockMacwardenAPIClient.swift
@@ -51,6 +51,10 @@ actor MockMacwardenAPIClient: MacwardenAPIClientProtocol {
         storedAccessToken = token
     }
 
+    func clearAccessToken() {
+        storedAccessToken = nil
+    }
+
     func preLogin(email: String) async throws -> PreLoginResponse {
         if let err = preLoginShouldThrow { throw err }
         return preLoginResponse ?? PreLoginResponse(

--- a/Macwarden/MacwardenTests/Mocks/MockMacwardenCryptoService.swift
+++ b/Macwarden/MacwardenTests/Mocks/MockMacwardenCryptoService.swift
@@ -27,7 +27,7 @@ actor MockMacwardenCryptoService: MacwardenCryptoService {
 
     // MARK: - MacwardenCryptoService
 
-    func makeMasterKey(password: String, email: String, kdf: KdfParams) async throws -> Data {
+    func makeMasterKey(password: Data, email: String, kdf: KdfParams) async throws -> Data {
         stubbedMasterKey
     }
 
@@ -35,7 +35,7 @@ actor MockMacwardenCryptoService: MacwardenCryptoService {
         stubbedStretchedKeys
     }
 
-    func makeServerHash(masterKey: Data, password: String) async throws -> String {
+    func makeServerHash(masterKey: Data, password: Data) async throws -> String {
         stubbedServerHash
     }
 

--- a/Macwarden/MacwardenTests/Mocks/MockSyncUseCase.swift
+++ b/Macwarden/MacwardenTests/Mocks/MockSyncUseCase.swift
@@ -1,0 +1,16 @@
+import Foundation
+@testable import Macwarden
+
+/// Test double for `SyncUseCase`.
+final class MockSyncUseCase: SyncUseCase {
+
+    private(set) var executeCalled: Bool = false
+    var stubbedResult: SyncResult = SyncResult(syncedAt: Date(), totalCiphers: 0, failedDecryptionCount: 0)
+    var executeError: Error?
+
+    func execute(progress: @Sendable @escaping (String) -> Void) async throws -> SyncResult {
+        executeCalled = true
+        if let err = executeError { throw err }
+        return stubbedResult
+    }
+}

--- a/Macwarden/MacwardenTests/UnlockUseCaseTests.swift
+++ b/Macwarden/MacwardenTests/UnlockUseCaseTests.swift
@@ -10,7 +10,7 @@ final class UnlockUseCaseTests: XCTestCase {
     private var mockAuth: MockAuthRepository!
     private var mockSync: MockSyncRepository!
 
-    private let masterPassword = "masterPassword1!"
+    private let masterPassword = Data("masterPassword1!".utf8)
 
     override func setUp() async throws {
         try await super.setUp()
@@ -39,7 +39,7 @@ final class UnlockUseCaseTests: XCTestCase {
 
         let sut = self.sut!
         await XCTAssertThrowsErrorAsync(
-            try await sut.execute(masterPassword: "wrong!")
+            try await sut.execute(masterPassword: Data("wrong!".utf8))
         ) { error in
             XCTAssertEqual(error as? AuthError, .invalidCredentials)
         }
@@ -64,7 +64,7 @@ final class UnlockUseCaseTests: XCTestCase {
         mockAuth.unlockWithPasswordError   = AuthError.invalidCredentials
         mockAuth.lockVaultCalledCount      = 0
 
-        _ = try? await sut.execute(masterPassword: "wrong!")
+        _ = try? await sut.execute(masterPassword: Data("wrong!".utf8))
 
         XCTAssertEqual(mockAuth.lockVaultCalledCount, 0,
                        "lockVault must not be called on wrong password — session stays intact")

--- a/Macwarden/MacwardenTests/UnlockViewModelTests.swift
+++ b/Macwarden/MacwardenTests/UnlockViewModelTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import Macwarden
+
+@MainActor
+final class UnlockViewModelTests: XCTestCase {
+
+    private var sut:         UnlockViewModel!
+    private var mockAuth:    MockAuthRepository!
+    private var mockSync:    MockSyncUseCase!
+
+    private let stubAccount = Account(
+        userId:            "user-001",
+        email:             "alice@example.com",
+        name:              nil,
+        serverEnvironment: ServerEnvironment(
+            base:      URL(string: "https://vault.example.com")!,
+            overrides: nil
+        )
+    )
+
+    override func setUp() async throws {
+        try await super.setUp()
+        mockAuth = MockAuthRepository()
+        mockSync = MockSyncUseCase()
+        sut      = UnlockViewModel(auth: mockAuth, sync: mockSync, account: stubAccount)
+    }
+
+    // MARK: - unlock: password cleared on success
+
+    /// unlock() clears the password field after a successful unlock (Constitution §III).
+    func testUnlock_success_clearsPasswordField() async throws {
+        mockAuth.stubbedLoginResult = .success(stubAccount)
+        sut.password = "SuperSecret1!"
+
+        sut.unlock()
+
+        await Task.yield()
+        try await Task.sleep(nanoseconds: 10_000_000)
+
+        XCTAssertEqual(sut.password, "", "Password field must be cleared after successful unlock")
+    }
+
+    /// unlock() does NOT clear the password field on wrong password so the user can correct it.
+    func testUnlock_wrongPassword_retainsPasswordField() async throws {
+        mockAuth.unlockWithPasswordError = AuthError.invalidCredentials
+        sut.password = "WrongPassword!"
+
+        sut.unlock()
+
+        await Task.yield()
+        try await Task.sleep(nanoseconds: 10_000_000)
+
+        XCTAssertEqual(sut.password, "WrongPassword!",
+                       "Password field must be retained on failed unlock so the user can correct it")
+    }
+
+    /// unlock() surfaces an error message on wrong password.
+    func testUnlock_wrongPassword_setsErrorMessage() async throws {
+        mockAuth.unlockWithPasswordError = AuthError.invalidCredentials
+        sut.password = "WrongPassword!"
+
+        sut.unlock()
+
+        await Task.yield()
+        try await Task.sleep(nanoseconds: 10_000_000)
+
+        XCTAssertNotNil(sut.errorMessage, "An error message must be shown on failed unlock")
+    }
+
+    /// email property returns the stored account's email address.
+    func testEmail_returnsStoredAccountEmail() {
+        XCTAssertEqual(sut.email, "alice@example.com")
+    }
+}

--- a/Macwarden/MacwardenTests/UnlockViewModelTests.swift
+++ b/Macwarden/MacwardenTests/UnlockViewModelTests.swift
@@ -1,12 +1,14 @@
 import XCTest
+import Combine
 @testable import Macwarden
 
 @MainActor
 final class UnlockViewModelTests: XCTestCase {
 
-    private var sut:         UnlockViewModel!
-    private var mockAuth:    MockAuthRepository!
-    private var mockSync:    MockSyncUseCase!
+    private var sut:          UnlockViewModel!
+    private var mockAuth:     MockAuthRepository!
+    private var mockSync:     MockSyncUseCase!
+    private var cancellables: Set<AnyCancellable> = []
 
     private let stubAccount = Account(
         userId:            "user-001",
@@ -25,6 +27,11 @@ final class UnlockViewModelTests: XCTestCase {
         sut      = UnlockViewModel(auth: mockAuth, sync: mockSync, account: stubAccount)
     }
 
+    override func tearDown() async throws {
+        cancellables.removeAll()
+        try await super.tearDown()
+    }
+
     // MARK: - unlock: password cleared on success
 
     /// unlock() clears the password field after a successful unlock (Constitution §III).
@@ -32,40 +39,53 @@ final class UnlockViewModelTests: XCTestCase {
         mockAuth.stubbedLoginResult = .success(stubAccount)
         sut.password = "SuperSecret1!"
 
+        let exp = expectation(description: "password cleared after unlock")
+        sut.$password
+            .dropFirst()
+            .filter { $0.isEmpty }
+            .first()
+            .sink { _ in exp.fulfill() }
+            .store(in: &cancellables)
+
         sut.unlock()
 
-        await Task.yield()
-        try await Task.sleep(nanoseconds: 10_000_000)
-
+        await fulfillment(of: [exp], timeout: 2.0)
         XCTAssertEqual(sut.password, "", "Password field must be cleared after successful unlock")
+    }
+
+    // MARK: - unlock: wrong password
+
+    /// Configures a wrong-password unlock and waits for the async Task to complete.
+    /// Both wrong-password assertions share this setup to avoid duplication.
+    private func runUnlockWithWrongPassword() async {
+        mockAuth.unlockWithPasswordError = AuthError.invalidCredentials
+        sut.password = "WrongPassword!"
+
+        let exp = expectation(description: "unlock fails with error message")
+        sut.$errorMessage
+            .compactMap { $0 }
+            .first()
+            .sink { _ in exp.fulfill() }
+            .store(in: &cancellables)
+
+        sut.unlock()
+        await fulfillment(of: [exp], timeout: 2.0)
     }
 
     /// unlock() does NOT clear the password field on wrong password so the user can correct it.
     func testUnlock_wrongPassword_retainsPasswordField() async throws {
-        mockAuth.unlockWithPasswordError = AuthError.invalidCredentials
-        sut.password = "WrongPassword!"
-
-        sut.unlock()
-
-        await Task.yield()
-        try await Task.sleep(nanoseconds: 10_000_000)
-
+        await runUnlockWithWrongPassword()
         XCTAssertEqual(sut.password, "WrongPassword!",
                        "Password field must be retained on failed unlock so the user can correct it")
     }
 
     /// unlock() surfaces an error message on wrong password.
     func testUnlock_wrongPassword_setsErrorMessage() async throws {
-        mockAuth.unlockWithPasswordError = AuthError.invalidCredentials
-        sut.password = "WrongPassword!"
-
-        sut.unlock()
-
-        await Task.yield()
-        try await Task.sleep(nanoseconds: 10_000_000)
-
+        await runUnlockWithWrongPassword()
         XCTAssertNotNil(sut.errorMessage, "An error message must be shown on failed unlock")
     }
+
+    // MARK: - email property
 
     /// email property returns the stored account's email address.
     func testEmail_returnsStoredAccountEmail() {

--- a/Macwarden/Presentation/AccessibilityIdentifiers.swift
+++ b/Macwarden/Presentation/AccessibilityIdentifiers.swift
@@ -23,6 +23,7 @@ nonisolated enum AccessibilityID {
         static let codeField         = "totp.code"
         static let rememberToggle    = "totp.remember"
         static let continueButton    = "totp.continue"
+        static let cancelButton      = "totp.cancel"
         static let errorMessage      = "totp.error"
         static let headerTitle       = "totp.headerTitle"
     }

--- a/Macwarden/Presentation/Components/FieldRowView.swift
+++ b/Macwarden/Presentation/Components/FieldRowView.swift
@@ -1,14 +1,5 @@
 import SwiftUI
 
-// MARK: - FieldRowAction
-
-/// Actions that can appear on hover for a field row.
-enum FieldRowAction {
-    case copy
-    case reveal
-    case openInBrowser(URL)
-}
-
 // MARK: - FieldRowView
 
 /// A single labeled field row with hover-activated action buttons (FR-023, FR-025).

--- a/Macwarden/Presentation/Components/VerticalLabeledContentStyle.swift
+++ b/Macwarden/Presentation/Components/VerticalLabeledContentStyle.swift
@@ -8,7 +8,7 @@ struct VerticalLabeledContentStyle: LabeledContentStyle {
     func makeBody(configuration: Configuration) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             configuration.label
-                .font(.callout.weight(.medium))
+                .font(Typography.fieldLabelProminent)
                 .foregroundStyle(.secondary)
             configuration.content
         }

--- a/Macwarden/Presentation/DesignSystem.swift
+++ b/Macwarden/Presentation/DesignSystem.swift
@@ -36,6 +36,15 @@ enum Typography {
 
     /// Status banner text (e.g. "This item is in Trash.") — slightly larger than utility/caption.
     static let bannerText: Font    = .callout
+
+    /// Large icon on the Login, TOTP, and Unlock screens (keyhole / app symbol).
+    static let screenIcon: Font    = .system(size: 48)
+
+    /// Primary heading on the Login, TOTP, and Unlock screens ("Welcome to Macwarden").
+    static let screenHeading: Font = .title.bold()
+
+    /// Secondary body copy on the Login, TOTP, and Unlock screens.
+    static let screenBody: Font    = .callout
 }
 
 // MARK: - Spacing
@@ -68,4 +77,13 @@ enum Spacing {
 
     /// Horizontal padding inside a field row (left and right).
     static let rowHorizontal: CGFloat = 12
+
+    /// Uniform padding inside the item metadata footer (created / updated dates).
+    static let footerPadding: CGFloat = 12
+
+    /// Horizontal padding inside status banners (sync error, trash banner).
+    static let bannerHorizontal: CGFloat = 12
+
+    /// Vertical padding inside status banners.
+    static let bannerVertical: CGFloat = 8
 }

--- a/Macwarden/Presentation/DesignSystem.swift
+++ b/Macwarden/Presentation/DesignSystem.swift
@@ -41,6 +41,10 @@ enum Typography {
     /// Semibold weight distinguishes it from regular body copy in loading contexts.
     static let progressLabel: Font = .headline
 
+    /// Inline field label shown above a form input (e.g. "Authentication code").
+    /// Slightly heavier than `fieldLabel` to visually separate it from body content.
+    static let fieldLabelProminent: Font = .callout.weight(.medium)
+
     /// Large icon on the Login, TOTP, and Unlock screens (keyhole / app symbol).
     static let screenIcon: Font    = .system(size: 48)
 
@@ -93,4 +97,7 @@ enum Spacing {
 
     /// Inner padding for read-only display fields (e.g. the email chip on UnlockView).
     static let readOnlyField: CGFloat = 6
+
+    /// Horizontal padding on full-screen auth/sync flows (Login, TOTP, Unlock, SyncProgress).
+    static let screenHorizontal: CGFloat = 40
 }

--- a/Macwarden/Presentation/DesignSystem.swift
+++ b/Macwarden/Presentation/DesignSystem.swift
@@ -37,6 +37,10 @@ enum Typography {
     /// Status banner text (e.g. "This item is in Trash.") — slightly larger than utility/caption.
     static let bannerText: Font    = .callout
 
+    /// Prominent status label on loading/syncing screens (e.g. "Fetching vault…").
+    /// Semibold weight distinguishes it from regular body copy in loading contexts.
+    static let progressLabel: Font = .headline
+
     /// Large icon on the Login, TOTP, and Unlock screens (keyhole / app symbol).
     static let screenIcon: Font    = .system(size: 48)
 
@@ -86,4 +90,7 @@ enum Spacing {
 
     /// Vertical padding inside status banners.
     static let bannerVertical: CGFloat = 8
+
+    /// Inner padding for read-only display fields (e.g. the email chip on UnlockView).
+    static let readOnlyField: CGFloat = 6
 }

--- a/Macwarden/Presentation/Login/LoginView.swift
+++ b/Macwarden/Presentation/Login/LoginView.swift
@@ -96,7 +96,7 @@ struct LoginView: View {
 
             Spacer()
         }
-        .padding(.horizontal, 40)
+        .padding(.horizontal, Spacing.screenHorizontal)
         .padding(.bottom, 32)
         .frame(minWidth: 480, minHeight: 400)
         .onAppear { focusedField = .serverURL }

--- a/Macwarden/Presentation/Login/LoginView.swift
+++ b/Macwarden/Presentation/Login/LoginView.swift
@@ -22,10 +22,10 @@ struct LoginView: View {
             // MARK: Header
             VStack(spacing: 4) {
                 Image(systemName: "lock.shield.fill")
-                    .font(.system(size: 48))
+                    .font(Typography.screenIcon)
                     .foregroundStyle(.tint)
                 Text("Macwarden")
-                    .font(.title.bold())
+                    .font(Typography.screenHeading)
                 Text("Self-hosted vault")
                     .font(Typography.fieldLabel)
                     .foregroundStyle(.secondary)
@@ -69,7 +69,7 @@ struct LoginView: View {
             // MARK: Error message
             if let error = viewModel.errorMessage {
                 Text(error)
-                    .font(.callout)
+                    .font(Typography.screenBody)
                     .foregroundStyle(.red)
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: 360)

--- a/Macwarden/Presentation/Login/LoginViewModel.swift
+++ b/Macwarden/Presentation/Login/LoginViewModel.swift
@@ -49,16 +49,28 @@ final class LoginViewModel: ObservableObject {
         errorMessage = nil
         flowState    = .loading
 
+        // Convert the password String to Data at this boundary — the only place the
+        // String-to-bytes conversion happens. `Data` can be zeroed after the KDF call;
+        // `String` cannot (Constitution §III).
+        guard let passwordData = password.data(using: .utf8) else {
+            errorMessage = "Invalid password encoding."
+            flowState    = .login
+            return
+        }
+
         Task {
             do {
                 let result = try await loginUseCase.execute(
                     serverURL:      serverURL,
                     email:          email,
-                    masterPassword: password
+                    masterPassword: passwordData
                 )
 
                 switch result {
                 case .success:
+                    // Clear the password field so the plaintext does not linger in
+                    // the published property (and therefore the SwiftUI state graph).
+                    password  = ""
                     flowState = .vault
 
                 case .requiresTwoFactor(let method):
@@ -68,6 +80,7 @@ final class LoginViewModel: ObservableObject {
                         }
                         throw AuthError.invalidCredentials
                     }
+                    password  = ""
                     flowState = .totpPrompt
                 }
 
@@ -81,6 +94,12 @@ final class LoginViewModel: ObservableObject {
                 flowState    = .login
             }
         }
+    }
+
+    /// Cancels the pending TOTP challenge and returns to the login screen.
+    func cancelTOTP() {
+        loginUseCase.cancelTOTP()
+        flowState = .login
     }
 
     /// Completes a pending TOTP 2FA challenge.

--- a/Macwarden/Presentation/Login/LoginViewModel.swift
+++ b/Macwarden/Presentation/Login/LoginViewModel.swift
@@ -52,7 +52,9 @@ final class LoginViewModel: ObservableObject {
         // Convert the password String to Data at this boundary — the only place the
         // String-to-bytes conversion happens. `Data` can be zeroed after the KDF call;
         // `String` cannot (Constitution §III).
-        guard let passwordData = password.data(using: .utf8) else {
+        // Reject empty password here to match the UI's disabled-button guard.
+        // The Task below must never be spawned with an empty credential.
+        guard let passwordData = password.data(using: .utf8), !passwordData.isEmpty else {
             errorMessage = "Invalid password encoding."
             flowState    = .login
             return

--- a/Macwarden/Presentation/Login/TOTPPromptView.swift
+++ b/Macwarden/Presentation/Login/TOTPPromptView.swift
@@ -19,13 +19,13 @@ struct TOTPPromptView: View {
             // MARK: Header
             VStack(spacing: 4) {
                 Image(systemName: "key.2.on.ring.fill")
-                    .font(.system(size: 48))
+                    .font(Typography.screenIcon)
                     .foregroundStyle(.tint)
                 Text("Two-step login")
-                    .font(.title.bold())
+                    .font(Typography.screenHeading)
                     .accessibilityIdentifier(AccessibilityID.TOTP.headerTitle)
                 Text("Enter the 6-digit code from your authenticator app.")
-                    .font(.subheadline)
+                    .font(Typography.fieldLabel)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
             }
@@ -56,7 +56,7 @@ struct TOTPPromptView: View {
             // MARK: Error message
             if let error = viewModel.errorMessage {
                 Text(error)
-                    .font(.callout)
+                    .font(Typography.screenBody)
                     .foregroundStyle(.red)
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: 360)
@@ -78,6 +78,16 @@ struct TOTPPromptView: View {
             .disabled(isSubmitDisabled)
             .keyboardShortcut(.return, modifiers: [])
             .accessibilityIdentifier(AccessibilityID.TOTP.continueButton)
+
+            // MARK: Cancel button
+            // Cancelling clears in-memory key material (stretched keys + password hash)
+            // that was retained from the initial password-login step (Constitution §III).
+            Button("Cancel") {
+                viewModel.cancelTOTP()
+            }
+            .buttonStyle(.borderless)
+            .foregroundStyle(.secondary)
+            .accessibilityIdentifier(AccessibilityID.TOTP.cancelButton)
 
             Spacer()
         }

--- a/Macwarden/Presentation/Login/TOTPPromptView.swift
+++ b/Macwarden/Presentation/Login/TOTPPromptView.swift
@@ -34,7 +34,7 @@ struct TOTPPromptView: View {
             // MARK: Code field
             VStack(alignment: .leading, spacing: 4) {
                 Text("Authentication code")
-                    .font(.callout.weight(.medium))
+                    .font(Typography.fieldLabelProminent)
                     .foregroundStyle(.secondary)
                 TextField("000000", text: $totpCode)
                     .textFieldStyle(.roundedBorder)
@@ -91,7 +91,7 @@ struct TOTPPromptView: View {
 
             Spacer()
         }
-        .padding(.horizontal, 40)
+        .padding(.horizontal, Spacing.screenHorizontal)
         .padding(.bottom, 32)
         .frame(minWidth: 480, minHeight: 360)
         .onAppear { codeFieldFocused = true }

--- a/Macwarden/Presentation/Sync/SyncProgressView.swift
+++ b/Macwarden/Presentation/Sync/SyncProgressView.swift
@@ -26,6 +26,6 @@ struct SyncProgressView: View {
                 .accessibilityIdentifier(AccessibilityID.Sync.progressMessage)
         }
         .frame(minWidth: 480, minHeight: 320)
-        .padding(40)
+        .padding(Spacing.screenHorizontal)
     }
 }

--- a/Macwarden/Presentation/Sync/SyncProgressView.swift
+++ b/Macwarden/Presentation/Sync/SyncProgressView.swift
@@ -20,7 +20,7 @@ struct SyncProgressView: View {
                 .padding(.bottom, 8)
 
             Text(message)
-                .font(.headline)
+                .font(Typography.progressLabel)
                 .foregroundStyle(.secondary)
                 .animation(.easeInOut, value: message)
                 .accessibilityIdentifier(AccessibilityID.Sync.progressMessage)

--- a/Macwarden/Presentation/Unlock/UnlockView.swift
+++ b/Macwarden/Presentation/Unlock/UnlockView.swift
@@ -91,7 +91,7 @@ struct UnlockView: View {
 
             Spacer()
         }
-        .padding(.horizontal, 40)
+        .padding(.horizontal, Spacing.screenHorizontal)
         .padding(.bottom, 32)
         .frame(minWidth: 480, minHeight: 400)
         .onAppear { passwordFocused = true }

--- a/Macwarden/Presentation/Unlock/UnlockView.swift
+++ b/Macwarden/Presentation/Unlock/UnlockView.swift
@@ -17,10 +17,10 @@ struct UnlockView: View {
             // MARK: Header
             VStack(spacing: 4) {
                 Image(systemName: "lock.fill")
-                    .font(.system(size: 48))
+                    .font(Typography.screenIcon)
                     .foregroundStyle(.tint)
                 Text("Vault locked")
-                    .font(.title.bold())
+                    .font(Typography.screenHeading)
                     .accessibilityIdentifier(AccessibilityID.Unlock.headerTitle)
                 Text("Enter your master password to unlock.")
                     .font(Typography.fieldLabel)
@@ -35,7 +35,7 @@ struct UnlockView: View {
                     Text(viewModel.email)
                         .foregroundStyle(.primary)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(6)
+                        .padding(Spacing.readOnlyField)
                         .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
                         .accessibilityIdentifier(AccessibilityID.Unlock.emailLabel)
                 }
@@ -55,7 +55,7 @@ struct UnlockView: View {
             // MARK: Error message
             if let error = viewModel.errorMessage {
                 Text(error)
-                    .font(.callout)
+                    .font(Typography.screenBody)
                     .foregroundStyle(.red)
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: 360)
@@ -85,7 +85,7 @@ struct UnlockView: View {
                 viewModel.signInWithDifferentAccount()
             }
             .buttonStyle(.plain)
-            .font(.callout)
+            .font(Typography.screenBody)
             .foregroundStyle(.secondary)
             .accessibilityIdentifier(AccessibilityID.Unlock.switchAccount)
 

--- a/Macwarden/Presentation/Unlock/UnlockViewModel.swift
+++ b/Macwarden/Presentation/Unlock/UnlockViewModel.swift
@@ -55,9 +55,20 @@ final class UnlockViewModel: ObservableObject {
         errorMessage = nil
         flowState    = .loading
 
+        // Convert the password String to Data at this boundary so the KDF stack
+        // receives `Data` that can be zeroed after use (Constitution §III).
+        guard let passwordData = password.data(using: .utf8) else {
+            errorMessage = "Invalid password encoding."
+            flowState    = .unlock
+            return
+        }
+
         Task {
             do {
-                _ = try await auth.unlockWithPassword(password)
+                _ = try await auth.unlockWithPassword(passwordData)
+                // Clear the password field after a successful unlock so the plaintext
+                // does not linger in the published property.
+                password = ""
                 await performSync()
             } catch let err as AuthError {
                 logger.error("Unlock failed: \(err.localizedDescription, privacy: .public)")

--- a/Macwarden/Presentation/Vault/Detail/CustomFieldsSection.swift
+++ b/Macwarden/Presentation/Vault/Detail/CustomFieldsSection.swift
@@ -29,7 +29,7 @@ struct CustomFieldsSection: View {
                     .font(Typography.fieldLabel)
                     .foregroundStyle(.secondary)
                     .padding(.top, Spacing.headerGap)
-                    .padding(.horizontal, 8)
+                    .padding(.horizontal, Spacing.headerGap)
             }
         }
     }

--- a/Macwarden/Presentation/Vault/Detail/ItemDetailView.swift
+++ b/Macwarden/Presentation/Vault/Detail/ItemDetailView.swift
@@ -82,7 +82,7 @@ struct ItemDetailView: View {
             Label("Updated \(item.revisionDate.formatted(date: .abbreviated, time: .omitted))", systemImage: "clock")
                 .font(Typography.utility).foregroundStyle(.secondary)
         }
-        .padding(12)
+        .padding(Spacing.footerPadding)
     }
 
     @ViewBuilder

--- a/Macwarden/Presentation/Vault/Edit/ItemEditViewModel.swift
+++ b/Macwarden/Presentation/Vault/Edit/ItemEditViewModel.swift
@@ -55,7 +55,8 @@ final class ItemEditViewModel: ObservableObject {
     // MARK: - Private state
 
     /// Snapshot of the item as it was when the sheet opened — used for `hasChanges`.
-    private let original: DraftVaultItem
+    /// `var` so `clearDraft()` can overwrite it with a blank sentinel (Constitution §III).
+    private var original: DraftVaultItem
 
     private let editUseCase: (any EditVaultItemUseCase)?
     private let createUseCase: (any CreateVaultItemUseCase)?
@@ -137,8 +138,11 @@ final class ItemEditViewModel: ObservableObject {
     /// held in the heap. Swift ARC may retain additional copies; this removes the primary
     /// reference held by this ViewModel.
     func clearDraft() {
-        // Replace with a minimal no-op draft to release any large string values.
-        draft = DraftVaultItem(VaultItem(
+        // Replace both draft and original with a blank sentinel to release all
+        // string values (passwords, keys, notes) from the heap (Constitution §III).
+        // `original` must also be cleared — it holds a full snapshot of the item
+        // as it was when the sheet opened, including any sensitive plaintext fields.
+        let blank = DraftVaultItem(VaultItem(
             id: original.id,
             name: "",
             isFavorite: false,
@@ -147,6 +151,8 @@ final class ItemEditViewModel: ObservableObject {
             revisionDate: original.revisionDate,
             content: .secureNote(SecureNoteContent(notes: nil, customFields: []))
         ))
+        draft    = blank
+        original = blank
     }
 
     // MARK: - Vault lock observation

--- a/Macwarden/Presentation/Vault/VaultBrowserView.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserView.swift
@@ -14,7 +14,6 @@ struct VaultBrowserView: View {
     let faviconLoader: FaviconLoader
     let makeEditViewModel: (VaultItem) -> ItemEditViewModel
     let makeCreateViewModel: (ItemType) -> ItemEditViewModel
-    var onEditSheetState: ((Bool) -> Void)? = nil
 
     @State private var showSoftDeleteAlert = false
     @State private var showPermanentDeleteAlert = false
@@ -82,10 +81,7 @@ struct VaultBrowserView: View {
                     faviconLoader:       faviconLoader,
                     onCopy:              { viewModel.copy($0) },
                     makeEditViewModel:   makeEditViewModel,
-                    onEditSheetChanged:  { open in
-                        viewModel.handleEditSheetState(open)
-                        onEditSheetState?(open)
-                    },
+                    onEditSheetChanged: { viewModel.handleEditSheetState($0) },
                     onSoftDelete:        { id in await viewModel.performSoftDelete(id: id) },
                     onRestore:           { id in await viewModel.performRestore(id: id) },
                     onPermanentDelete:   { id in await viewModel.performPermanentDelete(id: id) },
@@ -196,8 +192,8 @@ struct VaultBrowserView: View {
                 .help("Dismiss")
                 .accessibilityIdentifier(AccessibilityID.Vault.syncErrorDismiss)
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
+            .padding(.horizontal, Spacing.bannerHorizontal)
+            .padding(.vertical, Spacing.bannerVertical)
             .background(Color.yellow.opacity(0.15))
             .frame(maxHeight: 44)
             .accessibilityIdentifier(AccessibilityID.Vault.syncErrorBanner)

--- a/Macwarden/Presentation/Vault/VaultBrowserView.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserView.swift
@@ -180,7 +180,7 @@ struct VaultBrowserView: View {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundStyle(.yellow)
                 Text(message)
-                    .font(.callout)
+                    .font(Typography.bannerText)
                 Spacer()
                 Button {
                     viewModel.dismissSyncError()


### PR DESCRIPTION
## Summary

- **Security**: master password and unlock password passed as `Data` (not `String`) through the full stack so key material can be zeroed after use; `cancelTwoFactor()` explicitly zeros stretched key buffers before releasing pending 2FA state; `signOut()` clears the access token; HTTPS-only enforcement for server URLs
- **Design system**: all raw font/spacing literals in views replaced with `Typography.*` and `Spacing.*` tokens; new tokens added to `DesignSystem.swift` (`screenIcon`, `screenHeading`, `screenBody`, `progressLabel`, `fieldLabelProminent`, `screenHorizontal`, `readOnlyField`)
- **Cancel 2FA**: added `cancelTwoFactor()` through the full stack (repository → use case → view model) with a Cancel button in `TOTPPromptView`
- **Test reliability**: replaced `Task.yield() + Task.sleep(10ms)` timing hacks in `LoginViewModelTests` and `UnlockViewModelTests` with Combine `$password`/`$flowState`/`$errorMessage` subscriptions + `fulfillment(of:timeout:)`; extracted shared `runUnlockWithWrongPassword()` helper; added `MockLoginUseCase` and `MockSyncUseCase`

## Test plan

- [x] Build succeeds with no warnings
- [x] All existing unit tests pass
- [x] `LoginViewModelTests` — sign-in clears password on success and on 2FA transition; empty password does not call use case; `cancelTOTP` resets state
- [x] `UnlockViewModelTests` — unlock clears password on success; wrong password retains field and shows error
- [x] `AuthRepositoryImplTests` — `cancelTwoFactor` clears pending state; HTTP URL throws; TOTP flow completes
- [x] Manual: login → 2FA prompt → Cancel returns to login screen with no credential leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)