### PR TITLE
feat: global search with ⌘F and match highlighting

### DIFF
--- a/Macwarden/Macwarden.xcodeproj/project.pbxproj
+++ b/Macwarden/Macwarden.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		A2B3C4D5E6F74718B9C0D1E2 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8F9A0B1C2D3E4F5A6B7C8D /* KeychainService.swift */; };
 		A2D9C5FB40924655AABA3088 /* SyncProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DBDEAA0270497F84F76A29 /* SyncProgressView.swift */; };
 		A7E3F19B8C2D4A61B04DE723 /* SearchVaultUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B41D0A2F7E54938AE12C8B5 /* SearchVaultUseCaseImpl.swift */; };
+		A96C7D84DE3B404CA450285C /* CreateVaultItemUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B465482A0CFB4710AD4727CB /* CreateVaultItemUseCaseImpl.swift */; };
 		AA0001010000000100000001 /* RandomnessProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0002010000000100000001 /* RandomnessProvider.swift */; };
 		AA0001020000000200000002 /* PasswordGeneratorConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0002020000000200000002 /* PasswordGeneratorConfig.swift */; };
 		AA0001030000000300000003 /* PasswordGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0002030000000300000003 /* PasswordGenerator.swift */; };
@@ -65,13 +66,13 @@
 		AA1122334455667788990011 /* OptionKeyMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2233445566778899001122 /* OptionKeyMonitor.swift */; };
 		AA11BB22CC3344DD55EE66FF /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB22CC33DD4455EE66FF7700 /* AccessibilityIdentifiers.swift */; };
 		AB64508ED7804841AAC551A0 /* KdfParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25C290F2D7A470EB4AB8698 /* KdfParams.swift */; };
+		AC3EC95F694247B5A5809233 /* CreateVaultItemUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A335CC7B3C743B59A7630D8 /* CreateVaultItemUseCase.swift */; };
 		B11759DE56D34E4199773C2D /* FieldRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E105187F1E54E0E91E82B14 /* FieldRowView.swift */; };
 		B2390AAAD10D4CE69AD6660C /* AuthRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DA2B1AD4924580BCE20BF3 /* AuthRepositoryImpl.swift */; };
 		B2C3D4E5F6A748B9C0D1E2F3 /* EncString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBB82A6241244DD890E615C /* EncString.swift */; };
 		C290678FFC8F4FDDB215C261 /* LoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257FAE34CC064783806B6A5C /* LoginUseCase.swift */; };
 		C3D2E3F400A1B05B50607080 /* SecureNoteEditForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E3F400A1B2C06C60708090 /* SecureNoteEditForm.swift */; };
 		C3D4E5F607182940B5C6D7E8 /* EditVaultItemUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F6071829304AC6D7E8F9 /* EditVaultItemUseCase.swift */; };
-		AC3EC95F694247B5A5809233 /* CreateVaultItemUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A335CC7B3C743B59A7630D8 /* CreateVaultItemUseCase.swift */; };
 		C3D4E5F6A7B849C0D1E2F3A4 /* MacwardenCryptoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D710BEABBB4ADD9ADFCD1F /* MacwardenCryptoService.swift */; };
 		C3DDB598E8834E85833D86FE /* VaultBrowserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F177A6089741F69C02E285 /* VaultBrowserViewModel.swift */; };
 		C8951B673C224D76A33775A1 /* UnlockViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AFBFFDE4FCE4BD28D3C8E9A /* UnlockViewModel.swift */; };
@@ -85,7 +86,6 @@
 		E17D4DA652374B49BC2CD6B1 /* VaultBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D9916B5072420494DE6F9F /* VaultBrowserView.swift */; };
 		E5F400A1B2C3D07D70809000 /* SSHKeyEditForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = F600A1B2C3D4E08E80900A1B /* SSHKeyEditForm.swift */; };
 		E5F607182930405BD7E8F90A /* EditVaultItemUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = F607182930405A6CE8F90A1B /* EditVaultItemUseCaseImpl.swift */; };
-		A96C7D84DE3B404CA450285C /* CreateVaultItemUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B465482A0CFB4710AD4727CB /* CreateVaultItemUseCaseImpl.swift */; };
 		E5F6A7B8C9D04BE2F3A4B5C6 /* SyncResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F3A553820942CF9B3935FD /* SyncResponse.swift */; };
 		E7772DAF3F324B8A807B7491 /* ItemRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6631A93BC5EA4827BC497076 /* ItemRowView.swift */; };
 		EE11223344556677889900BB /* DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00112233445566778899AA /* DesignSystem.swift */; };
@@ -136,6 +136,7 @@
 		4D6A671692BE497AA7E39F45 /* SyncRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncRepositoryImpl.swift; sourceTree = "<group>"; };
 		4F246F209ADA45F99C9B17DB /* LoginDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginDetailView.swift; sourceTree = "<group>"; };
 		50445584AD814B6EBD971FDA /* FaviconLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconLoader.swift; sourceTree = "<group>"; };
+		5A335CC7B3C743B59A7630D8 /* CreateVaultItemUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateVaultItemUseCase.swift; sourceTree = "<group>"; };
 		5C607080900A10E4E5F60718 /* EditFieldRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditFieldRow.swift; sourceTree = "<group>"; };
 		5EBA517603CA448A8F9106AF /* SyncUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncUseCase.swift; sourceTree = "<group>"; };
 		6631A93BC5EA4827BC497076 /* ItemRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemRowView.swift; sourceTree = "<group>"; };
@@ -167,6 +168,7 @@
 		AA0002070000000700000007 /* eff-large-wordlist.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "eff-large-wordlist.txt"; sourceTree = "<group>"; };
 		B2C1D2E3F400A04A40506070 /* IdentityEditForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityEditForm.swift; sourceTree = "<group>"; };
 		B2D3E4F506172839A4B5C6D7 /* DraftVaultItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftVaultItem.swift; sourceTree = "<group>"; };
+		B465482A0CFB4710AD4727CB /* CreateVaultItemUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateVaultItemUseCaseImpl.swift; sourceTree = "<group>"; };
 		B65E7D6288C347DCA88A20DF /* AuthRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRepository.swift; sourceTree = "<group>"; };
 		BB2233445566778899001122 /* OptionKeyMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionKeyMonitor.swift; sourceTree = "<group>"; };
 		BB22CC33DD4455EE66FF7700 /* AccessibilityIdentifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityIdentifiers.swift; sourceTree = "<group>"; };
@@ -174,7 +176,6 @@
 		D4C3B2A1F6E54789D4C3B2A1 /* VerticalLabeledContentStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalLabeledContentStyle.swift; sourceTree = "<group>"; };
 		D4E3F400A1B2C06C60708090 /* SecureNoteEditForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureNoteEditForm.swift; sourceTree = "<group>"; };
 		D4E5F6071829304AC6D7E8F9 /* EditVaultItemUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditVaultItemUseCase.swift; sourceTree = "<group>"; };
-		5A335CC7B3C743B59A7630D8 /* CreateVaultItemUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateVaultItemUseCase.swift; sourceTree = "<group>"; };
 		D7044163F8FD4199B4925DD2 /* SidebarSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSelection.swift; sourceTree = "<group>"; };
 		D8D710BEABBB4ADD9ADFCD1F /* MacwardenCryptoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacwardenCryptoService.swift; sourceTree = "<group>"; };
 		DF8949A6D242488CBEC15CC0 /* ItemListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListView.swift; sourceTree = "<group>"; };
@@ -190,7 +191,6 @@
 		F5F177A6089741F69C02E285 /* VaultBrowserViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultBrowserViewModel.swift; sourceTree = "<group>"; };
 		F600A1B2C3D4E08E80900A1B /* SSHKeyEditForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHKeyEditForm.swift; sourceTree = "<group>"; };
 		F607182930405A6CE8F90A1B /* EditVaultItemUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditVaultItemUseCaseImpl.swift; sourceTree = "<group>"; };
-		B465482A0CFB4710AD4727CB /* CreateVaultItemUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateVaultItemUseCaseImpl.swift; sourceTree = "<group>"; };
 		F641DA62DF364B3C9D896204 /* TOTPPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOTPPromptView.swift; sourceTree = "<group>"; };
 		F8197007AA7E412D96A52B14 /* MaskedFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskedFieldView.swift; sourceTree = "<group>"; };
 		F95EFA050DE64617AC5076CD /* CustomFieldsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldsSection.swift; sourceTree = "<group>"; };

--- a/Macwarden/MacwardenTests/HighlightedTextTests.swift
+++ b/Macwarden/MacwardenTests/HighlightedTextTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import Macwarden
+
+final class HighlightedTextTests: XCTestCase {
+
+    // MARK: - Match applies bold
+
+    func testHighlightedText_matchAppliesBold() {
+        let result = ItemRowView.highlightedText("Hello World", query: "World")
+        let runs = Array(result.runs)
+        XCTAssertEqual(runs.count, 2)
+        XCTAssertNil(runs[0].attributes.inlinePresentationIntent)
+        XCTAssertEqual(runs[1].attributes.inlinePresentationIntent, .stronglyEmphasized)
+    }
+
+    // MARK: - No match returns plain
+
+    func testHighlightedText_noMatch_returnsPlain() {
+        let result = ItemRowView.highlightedText("Hello World", query: "xyz")
+        let runs = Array(result.runs)
+        XCTAssertEqual(runs.count, 1)
+        XCTAssertNil(runs[0].attributes.inlinePresentationIntent)
+    }
+
+    // MARK: - Case-insensitive matching
+
+    func testHighlightedText_caseInsensitive() {
+        let result = ItemRowView.highlightedText("Alice's Bank", query: "alice")
+        let runs = Array(result.runs)
+        XCTAssertEqual(runs.count, 2)
+        XCTAssertEqual(runs[0].attributes.inlinePresentationIntent, .stronglyEmphasized)
+        XCTAssertEqual(String(result.characters[runs[0].range]), "Alice")
+    }
+
+    // MARK: - Empty query returns plain
+
+    func testHighlightedText_emptyQuery_returnsPlain() {
+        let result = ItemRowView.highlightedText("Hello World", query: "")
+        let runs = Array(result.runs)
+        XCTAssertEqual(runs.count, 1)
+        XCTAssertNil(runs[0].attributes.inlinePresentationIntent)
+    }
+}

--- a/Macwarden/MacwardenTests/VaultBrowserViewModelGlobalSearchTests.swift
+++ b/Macwarden/MacwardenTests/VaultBrowserViewModelGlobalSearchTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import Macwarden
+
+@MainActor
+final class VaultBrowserViewModelGlobalSearchTests: XCTestCase {
+
+    private var vault: MockVaultRepository!
+    private var sut: VaultBrowserViewModel!
+
+    private let sampleLogin = VaultItem(
+        id: "1", name: "GitHub", isFavorite: false, isDeleted: false,
+        creationDate: .now, revisionDate: .now,
+        content: .login(LoginContent(username: "alice", password: nil, uris: [], totp: nil, notes: nil, customFields: []))
+    )
+    private let sampleCard = VaultItem(
+        id: "2", name: "Visa", isFavorite: false, isDeleted: false,
+        creationDate: .now, revisionDate: .now,
+        content: .card(CardContent(cardholderName: "Alice", brand: nil, number: "4111111111111111", expMonth: nil, expYear: nil, code: nil, notes: nil, customFields: []))
+    )
+
+    override func setUp() async throws {
+        try await super.setUp()
+        vault = MockVaultRepository()
+        vault.populate(items: [sampleLogin, sampleCard], syncedAt: .now)
+        sut = VaultBrowserViewModel(
+            vault: vault,
+            search: SearchVaultUseCaseImpl(vault: vault),
+            delete: StubDeleteUseCase(),
+            permanentDelete: StubPermanentDeleteUseCase(),
+            restore: StubRestoreUseCase()
+        )
+    }
+
+    // MARK: - 1.1 activateGlobalSearch stores previous selection and sets flag
+
+    func testActivateGlobalSearch_storesPreviousSelectionAndSetsFlag() {
+        sut.sidebarSelection = .type(.login)
+        sut.activateGlobalSearch()
+
+        XCTAssertTrue(sut.isGlobalSearch)
+        XCTAssertEqual(sut.previousSelection, .type(.login))
+    }
+
+    // MARK: - 1.2 deactivateGlobalSearch restores selection, clears query, resets flag
+
+    func testDeactivateGlobalSearch_restoresSelectionAndClearsState() {
+        sut.sidebarSelection = .favorites
+        sut.activateGlobalSearch()
+        sut.searchQuery = "test"
+
+        sut.deactivateGlobalSearch()
+
+        XCTAssertFalse(sut.isGlobalSearch)
+        XCTAssertEqual(sut.searchQuery, "")
+        XCTAssertEqual(sut.sidebarSelection, .favorites)
+    }
+
+    // MARK: - 1.3 search passes .allItems when isGlobalSearch is true
+
+    func testGlobalSearch_searchesAllItems() {
+        sut.sidebarSelection = .type(.login)
+        sut.activateGlobalSearch()
+        sut.searchQuery = "Visa"
+
+        // Visa is a Card, not a Login — should still appear in global search
+        XCTAssertTrue(sut.displayedItems.contains(where: { $0.name == "Visa" }))
+    }
+
+    // MARK: - 1.4 sidebar selection change deactivates global search
+
+    func testSidebarSelectionChange_deactivatesGlobalSearch() {
+        sut.activateGlobalSearch()
+        XCTAssertTrue(sut.isGlobalSearch)
+
+        sut.sidebarSelection = .type(.card)
+
+        XCTAssertFalse(sut.isGlobalSearch)
+    }
+
+    // MARK: - 1.5 escape/clear deactivates global search and restores selection
+
+    func testDeactivateGlobalSearch_afterEscape_restoresSelection() {
+        sut.sidebarSelection = .type(.identity)
+        sut.activateGlobalSearch()
+        sut.searchQuery = "something"
+
+        // Simulate escape/clear
+        sut.deactivateGlobalSearch()
+
+        XCTAssertFalse(sut.isGlobalSearch)
+        XCTAssertEqual(sut.sidebarSelection, .type(.identity))
+        XCTAssertEqual(sut.searchQuery, "")
+    }
+}
+
+// MARK: - Stub use cases (minimal, no-op)
+
+private final class StubDeleteUseCase: DeleteVaultItemUseCase {
+    func execute(id: String) async throws {}
+}
+
+private final class StubPermanentDeleteUseCase: PermanentDeleteVaultItemUseCase {
+    func execute(id: String) async throws {}
+}
+
+private final class StubRestoreUseCase: RestoreVaultItemUseCase {
+    func execute(id: String) async throws {}
+}

--- a/Macwarden/Presentation/Vault/ItemList/ItemListView.swift
+++ b/Macwarden/Presentation/Vault/ItemList/ItemListView.swift
@@ -12,6 +12,7 @@ struct ItemListView: View {
     let items:         [VaultItem]
     @Binding var selection: VaultItem?
     let faviconLoader: FaviconLoader
+    var searchQuery:   String? = nil
     /// Called when the user confirms moving an item to Trash from the row context menu.
     /// Nil disables the delete context-menu action (e.g. when trash actions are unavailable).
     var onDelete: ((String) async -> Void)? = nil
@@ -31,7 +32,7 @@ struct ItemListView: View {
                 .accessibilityIdentifier(AccessibilityID.ItemList.emptyState)
             } else {
                 List(items, id: \.id, selection: $selection) { item in
-                    ItemRowView(item: item, faviconLoader: faviconLoader)
+                    ItemRowView(item: item, faviconLoader: faviconLoader, searchQuery: searchQuery)
                         .tag(item)
                         .accessibilityIdentifier(AccessibilityID.ItemList.row(item.id))
                         .contextMenu {

--- a/Macwarden/Presentation/Vault/ItemList/ItemRowView.swift
+++ b/Macwarden/Presentation/Vault/ItemList/ItemRowView.swift
@@ -17,6 +17,7 @@ struct ItemRowView: View {
 
     let item:          VaultItem
     let faviconLoader: FaviconLoader
+    var searchQuery:   String? = nil
 
     var body: some View {
         HStack(spacing: 8) {
@@ -28,7 +29,7 @@ struct ItemRowView: View {
 
             VStack(alignment: .leading, spacing: 1) {
                 HStack(spacing: 4) {
-                    Text(item.name)
+                    Text(styledName)
                         .font(Typography.listTitle)
                         .lineLimit(1)
                     if item.isFavorite {
@@ -38,7 +39,7 @@ struct ItemRowView: View {
                     }
                 }
                 if let subtitle = subtitle(for: item) {
-                    Text(subtitle)
+                    Text(styledSubtitle(subtitle))
                         .font(Typography.listSubtitle)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
@@ -46,6 +47,33 @@ struct ItemRowView: View {
             }
         }
         .padding(.vertical, 2)
+    }
+
+    // MARK: - Highlighted text helpers
+
+    private var styledName: AttributedString {
+        guard let q = searchQuery, !q.isEmpty else { return AttributedString(item.name) }
+        return Self.highlightedText(item.name, query: q)
+    }
+
+    private func styledSubtitle(_ text: String) -> AttributedString {
+        guard let q = searchQuery, !q.isEmpty else { return AttributedString(text) }
+        return Self.highlightedText(text, query: q)
+    }
+
+    /// Returns an `AttributedString` with the first case-insensitive match of `query` rendered in bold.
+    static func highlightedText(_ text: String, query: String) -> AttributedString {
+        var result = AttributedString(text)
+        guard !query.isEmpty,
+              let range = text.range(of: query, options: .caseInsensitive) else {
+            return result
+        }
+        let lower = text.distance(from: text.startIndex, to: range.lowerBound)
+        let upper = text.distance(from: text.startIndex, to: range.upperBound)
+        let start = result.index(result.startIndex, offsetByCharacters: lower)
+        let end   = result.index(result.startIndex, offsetByCharacters: upper)
+        result[start..<end].inlinePresentationIntent = .stronglyEmphasized
+        return result
     }
 
     // MARK: - Subtitle (FR-021, FR-046, FR-047)

--- a/Macwarden/Presentation/Vault/Sidebar/SidebarView.swift
+++ b/Macwarden/Presentation/Vault/Sidebar/SidebarView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// The sidebar is always visible, even when a category is empty (FR-006, FR-042).
 struct SidebarView: View {
 
-    @Binding var selection: SidebarSelection
+    @Binding var selection: SidebarSelection?
     let itemCounts: [SidebarSelection: Int]
 
     var body: some View {

--- a/Macwarden/Presentation/Vault/VaultBrowserView.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserView.swift
@@ -175,7 +175,11 @@ struct VaultBrowserView: View {
         .onChange(of: viewModel.searchQuery) { _, newValue in
             if newValue.isEmpty && viewModel.isGlobalSearch {
                 viewModel.deactivateGlobalSearch()
+                isSearchFieldFocused = false
             }
+        }
+        .onChange(of: viewModel.isGlobalSearch) { _, isActive in
+            if !isActive { isSearchFieldFocused = false }
         }
         .background {
             Button("") {

--- a/Macwarden/Presentation/Vault/VaultBrowserView.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserView.swift
@@ -17,6 +17,7 @@ struct VaultBrowserView: View {
 
     @State private var showSoftDeleteAlert = false
     @State private var showPermanentDeleteAlert = false
+    @State private var isSearchFieldFocused = false
 
     private let logger = Logger(subsystem: "com.macwarden", category: "UI.VaultBrowser")
 
@@ -130,6 +131,7 @@ struct VaultBrowserView: View {
                 }
                 .searchable(
                     text: $viewModel.searchQuery,
+                    isPresented: $isSearchFieldFocused,
                     placement: .toolbar,
                     prompt: "Search vault"
                 )
@@ -176,10 +178,13 @@ struct VaultBrowserView: View {
             }
         }
         .background {
-            Button("") { viewModel.activateGlobalSearch() }
-                .keyboardShortcut("f", modifiers: .command)
-                .frame(width: 0, height: 0)
-                .opacity(0)
+            Button("") {
+                viewModel.activateGlobalSearch()
+                isSearchFieldFocused = true
+            }
+            .keyboardShortcut("f", modifiers: .command)
+            .frame(width: 0, height: 0)
+            .opacity(0)
         }
         .sheet(item: $viewModel.createItemType) { type in
             ItemEditView(

--- a/Macwarden/Presentation/Vault/VaultBrowserView.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserView.swift
@@ -24,7 +24,14 @@ struct VaultBrowserView: View {
         NavigationSplitView(
             sidebar: {
                 SidebarView(
-                    selection:  $viewModel.sidebarSelection,
+                    selection: Binding(
+                        get: { viewModel.isGlobalSearch ? nil : viewModel.sidebarSelection },
+                        set: { newValue in
+                            if let value = newValue {
+                                viewModel.sidebarSelection = value
+                            }
+                        }
+                    ),
                     itemCounts: viewModel.itemCounts
                 )
                 .navigationSplitViewColumnWidth(min: 180, ideal: 210)
@@ -45,6 +52,7 @@ struct VaultBrowserView: View {
                             items:         viewModel.displayedItems,
                             selection:     $viewModel.itemSelection,
                             faviconLoader: faviconLoader,
+                            searchQuery:   viewModel.searchQuery.isEmpty ? nil : viewModel.searchQuery,
                             onDelete:      { id in await viewModel.performSoftDelete(id: id) }
                         )
                     }
@@ -158,7 +166,20 @@ struct VaultBrowserView: View {
         }
         .accessibilityIdentifier(AccessibilityID.Vault.navigationSplit)
         .onChange(of: viewModel.sidebarSelection) { _, newValue in
-            if newValue == .trash { viewModel.searchQuery = "" }
+            if newValue == .trash {
+                viewModel.searchQuery = ""
+            }
+        }
+        .onChange(of: viewModel.searchQuery) { _, newValue in
+            if newValue.isEmpty && viewModel.isGlobalSearch {
+                viewModel.deactivateGlobalSearch()
+            }
+        }
+        .background {
+            Button("") { viewModel.activateGlobalSearch() }
+                .keyboardShortcut("f", modifiers: .command)
+                .frame(width: 0, height: 0)
+                .opacity(0)
         }
         .sheet(item: $viewModel.createItemType) { type in
             ItemEditView(

--- a/Macwarden/Presentation/Vault/VaultBrowserView.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserView.swift
@@ -175,7 +175,6 @@ struct VaultBrowserView: View {
         .onChange(of: viewModel.searchQuery) { _, newValue in
             if newValue.isEmpty && viewModel.isGlobalSearch {
                 viewModel.deactivateGlobalSearch()
-                isSearchFieldFocused = false
             }
         }
         .onChange(of: viewModel.isGlobalSearch) { _, isActive in

--- a/Macwarden/Presentation/Vault/VaultBrowserViewModel.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserViewModel.swift
@@ -39,7 +39,7 @@ final class VaultBrowserViewModel: ObservableObject {
     @Published private(set) var isGlobalSearch: Bool = false
 
     /// The sidebar selection that was active before global search was activated.
-    @Published private(set) var previousSelection: SidebarSelection?
+    private(set) var previousSelection: SidebarSelection?
 
     @Published private(set) var displayedItems: [VaultItem] = []
     @Published private(set) var itemCounts: [SidebarSelection: Int] = [:]
@@ -125,12 +125,13 @@ final class VaultBrowserViewModel: ObservableObject {
     ///   that was active before global search. Pass `false` when the caller already set a new selection.
     func deactivateGlobalSearch(restoreSelection: Bool = true) {
         guard isGlobalSearch else { return }
+        let saved = previousSelection
         isGlobalSearch = false
-        searchQuery = ""
-        if restoreSelection, let previous = previousSelection {
+        previousSelection = nil
+        if restoreSelection, let previous = saved {
             sidebarSelection = previous
         }
-        previousSelection = nil
+        searchQuery = ""
     }
 
     /// Copies `value` to the pasteboard and schedules a 30-second auto-clear (FR-011).

--- a/Macwarden/Presentation/Vault/VaultBrowserViewModel.swift
+++ b/Macwarden/Presentation/Vault/VaultBrowserViewModel.swift
@@ -21,6 +21,7 @@ final class VaultBrowserViewModel: ObservableObject {
     @Published var sidebarSelection: SidebarSelection = .allItems {
         didSet {
             if oldValue != sidebarSelection {
+                if isGlobalSearch { deactivateGlobalSearch(restoreSelection: false) }
                 Task { @MainActor [weak self] in
                     self?.itemSelection = nil
                     self?.refreshItems()
@@ -33,6 +34,12 @@ final class VaultBrowserViewModel: ObservableObject {
     @Published var searchQuery:   String = "" {
         didSet { Task { @MainActor in refreshItems() } }
     }
+
+    /// When true, search queries are scoped to `.allItems` regardless of sidebar selection.
+    @Published private(set) var isGlobalSearch: Bool = false
+
+    /// The sidebar selection that was active before global search was activated.
+    @Published private(set) var previousSelection: SidebarSelection?
 
     @Published private(set) var displayedItems: [VaultItem] = []
     @Published private(set) var itemCounts: [SidebarSelection: Int] = [:]
@@ -105,6 +112,27 @@ final class VaultBrowserViewModel: ObservableObject {
 
     // MARK: - Actions
 
+    /// Activates global search mode: stores the current sidebar selection and sets the flag.
+    func activateGlobalSearch() {
+        guard !isGlobalSearch else { return }
+        previousSelection = sidebarSelection
+        isGlobalSearch = true
+        refreshItems()
+    }
+
+    /// Deactivates global search mode: restores the previous sidebar selection and clears the query.
+    /// - Parameter restoreSelection: When `true` (default), restores the sidebar selection
+    ///   that was active before global search. Pass `false` when the caller already set a new selection.
+    func deactivateGlobalSearch(restoreSelection: Bool = true) {
+        guard isGlobalSearch else { return }
+        isGlobalSearch = false
+        searchQuery = ""
+        if restoreSelection, let previous = previousSelection {
+            sidebarSelection = previous
+        }
+        previousSelection = nil
+    }
+
     /// Copies `value` to the pasteboard and schedules a 30-second auto-clear (FR-011).
     func copy(_ value: String) {
         let pasteboard = NSPasteboard.general
@@ -137,7 +165,8 @@ final class VaultBrowserViewModel: ObservableObject {
     /// Refreshes `displayedItems` from the vault store based on current selection + search query.
     func refreshItems() {
         do {
-            displayedItems = try search.execute(query: searchQuery, in: sidebarSelection)
+            let scope = isGlobalSearch ? .allItems : sidebarSelection
+            displayedItems = try search.execute(query: searchQuery, in: scope)
         } catch {
             logger.error("Failed to load vault items: \(error.localizedDescription, privacy: .public)")
             displayedItems = []

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A native Bitwarden client for macOS. Connect to your self-hosted [Bitwarden](htt
 | ⌘N | New Login item |
 | ⌘E | Edit selected item |
 | ⌘S | Save edits |
+| ⌘F | Global search across all items |
 | ⇧⌘Q | Sign out |
 | ⌥ (hold) | Peek at masked passwords and secrets |
 | ↑ ↓ | Navigate item list |

--- a/openspec/changes/global-search/.openspec.yaml
+++ b/openspec/changes/global-search/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-26

--- a/openspec/changes/global-search/design.md
+++ b/openspec/changes/global-search/design.md
@@ -1,0 +1,47 @@
+## Context
+
+Search is currently implemented via SwiftUI's `.searchable` modifier with `.sidebar` placement. It filters the item list within the active `SidebarSelection` — if the user is viewing Logins, search only returns Logins. The `SearchVaultUseCase` delegates to `VaultRepository.searchItems(query:in:)` which handles per-type field matching. There is no way to search across all types without first selecting "All Items" in the sidebar.
+
+## Goals / Non-Goals
+
+**Goals:**
+- ⌘F activates a global search mode that searches across all vault items regardless of sidebar selection
+- Matching text fragments are highlighted in item list rows so users see why an item matched
+- Escape or clearing the query exits global search and restores the prior sidebar state
+- Existing category-scoped search continues to work unchanged
+
+**Non-Goals:**
+- Fuzzy/typo-tolerant search — exact substring matching is sufficient for v1
+- Search history or recent searches
+- Searching inside custom field values or notes content beyond what's already matched
+- Spotlight or system-level search integration
+
+## Decisions
+
+**1. Global search as a mode flag, not a new view**
+
+Add an `isGlobalSearch: Bool` flag to `VaultBrowserViewModel`. When true, search passes `.allItems` to the use case regardless of the current sidebar selection. The sidebar selection is preserved and restored on exit.
+
+Alternative considered: a separate search overlay/sheet. Rejected because it breaks the three-pane mental model and adds navigation complexity.
+
+**2. ⌘F via SwiftUI `.onKeyPress` or `keyboardShortcut`**
+
+Use a hidden `Button` with `.keyboardShortcut("f")` to activate global search mode and focus the search field. This is the standard SwiftUI pattern and avoids `NSEvent` monitors.
+
+Alternative considered: `NSEvent.addLocalMonitorForEvents`. Rejected — unnecessary AppKit dependency when SwiftUI provides the mechanism.
+
+**3. Match highlighting via `AttributedString` in `ItemRowView`**
+
+When a search query is active, `ItemRowView` receives the query string and uses `AttributedString` to apply bold text weight to matching substrings in the name and subtitle. This is computed per-row at render time — no caching needed given the filtered result set is small.
+
+Alternative considered: returning match ranges from the repository layer. Rejected — adds complexity to the domain layer for a purely presentational concern.
+
+**4. Reuse existing `SearchVaultUseCase` with `.allItems` selection**
+
+No new use case needed. Global search simply calls `execute(query:in: .allItems)`. The repository already supports `.allItems` which searches across all types.
+
+## Risks / Trade-offs
+
+- **[Risk] ⌘F conflicts with system Find** → Mitigation: macOS apps commonly override ⌘F. The `.searchable` modifier's built-in ⌘F behavior may already handle focus; we may only need to set the global flag. Test for conflicts with the Edit menu's Find command.
+- **[Risk] Highlight computation on every keystroke** → Mitigation: `AttributedString` substring matching is O(n) per row on an already-filtered list (typically <50 items). No performance concern at vault sizes up to 1,000 items.
+- **[Risk] Sidebar selection state confusion** → Mitigation: Store `previousSelection` before entering global mode. On exit, restore it. Visual indicator (e.g., sidebar deselects or dims) signals global mode is active.

--- a/openspec/changes/global-search/proposal.md
+++ b/openspec/changes/global-search/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The current search is scoped to the active sidebar category and only accessible from the vault browser's `.searchable` modifier. Users who want to find an item quickly — regardless of which category they're viewing — must manually switch categories or select "All Items" first. A global ⌘F shortcut that searches across all item types from any screen, with result highlighting, removes this friction and matches the behavior users expect from native macOS apps.
+
+## What Changes
+
+- Add a global ⌘F keyboard shortcut that activates search from any vault screen, overriding the current sidebar-scoped search
+- When global search is active, search across all vault items regardless of the current sidebar selection
+- Highlight matching text fragments in the item list rows (name, subtitle) so users can see *why* an item matched
+- Pressing Escape or clearing the query exits global search and restores the previous sidebar selection and scope
+- The existing category-scoped search (typing in the search field without ⌘F) continues to work as before
+
+## Capabilities
+
+### New Capabilities
+- `global-search`: Global ⌘F search across all vault items with match highlighting in the item list
+
+### Modified Capabilities
+- `vault-browser-ui`: Search requirement updated to support a global search mode alongside the existing category-scoped search
+
+## Impact
+
+- `Presentation/Vault/VaultBrowserView.swift` — search field activation via ⌘F, global vs scoped mode toggle
+- `Presentation/Vault/VaultBrowserViewModel.swift` — new global search state, mode switching
+- `Presentation/Vault/ItemList/ItemRowView.swift` — highlighted match fragments in name/subtitle
+- `Domain/UseCases/SearchVaultUseCase.swift` — support unscoped (all-items) search
+- `Data/UseCases/SearchVaultUseCaseImpl.swift` — implementation of unscoped search
+- No new dependencies or API changes; all data is already available locally after sync

--- a/openspec/changes/global-search/specs/global-search/spec.md
+++ b/openspec/changes/global-search/specs/global-search/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: User can activate global search with ⌘F
+The system SHALL provide a ⌘F keyboard shortcut that activates global search mode. When global search is active, the search field SHALL be focused and all vault items (excluding Trash) SHALL be searchable regardless of the current sidebar selection. The sidebar selection SHALL be visually deselected while global search is active.
+
+#### Scenario: ⌘F activates global search and focuses the search field
+- **WHEN** the user presses ⌘F from the vault browser
+- **THEN** the search field is focused, global search mode is active, and the sidebar selection is visually deselected
+
+#### Scenario: Global search returns results across all item types
+- **GIVEN** global search is active
+- **WHEN** the user types a query that matches items of different types (e.g., a Login and a Card)
+- **THEN** both items appear in the item list
+
+#### Scenario: Global search excludes trashed items
+- **GIVEN** global search is active and the vault contains trashed items matching the query
+- **WHEN** the user types a query
+- **THEN** trashed items SHALL NOT appear in the results
+
+#### Scenario: Escape exits global search and restores sidebar selection
+- **GIVEN** global search is active
+- **WHEN** the user presses Escape or clears the search field
+- **THEN** global search mode is deactivated, the previous sidebar selection is restored, and the item list shows items for that selection
+
+#### Scenario: Selecting a sidebar entry exits global search
+- **GIVEN** global search is active
+- **WHEN** the user clicks a sidebar entry
+- **THEN** global search mode is deactivated and the selected category's items are shown
+
+---
+
+### Requirement: Matching text is highlighted in item list rows during search
+The system SHALL highlight matching substrings in the item name and subtitle when a search query is active (both global and category-scoped). Highlighting SHALL use bold text weight to distinguish matched fragments from surrounding text.
+
+#### Scenario: Name match is highlighted
+- **GIVEN** a search query is active
+- **WHEN** an item's name contains the query as a substring
+- **THEN** the matching portion of the name is rendered in bold
+
+#### Scenario: Subtitle match is highlighted
+- **GIVEN** a search query is active
+- **WHEN** an item's subtitle (username, cardholder, etc.) contains the query as a substring
+- **THEN** the matching portion of the subtitle is rendered in bold
+
+#### Scenario: No highlight when search is empty
+- **WHEN** the search field is empty
+- **THEN** item names and subtitles render with their default text weight
+
+#### Scenario: Highlighting is case-insensitive
+- **GIVEN** a search query "alice"
+- **WHEN** an item's name is "Alice's Bank"
+- **THEN** "Alice" is highlighted despite the case difference

--- a/openspec/changes/global-search/specs/vault-browser-ui/spec.md
+++ b/openspec/changes/global-search/specs/vault-browser-ui/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Real-time search filters the item list within the active category
+The system SHALL provide search via the native `.searchable(text:placement:prompt:)` modifier with `.sidebar` placement on the content column. Search SHALL filter the item list in real time on every keystroke, scoped to the currently selected sidebar category.
+
+When global search is active (triggered by ⌘F), search SHALL be scoped to `.allItems` regardless of the current sidebar selection.
+
+Fields searched per type: Login (name, username, URIs, notes), Card (name, cardholderName, notes), Identity (name, firstName, lastName, email, company, notes), Secure Note (name, notes), SSH Key (name only).
+
+When the sidebar selection changes to Trash, the search query SHALL be cleared so that no invisible filter is applied to the trash item list.
+
+#### Scenario: Real-time filtering
+- **WHEN** the user types in the search field
+- **THEN** the item list immediately updates to show only matching items within the active category
+
+#### Scenario: Global search overrides category scope
+- **GIVEN** global search mode is active
+- **WHEN** the user types in the search field
+- **THEN** the item list shows matching items from all categories (excluding Trash)
+
+#### Scenario: Empty search results
+- **WHEN** the search term matches no items
+- **THEN** a clear "no results" empty state is shown
+
+#### Scenario: Clear search restores full list
+- **WHEN** the user clears the search field
+- **THEN** the middle pane shows all items for the active category
+
+#### Scenario: Search query cleared on entering Trash
+- **WHEN** the user selects Trash in the sidebar while a search query is active
+- **THEN** the search query is cleared

--- a/openspec/changes/global-search/tasks.md
+++ b/openspec/changes/global-search/tasks.md
@@ -1,0 +1,39 @@
+## 1. Tests — Global Search State
+
+- [x] 1.1 Add unit tests for `VaultBrowserViewModel`: `activateGlobalSearch` stores previous selection and sets flag
+- [x] 1.2 Add unit test: `deactivateGlobalSearch` restores previous selection, clears query, resets flag
+- [x] 1.3 Add unit test: search passes `.allItems` to `SearchVaultUseCase` when `isGlobalSearch` is true
+- [x] 1.4 Add unit test: sidebar selection change during global search deactivates global search
+- [x] 1.5 Add unit test: escape/clear during global search deactivates global search and restores selection
+
+## 2. Global Search State in ViewModel
+
+- [x] 2.1 Add `isGlobalSearch: Bool` and `previousSelection: SidebarSelection?` properties to `VaultBrowserViewModel`
+- [x] 2.2 Add `activateGlobalSearch()` method that stores the current sidebar selection, sets `isGlobalSearch = true`, and focuses the search field
+- [x] 2.3 Add `deactivateGlobalSearch()` method that restores `previousSelection`, clears the query, and sets `isGlobalSearch = false`
+- [x] 2.4 Update the existing search filtering logic to pass `.allItems` to `SearchVaultUseCase` when `isGlobalSearch` is true
+
+## 3. ⌘F Keyboard Shortcut
+
+- [x] 3.1 Add a hidden `Button` with `.keyboardShortcut("f")` in `VaultBrowserView` that calls `activateGlobalSearch()`
+- [x] 3.2 Wire Escape key or search field clearing to call `deactivateGlobalSearch()`
+- [x] 3.3 Wire sidebar selection changes during global search to call `deactivateGlobalSearch()` before applying the new selection
+
+## 4. Sidebar Visual Feedback
+
+- [x] 4.1 Deselect the sidebar (set selection to `nil` or equivalent) while `isGlobalSearch` is active so no category appears highlighted
+
+## 5. Tests — Match Highlighting
+
+- [x] 5.1 Add unit tests for `highlightedText` helper: match applies bold, no match returns plain, case-insensitive matching, empty query returns plain
+
+## 6. Match Highlighting in Item Rows
+
+- [x] 6.1 Add a `highlightedText(_:query:)` helper that returns an `AttributedString` with bold applied to case-insensitive substring matches
+- [x] 6.2 Update `ItemRowView` to accept an optional `searchQuery: String?` parameter
+- [x] 6.3 Apply `highlightedText` to the item name and subtitle `Text` views when `searchQuery` is non-empty
+- [x] 6.4 Pass the active search query from `ItemListView` down to each `ItemRowView`
+
+## 7. Documentation
+
+- [x] 7.1 Update README.md keyboard shortcuts table to include ⌘F for global search


### PR DESCRIPTION
## What

- **⌘F global search**: Searches all vault items regardless of sidebar selection
- **Match highlighting**: Bold text on matching substrings in item names and subtitles
- **Sidebar deselects** while global search is active
- **Escape / clear** exits global search and restores previous sidebar selection
- **Sidebar click** exits global search and switches to that category

## Files Changed

- `VaultBrowserViewModel` — `isGlobalSearch` flag, `activateGlobalSearch()`, `deactivateGlobalSearch()`, scope override
- `VaultBrowserView` — ⌘F shortcut, `searchable(isPresented:)` for focus, escape wiring
- `SidebarView` — optional selection binding for visual deselection
- `ItemRowView` — `highlightedText` helper, `searchQuery` parameter
- `ItemListView` — search query passthrough
- `README.md` — ⌘F added to keyboard shortcuts table

## Tests

- `VaultBrowserViewModelGlobalSearchTests` — activate, deactivate, restore, cross-type search, sidebar exit
- `HighlightedTextTests` — bold match, no match, case-insensitive, empty query