### PR TITLE
feat: Copy Username/Password/Code/Website menu commands

### DIFF
--- a/Macwarden/App/MacwardenApp.swift
+++ b/Macwarden/App/MacwardenApp.swift
@@ -190,6 +190,9 @@ final class RootViewModel: ObservableObject {
     /// Whether the Save command should be enabled: the edit sheet is currently open.
     @Published private(set) var menuBarCanSave: Bool = false
 
+    /// The login content of the currently selected item, or nil. Drives copy command disabled state.
+    @Published private(set) var selectedLogin: LoginContent?
+
     private let logger = Logger(subsystem: "com.macwarden", category: "RootViewModel")
 
     let loginVM:          LoginViewModel
@@ -261,6 +264,11 @@ final class RootViewModel: ObservableObject {
             for await selection in vaultBrowserVM.$itemSelection.values {
                 guard let self else { break }
                 self.menuBarCanEdit = selection != nil && !vaultBrowserVM.editSheetOpen
+                if case .login(let login) = selection?.content {
+                    self.selectedLogin = login
+                } else {
+                    self.selectedLogin = nil
+                }
             }
         }
 
@@ -392,8 +400,8 @@ final class RootViewModel: ObservableObject {
     }
 
     private func selectedFieldValue(_ field: CopyableField) -> String? {
-        guard let item = vaultBrowserVM.itemSelection,
-              case .login(let login) = item.content else { return nil }
+        guard let login = selectedLogin else { return nil }
+
         switch field {
         case .username: return login.username
         case .password: return login.password

--- a/Macwarden/App/MacwardenApp.swift
+++ b/Macwarden/App/MacwardenApp.swift
@@ -71,6 +71,32 @@ struct MacwardenApp: App {
                 }
                 .disabled(!rootVM.menuBarCanSave)
                 .keyboardShortcut("s", modifiers: .command)
+
+                Divider()
+
+                Button("Copy Username") {
+                    rootVM.copySelectedField(.username)
+                }
+                .keyboardShortcut("c", modifiers: [.command, .shift])
+                .disabled(!rootVM.selectedFieldAvailable(.username))
+
+                Button("Copy Password") {
+                    rootVM.copySelectedField(.password)
+                }
+                .keyboardShortcut("c", modifiers: [.command, .option])
+                .disabled(!rootVM.selectedFieldAvailable(.password))
+
+                Button("Copy Code") {
+                    rootVM.copySelectedField(.totp)
+                }
+                .keyboardShortcut("c", modifiers: [.command, .control])
+                .disabled(!rootVM.selectedFieldAvailable(.totp))
+
+                Button("Copy Website") {
+                    rootVM.copySelectedField(.website)
+                }
+                .keyboardShortcut("c", modifiers: [.command, .option, .shift])
+                .disabled(!rootVM.selectedFieldAvailable(.website))
             }
         }
     }
@@ -348,5 +374,31 @@ final class RootViewModel: ObservableObject {
             screen   = .login
         }
         logger.info("Screen transition → \(String(describing: state))")
+    }
+
+    // MARK: - Copy field from selected item
+
+    enum CopyableField {
+        case username, password, totp, website
+    }
+
+    func copySelectedField(_ field: CopyableField) {
+        guard let value = selectedFieldValue(field) else { return }
+        vaultBrowserVM.copy(value)
+    }
+
+    func selectedFieldAvailable(_ field: CopyableField) -> Bool {
+        selectedFieldValue(field) != nil
+    }
+
+    private func selectedFieldValue(_ field: CopyableField) -> String? {
+        guard let item = vaultBrowserVM.itemSelection,
+              case .login(let login) = item.content else { return nil }
+        switch field {
+        case .username: return login.username
+        case .password: return login.password
+        case .totp:     return login.totp
+        case .website:  return login.uris.first?.uri
+        }
     }
 }

--- a/Macwarden/Presentation/Components/OptionKeyMonitor.swift
+++ b/Macwarden/Presentation/Components/OptionKeyMonitor.swift
@@ -9,7 +9,7 @@ final class OptionKeyMonitor {
 
     init() {
         monitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
-            self?.isOptionHeld = event.modifierFlags.contains(.option)
+            self?.isOptionHeld = event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .option
             return event
         }
     }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ A native Bitwarden client for macOS. Connect to your self-hosted [Bitwarden](htt
 | ⌘S | Save edits |
 | ⌘L | Lock vault |
 | ⌘F | Global search across all items |
+| ⇧⌘C | Copy username |
+| ⌥⌘C | Copy password |
+| ⌃⌘C | Copy TOTP code |
+| ⌥⇧⌘C | Copy website |
 | ⇧⌘Q | Sign out |
 | ⌥ (hold) | Peek at masked passwords and secrets |
 | ↑ ↓ | Navigate item list |

--- a/openspec/changes/copy-menu-commands/.openspec.yaml
+++ b/openspec/changes/copy-menu-commands/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-27

--- a/openspec/changes/copy-menu-commands/design.md
+++ b/openspec/changes/copy-menu-commands/design.md
@@ -1,0 +1,27 @@
+## Context
+
+`VaultBrowserViewModel.copy(_:)` already handles clipboard write + 30s auto-clear. The Item menu has Edit (⌘E) and Save (⌘S). The selected item is available via `vaultBrowserVM.itemSelection`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Copy Username, Password, TOTP Code, and Website from the menu bar with keyboard shortcuts
+- Disabled state when field is unavailable
+
+**Non-Goals:**
+- Copy commands for non-Login types (Card number, Identity email — deferred)
+- Context menu on list rows (separate feature)
+
+## Decisions
+
+### Decision 1: Commands on RootViewModel, not VaultBrowserViewModel
+
+**Chosen:** `RootViewModel` owns the copy helpers because it already owns menu bar state (`menuBarCanEdit`, `menuBarCanSave`).
+
+**Rationale:** Menu commands live in `MacwardenApp.commands` which has access to `rootVM`. Keeping copy logic alongside existing menu state is consistent.
+
+### Decision 2: Login-only for v1
+
+**Chosen:** Copy commands only extract fields from `LoginContent`. Non-Login items disable all four commands.
+
+**Rationale:** Username/Password/TOTP/Website are Login-specific fields. Card number, Identity email etc. can be added later with type-specific menus.

--- a/openspec/changes/copy-menu-commands/proposal.md
+++ b/openspec/changes/copy-menu-commands/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Users need to copy credentials quickly without navigating into the detail view and hovering over individual fields. 1Password provides Copy Username/Password/Code/Website in the menu bar with keyboard shortcuts — Macwarden should match this for power users.
+
+## What Changes
+
+- Add Copy Username (⇧⌘C), Copy Password (⌥⌘C), Copy Code (⌃⌘C), Copy Website (⌥⇧⌘C) to the Item menu
+- Commands are disabled when the selected item doesn't have the corresponding field
+- Uses existing clipboard copy with 30s auto-clear
+
+## Capabilities
+
+### New Capabilities
+
+- `copy-menu-commands`: Keyboard-driven copy of Login fields from the menu bar
+
+### Modified Capabilities
+
+*(none)*
+
+## Impact
+
+- `MacwardenApp.swift` — new menu commands + helper methods on `RootViewModel`

--- a/openspec/changes/copy-menu-commands/specs/copy-menu-commands/spec.md
+++ b/openspec/changes/copy-menu-commands/specs/copy-menu-commands/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Copy field commands in Item menu
+The Item menu SHALL provide Copy Username (⇧⌘C), Copy Password (⌥⌘C), Copy Code (⌃⌘C), and Copy Website (⌥⇧⌘C) commands. Each command SHALL copy the corresponding field from the selected Login item to the clipboard with 30-second auto-clear. Commands SHALL be disabled when the selected item does not have the corresponding field or is not a Login item.
+
+#### Scenario: Copy Username copies username to clipboard
+- **GIVEN** a Login item with a username is selected
+- **WHEN** the user presses ⇧⌘C or selects Copy Username from the Item menu
+- **THEN** the username SHALL be copied to the clipboard with 30s auto-clear
+
+#### Scenario: Copy Password copies password to clipboard
+- **GIVEN** a Login item with a password is selected
+- **WHEN** the user presses ⌥⌘C
+- **THEN** the password SHALL be copied to the clipboard with 30s auto-clear
+
+#### Scenario: Copy Code copies TOTP seed to clipboard
+- **GIVEN** a Login item with a TOTP seed is selected
+- **WHEN** the user presses ⌃⌘C
+- **THEN** the TOTP seed SHALL be copied to the clipboard with 30s auto-clear
+
+#### Scenario: Copy Website copies first URI to clipboard
+- **GIVEN** a Login item with at least one URI is selected
+- **WHEN** the user presses ⌥⇧⌘C
+- **THEN** the first URI SHALL be copied to the clipboard with 30s auto-clear
+
+#### Scenario: Commands disabled when field unavailable
+- **GIVEN** the selected item is not a Login or the Login item lacks the field
+- **THEN** the corresponding copy command SHALL be disabled (grayed out)
+
+#### Scenario: Commands disabled when no item selected
+- **GIVEN** no item is selected in the item list
+- **THEN** all four copy commands SHALL be disabled

--- a/openspec/changes/copy-menu-commands/tasks.md
+++ b/openspec/changes/copy-menu-commands/tasks.md
@@ -1,0 +1,6 @@
+## 1. Copy Menu Commands
+
+- [x] 1.1 Add `CopyableField` enum to `RootViewModel` with cases `username`, `password`, `totp`, `website`
+- [x] 1.2 Add `copySelectedField(_:)` and `selectedFieldAvailable(_:)` methods to `RootViewModel`
+- [x] 1.3 Add Copy Username (⇧⌘C), Copy Password (⌥⌘C), Copy Code (⌃⌘C), Copy Website (⌥⇧⌘C) to Item `CommandMenu`
+- [x] 1.4 Disable each command when the corresponding field is unavailable


### PR DESCRIPTION
Adds quick-copy keyboard shortcuts to the Item menu.

| Shortcut | Action |
|---|---|
| ⇧⌘C | Copy Username |
| ⌥⌘C | Copy Password |
| ⌃⌘C | Copy Code (TOTP) |
| ⌥⇧⌘C | Copy Website |

- Commands disabled when field unavailable or non-Login item selected
- Uses existing 30s clipboard auto-clear
- Fix: Option-key peek now only triggers when Option is the sole modifier (⌥⌘C no longer reveals passwords)
