### PR TITLE
feat: item list polish — headline font, taller rows, A-Z sections

### DIFF
--- a/Macwarden/Presentation/Vault/ItemList/ItemListView.swift
+++ b/Macwarden/Presentation/Vault/ItemList/ItemListView.swift
@@ -21,6 +21,18 @@ struct ItemListView: View {
     @State private var itemToDelete:    VaultItem? = nil
     @State private var showDeleteAlert: Bool       = false
 
+    private var sections: [(letter: String, items: [VaultItem])] {
+        let grouped = Dictionary(grouping: items) { item in
+            let first = item.name.first.map { String($0).uppercased() } ?? "#"
+            return first.first?.isLetter == true ? first : "#"
+        }
+        return grouped.sorted { lhs, rhs in
+            if lhs.key == "#" { return false }
+            if rhs.key == "#" { return true }
+            return lhs.key < rhs.key
+        }.map { (letter: $0.key, items: $0.value) }
+    }
+
     var body: some View {
         Group {
             if items.isEmpty {
@@ -31,18 +43,24 @@ struct ItemListView: View {
                 )
                 .accessibilityIdentifier(AccessibilityID.ItemList.emptyState)
             } else {
-                List(items, id: \.id, selection: $selection) { item in
-                    ItemRowView(item: item, faviconLoader: faviconLoader, searchQuery: searchQuery)
-                        .tag(item)
-                        .accessibilityIdentifier(AccessibilityID.ItemList.row(item.id))
-                        .contextMenu {
-                            if onDelete != nil {
-                                Button("Delete", role: .destructive) {
-                                    itemToDelete    = item
-                                    showDeleteAlert = true
-                                }
+                List(selection: $selection) {
+                    ForEach(sections, id: \.letter) { section in
+                        Section(header: Text(section.letter)) {
+                            ForEach(section.items, id: \.id) { item in
+                                ItemRowView(item: item, faviconLoader: faviconLoader, searchQuery: searchQuery)
+                                    .tag(item)
+                                    .accessibilityIdentifier(AccessibilityID.ItemList.row(item.id))
+                                    .contextMenu {
+                                        if onDelete != nil {
+                                            Button("Delete", role: .destructive) {
+                                                itemToDelete    = item
+                                                showDeleteAlert = true
+                                            }
+                                        }
+                                    }
                             }
                         }
+                    }
                 }
                 // Soft-delete confirmation alert — shown when the user selects "Delete"
                 // from a row context menu. The item is only moved to Trash, not permanently

--- a/Macwarden/Presentation/Vault/ItemList/ItemRowView.swift
+++ b/Macwarden/Presentation/Vault/ItemList/ItemRowView.swift
@@ -20,17 +20,18 @@ struct ItemRowView: View {
     var searchQuery:   String? = nil
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 10) {
             FaviconView(
                 domain:    primaryDomain(for: item),
                 itemType:  itemType(for: item),
-                loader:    faviconLoader
+                loader:    faviconLoader,
+                size:      26
             )
 
-            VStack(alignment: .leading, spacing: 1) {
+            VStack(alignment: .leading, spacing: 3) {
                 HStack(spacing: 4) {
                     Text(styledName)
-                        .font(Typography.listTitle)
+                        .font(.headline)
                         .lineLimit(1)
                     if item.isFavorite {
                         Image(systemName: "star.fill")
@@ -40,13 +41,13 @@ struct ItemRowView: View {
                 }
                 if let subtitle = subtitle(for: item) {
                     Text(styledSubtitle(subtitle))
-                        .font(Typography.listSubtitle)
+                        .font(.callout)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
             }
         }
-        .padding(.vertical, 2)
+        .padding(.vertical, 8)
     }
 
     // MARK: - Highlighted text helpers

--- a/openspec/changes/archive/2026-03-27-item-list-row-polish/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-27-item-list-row-polish/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-27

--- a/openspec/changes/archive/2026-03-27-item-list-row-polish/design.md
+++ b/openspec/changes/archive/2026-03-27-item-list-row-polish/design.md
@@ -1,0 +1,33 @@
+## Context
+
+`ItemRowView` currently uses `.padding(.vertical, 2)`, `Typography.listTitle` (`.body`, 13pt) for the name, and `Typography.listSubtitle` (`.caption`, 10pt) for the subtitle. Spacing between name and subtitle is 1pt. The rows feel tight compared to the detail pane's generous card layout.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Taller rows with more vertical padding
+- More spacing between name and subtitle
+- Item name uses `.headline` (13pt semibold) to match detail view section headers
+
+**Non-Goals:**
+- Changing favicon size or spacing
+- Changing subtitle content or logic
+- Changing list selection behavior
+
+## Decisions
+
+### Decision 1: Use `.headline` for item name
+
+**Chosen:** Item name uses `.headline` font, matching the detail view section headers ("Credentials", "Websites").
+
+**Rationale:** Creates visual consistency between the list and detail panes. The semibold weight makes item names easier to scan in a long list.
+
+### Decision 2: Increase vertical padding to 8pt
+
+**Chosen:** `.padding(.vertical, 8)` on the row, spacing between name and subtitle increased to 3pt.
+
+**Rationale:** Gives each row breathing room without making the list feel wasteful. Comparable to Apple's Passwords app list density.
+
+## Risks / Trade-offs
+
+- Taller rows mean fewer visible items without scrolling. Acceptable — scannability matters more than density for a password manager.

--- a/openspec/changes/archive/2026-03-27-item-list-row-polish/proposal.md
+++ b/openspec/changes/archive/2026-03-27-item-list-row-polish/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The item list rows in the content pane are compact and dense. Row height is minimal (2pt vertical padding), the item name uses `.body` font, and there's little whitespace around the text. This makes the list feel cramped compared to the detail pane's polished card layout. Increasing row height, adding breathing room, and promoting the item name to `.headline` (matching the detail view section headers) will make the list more scannable and visually consistent.
+
+## What Changes
+
+- Increase vertical padding on `ItemRowView` for taller rows
+- Add more whitespace around text content
+- Item name uses `.headline` font (matching "Credentials", "Websites" etc. in the detail view)
+
+## Capabilities
+
+### New Capabilities
+
+*(none)*
+
+### Modified Capabilities
+
+- `vault-browser-ui`: Item list row height increased, item name promoted to `.headline` style
+
+## Impact
+
+- `ItemRowView.swift` — padding and font changes
+- Presentation layer only; no Domain or Data changes

--- a/openspec/changes/archive/2026-03-27-item-list-row-polish/specs/vault-browser-ui/spec.md
+++ b/openspec/changes/archive/2026-03-27-item-list-row-polish/specs/vault-browser-ui/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Item list row styling (MODIFIED)
+Item list rows SHALL use `.headline` font (13pt semibold) for the item name and `.callout` font (12pt) for the subtitle. Rows SHALL have 8pt vertical padding and 3pt spacing between name and subtitle. The favicon/type icon SHALL be 26pt and vertically centered. HStack spacing SHALL be 10pt.
+
+#### Scenario: Item name uses headline font
+- **WHEN** an item row is displayed in the list
+- **THEN** the item name SHALL render in `.headline` font
+
+#### Scenario: Subtitle uses callout font
+- **WHEN** an item row has a subtitle
+- **THEN** the subtitle SHALL render in `.callout` font with secondary color
+
+#### Scenario: Rows have adequate vertical spacing
+- **WHEN** the item list is displayed
+- **THEN** each row SHALL have 8pt vertical padding, 3pt spacing between name and subtitle, and a 26pt vertically-centered icon
+
+---
+
+### Requirement: Item list grouped by letter (ADDED)
+The item list SHALL group items into alphabetical sections with sticky letter headers (A, B, C … Z). Items whose names begin with a non-letter character SHALL be grouped under "#". Section grouping SHALL be applied to all sidebar categories including search results.
+
+#### Scenario: Items grouped under correct letter
+- **WHEN** the item list is displayed
+- **THEN** each item SHALL appear under the section header matching the first letter of its name (uppercased)
+
+#### Scenario: Non-letter names grouped under #
+- **WHEN** an item name begins with a digit or symbol
+- **THEN** the item SHALL appear under the "#" section header

--- a/openspec/changes/archive/2026-03-27-item-list-row-polish/tasks.md
+++ b/openspec/changes/archive/2026-03-27-item-list-row-polish/tasks.md
@@ -1,0 +1,9 @@
+## 1. ItemRowView — row polish
+
+- [x] 1.1 Change item name font from `Typography.listTitle` to `.headline`
+- [x] 1.2 Increase vertical padding from 2pt to 8pt
+- [x] 1.3 Increase spacing between name and subtitle from 1pt to 3pt
+- [x] 1.4 Vertically center the favicon/icon in the row
+- [x] 1.5 Increase favicon size from 16pt to 26pt
+- [x] 1.6 Increase subtitle font from `.caption` to `.callout`
+- [x] 1.7 Group items into A-Z sections with sticky letter headers

--- a/openspec/specs/vault-browser-ui/spec.md
+++ b/openspec/specs/vault-browser-ui/spec.md
@@ -214,3 +214,32 @@ The system SHALL provide a Sign Out option in the application menu. Selecting it
 - **SC-006**: Authentication errors, network failures, and incorrect passwords are communicated with a clear, human-readable message in 100% of failure cases.
 - **SC-007**: The three-pane layout is fully navigable by keyboard alone (Tab between panes, arrow keys in lists).
 - **SC-008**: Search results update within 100ms of each keystroke for vaults up to 1,000 items.
+## MODIFIED Requirements
+
+### Requirement: Item list row styling (MODIFIED)
+Item list rows SHALL use `.headline` font (13pt semibold) for the item name and `.callout` font (12pt) for the subtitle. Rows SHALL have 8pt vertical padding and 3pt spacing between name and subtitle. The favicon/type icon SHALL be 26pt and vertically centered. HStack spacing SHALL be 10pt.
+
+#### Scenario: Item name uses headline font
+- **WHEN** an item row is displayed in the list
+- **THEN** the item name SHALL render in `.headline` font
+
+#### Scenario: Subtitle uses callout font
+- **WHEN** an item row has a subtitle
+- **THEN** the subtitle SHALL render in `.callout` font with secondary color
+
+#### Scenario: Rows have adequate vertical spacing
+- **WHEN** the item list is displayed
+- **THEN** each row SHALL have 8pt vertical padding, 3pt spacing between name and subtitle, and a 26pt vertically-centered icon
+
+---
+
+### Requirement: Item list grouped by letter (ADDED)
+The item list SHALL group items into alphabetical sections with sticky letter headers (A, B, C … Z). Items whose names begin with a non-letter character SHALL be grouped under "#". Section grouping SHALL be applied to all sidebar categories including search results.
+
+#### Scenario: Items grouped under correct letter
+- **WHEN** the item list is displayed
+- **THEN** each item SHALL appear under the section header matching the first letter of its name (uppercased)
+
+#### Scenario: Non-letter names grouped under #
+- **WHEN** an item name begins with a digit or symbol
+- **THEN** the item SHALL appear under the "#" section header


### PR DESCRIPTION
Improves item list scannability and visual consistency with the detail pane.

**Changes:**
- Item name uses `.headline` (matching detail view section headers)
- Subtitle bumped from `.caption` to `.callout`
- Taller rows (8pt vertical padding), more breathing room (3pt name/subtitle gap)
- Favicon 16pt → 26pt, vertically centered
- A-Z section headers with `#` fallback for non-letter names
