### PR TITLE
feat(sidebar): increase font size

### DIFF
--- a/Prizm/App/AppContainer.swift
+++ b/Prizm/App/AppContainer.swift
@@ -121,6 +121,10 @@ final class AppContainer: ObservableObject {
             delete:          deleteVaultItemUseCase,
             permanentDelete: permanentDeleteVaultItemUseCase,
             restore:         restoreVaultItemUseCase,
+            createFolder:    createFolderUseCase,
+            renameFolder:    renameFolderUseCase,
+            deleteFolder:    deleteFolderUseCase,
+            moveItem:        moveItemToFolderUseCase,
             syncTimestamp:   syncTimestampRepository,
             getLastSyncDate: getLastSyncDateUseCase
         )
@@ -129,11 +133,13 @@ final class AppContainer: ObservableObject {
     /// Creates an `ItemEditViewModel` for the given item, wired with the live edit use case.
     /// The caller is responsible for setting `onSaveSuccess` to update the UI after a save.
     func makeItemEditViewModel(for item: VaultItem) -> ItemEditViewModel {
-        ItemEditViewModel(item: item, useCase: editVaultItemUseCase)
+        let folders = (try? vaultStore.folders()) ?? []
+        return ItemEditViewModel(item: item, useCase: editVaultItemUseCase, folders: folders)
     }
 
     /// Creates an `ItemEditViewModel` in create mode for the given item type.
     func makeItemCreateViewModel(for type: ItemType) -> ItemEditViewModel {
-        ItemEditViewModel(type: type, useCase: createVaultItemUseCase)
+        let folders = (try? vaultStore.folders()) ?? []
+        return ItemEditViewModel(type: type, useCase: createVaultItemUseCase, folders: folders)
     }
 }

--- a/Prizm/App/AppContainer.swift
+++ b/Prizm/App/AppContainer.swift
@@ -34,6 +34,10 @@ final class AppContainer: ObservableObject {
     let deleteVaultItemUseCase:          DeleteVaultItemUseCaseImpl
     let permanentDeleteVaultItemUseCase: PermanentDeleteVaultItemUseCaseImpl
     let restoreVaultItemUseCase:         RestoreVaultItemUseCaseImpl
+    let createFolderUseCase:             CreateFolderUseCaseImpl
+    let renameFolderUseCase:             RenameFolderUseCaseImpl
+    let deleteFolderUseCase:             DeleteFolderUseCaseImpl
+    let moveItemToFolderUseCase:         MoveItemToFolderUseCaseImpl
     let syncTimestampRepository:         SyncTimestampRepositoryImpl
     let getLastSyncDateUseCase:          any GetLastSyncDateUseCase
 
@@ -78,6 +82,10 @@ final class AppContainer: ObservableObject {
         self.deleteVaultItemUseCase          = DeleteVaultItemUseCaseImpl(repository: vault)
         self.permanentDeleteVaultItemUseCase = PermanentDeleteVaultItemUseCaseImpl(repository: vault)
         self.restoreVaultItemUseCase         = RestoreVaultItemUseCaseImpl(repository: vault)
+        self.createFolderUseCase             = CreateFolderUseCaseImpl(repository: vault)
+        self.renameFolderUseCase             = RenameFolderUseCaseImpl(repository: vault)
+        self.deleteFolderUseCase             = DeleteFolderUseCaseImpl(repository: vault)
+        self.moveItemToFolderUseCase         = MoveItemToFolderUseCaseImpl(repository: vault)
         self.syncTimestampRepository         = syncTimestamp
         self.getLastSyncDateUseCase          = GetLastSyncDateUseCaseImpl(repository: syncTimestamp)
     }

--- a/Prizm/Data/Crypto/PrizmCryptoService.swift
+++ b/Prizm/Data/Crypto/PrizmCryptoService.swift
@@ -97,6 +97,14 @@ protocol PrizmCryptoService: Actor {
     /// - Throws: `PrizmCryptoServiceError.vaultLocked` if the vault is not unlocked.
     func decryptList(ciphers: [RawCipher]) async throws -> (items: [VaultItem], failedCount: Int)
 
+    /// Decrypts folder names from the sync response.
+    ///
+    /// Per-folder decryption failures are non-fatal: failed folders are excluded and counted.
+    /// - Parameter folders: Raw encrypted folders from the sync response.
+    /// - Returns: Tuple of successfully decrypted `Folder`s and a failure count.
+    /// - Throws: `PrizmCryptoServiceError.vaultLocked` if the vault is not unlocked.
+    func decryptFolders(folders: [RawFolder]) async throws -> (folders: [Folder], failedCount: Int)
+
     /// Loads `keys` into memory, marking the vault as unlocked.
     func unlockWith(keys: CryptoKeys) async
 
@@ -199,6 +207,31 @@ actor PrizmCryptoServiceImpl: PrizmCryptoService {
         }
         logger.info("decryptList: completed — \(items.count) succeeded, \(failedCount) failed")
         return (items: items, failedCount: failedCount)
+    }
+
+    // MARK: - decryptFolders
+
+    func decryptFolders(folders rawFolders: [RawFolder]) async throws -> (folders: [Folder], failedCount: Int) {
+        guard let vaultKeys = keys else {
+            throw PrizmCryptoServiceError.vaultLocked
+        }
+        var folders: [Folder] = []
+        var failedCount = 0
+        for raw in rawFolders {
+            do {
+                let enc  = try EncString(string: raw.name)
+                let data = try enc.decrypt(keys: vaultKeys)
+                guard let name = String(data: data, encoding: .utf8) else {
+                    failedCount += 1
+                    continue
+                }
+                folders.append(Folder(id: raw.id, name: name))
+            } catch {
+                failedCount += 1
+                logger.error("decryptFolders: folder decryption failed for id \(raw.id, privacy: .public)")
+            }
+        }
+        return (folders: folders, failedCount: failedCount)
     }
 
     // MARK: - makeMasterKey

--- a/Prizm/Data/Keychain/KeychainService.swift
+++ b/Prizm/Data/Keychain/KeychainService.swift
@@ -58,6 +58,16 @@ final class KeychainServiceImpl: KeychainService {
     private let service = "com.prizm"
     private let logger = Logger(subsystem: "com.prizm", category: "KeychainService")
 
+    /// When `true` (default, production), routes all queries through the modern data
+    /// protection keychain (`kSecUseDataProtectionKeychain`), which requires the
+    /// `keychain-access-groups` entitlement. Pass `false` in test targets that run
+    /// without code signing, where the entitlement is unavailable.
+    private let useDataProtectionKeychain: Bool
+
+    init(useDataProtectionKeychain: Bool = true) {
+        self.useDataProtectionKeychain = useDataProtectionKeychain
+    }
+
     /// Returns the base Keychain query dictionary for `key`.
     ///
     /// `kSecUseDataProtectionKeychain: true` routes all queries to the modern data
@@ -66,12 +76,15 @@ final class KeychainServiceImpl: KeychainService {
     /// entitlement (`$(AppIdentifierPrefix)com.prizm`). Setting it explicitly here
     /// would require embedding the resolved Team ID in source code.
     private func baseQuery(for key: String) -> [CFString: Any] {
-        [
-            kSecClass:                   kSecClassGenericPassword,
-            kSecAttrService:             service,
-            kSecAttrAccount:             key,
-            kSecUseDataProtectionKeychain: true,
+        var query: [CFString: Any] = [
+            kSecClass:       kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: key,
         ]
+        if useDataProtectionKeychain {
+            query[kSecUseDataProtectionKeychain] = true
+        }
+        return query
     }
 
     // MARK: Write

--- a/Prizm/Data/Mappers/CipherMapper.swift
+++ b/Prizm/Data/Mappers/CipherMapper.swift
@@ -84,7 +84,8 @@ nonisolated final class CipherMapper {
             creationDate: creationDate,
             revisionDate: revisionDate,
             content:      content,
-            reprompt:     raw.reprompt ?? 0
+            reprompt:     raw.reprompt ?? 0,
+            folderId:     raw.folderId
         )
     }
 
@@ -289,6 +290,7 @@ nonisolated final class CipherMapper {
         return RawCipher(
             id:             draft.id,
             organizationId: nil,
+            folderId:       draft.folderId,
             type:           type,
             name:           encName,
             notes:          encNotes,

--- a/Prizm/Data/Network/Models/RawCipher.swift
+++ b/Prizm/Data/Network/Models/RawCipher.swift
@@ -13,6 +13,7 @@ import Foundation
 nonisolated struct RawCipher: Codable {
     let id:             String
     let organizationId: String?
+    let folderId:       String?
     /// 1 = Login, 2 = SecureNote, 3 = Card, 4 = Identity, 5 = SSH Key
     /// Reference: Bitwarden server `CipherType` enum (C#), Vaultwarden `CipherType` (Rust),
     /// and Bitwarden web client `CipherType` enum (TypeScript). All three sources agree.

--- a/Prizm/Data/Network/Models/RawFolder.swift
+++ b/Prizm/Data/Network/Models/RawFolder.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+// MARK: - RawFolder
+
+/// Wire-format model for a folder returned by the Bitwarden `/sync` API endpoint.
+///
+/// The `name` field is an EncString (type-2: AES-256-CBC + HMAC-SHA256) that must be
+/// decrypted using the user's vault symmetric key before display.
+///
+/// Reference: Bitwarden Server API `/api/sync` response body, `Folders[]` array;
+/// Bitwarden Server API `/api/folders` CRUD endpoints.
+nonisolated struct RawFolder: Codable {
+    let id:           String
+    let name:         String   // EncString
+    let revisionDate: String?  // ISO-8601 UTC
+}

--- a/Prizm/Data/Network/Models/SyncResponse.swift
+++ b/Prizm/Data/Network/Models/SyncResponse.swift
@@ -8,10 +8,23 @@ import Foundation
 /// the vault) and the list of encrypted ciphers.
 ///
 /// Reference: Bitwarden Server API `/api/sync` response schema.
-nonisolated struct SyncResponse: Codable {
+nonisolated struct SyncResponse: Decodable {
     let profile: RawProfile
     let ciphers: [RawCipher]
+    /// Decoded with a default of `[]` so that Vaultwarden instances that omit the key
+    /// (or future API variants) don't cause the entire sync decode to throw.
     let folders: [RawFolder]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        profile = try container.decode(RawProfile.self, forKey: .profile)
+        ciphers = try container.decode([RawCipher].self, forKey: .ciphers)
+        folders = (try? container.decode([RawFolder].self, forKey: .folders)) ?? []
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case profile, ciphers, folders
+    }
 }
 
 // MARK: - RawProfile

--- a/Prizm/Data/Network/Models/SyncResponse.swift
+++ b/Prizm/Data/Network/Models/SyncResponse.swift
@@ -11,6 +11,7 @@ import Foundation
 nonisolated struct SyncResponse: Codable {
     let profile: RawProfile
     let ciphers: [RawCipher]
+    let folders: [RawFolder]
 }
 
 // MARK: - RawProfile

--- a/Prizm/Data/Network/Models/SyncResponse.swift
+++ b/Prizm/Data/Network/Models/SyncResponse.swift
@@ -16,14 +16,25 @@ nonisolated struct SyncResponse: Decodable {
     let folders: [RawFolder]
 
     init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        profile = try container.decode(RawProfile.self, forKey: .profile)
-        ciphers = try container.decode([RawCipher].self, forKey: .ciphers)
-        folders = (try? container.decode([RawFolder].self, forKey: .folders)) ?? []
+        // Vaultwarden API uses camelCase; some versions / the official Bitwarden server
+        // use PascalCase. Try camelCase first, fall back to PascalCase for each key.
+        let container = try decoder.container(keyedBy: FlexKeys.self)
+        profile = try (try? container.decode(RawProfile.self,  forKey: FlexKeys("profile")))
+               ?? container.decode(RawProfile.self,  forKey: FlexKeys("Profile"))
+        ciphers = try (try? container.decode([RawCipher].self, forKey: FlexKeys("ciphers")))
+               ?? container.decode([RawCipher].self, forKey: FlexKeys("Ciphers"))
+        folders = (try? container.decode([RawFolder].self, forKey: FlexKeys("folders")))
+               ?? (try? container.decode([RawFolder].self, forKey: FlexKeys("Folders")))
+               ?? []
     }
 
-    private enum CodingKeys: String, CodingKey {
-        case profile, ciphers, folders
+    /// Ad-hoc `CodingKey` that accepts any string key, used to try multiple casing variants.
+    private struct FlexKeys: CodingKey {
+        var stringValue: String
+        var intValue: Int? { nil }
+        init(_ string: String) { stringValue = string }
+        init?(stringValue: String) { self.stringValue = stringValue }
+        init?(intValue: Int) { return nil }
     }
 }
 

--- a/Prizm/Data/Network/PrizmAPIClient.swift
+++ b/Prizm/Data/Network/PrizmAPIClient.swift
@@ -498,10 +498,21 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
 
-        let response: SyncResponse = try await perform(request: request)
-        if DebugConfig.isEnabled {
-            logger.debug("[debug] fetchSync ← ciphers=\(response.ciphers.count, privacy: .public) folders=\(response.folders.count, privacy: .public) profileEmail=\(response.profile.email, privacy: .private) hasPrivateKey=\(response.profile.privateKey != nil, privacy: .public)")
+        // Fetch raw data to log top-level JSON keys before decoding — diagnoses key-casing
+        // mismatches (e.g. "Folders" vs "folders") without requiring --debug-mode or test builds.
+        let (rawData, rawHTTPResponse) = try await session.data(for: request)
+        if let http = rawHTTPResponse as? HTTPURLResponse {
+            guard (200..<300).contains(http.statusCode) else {
+                let body = String(data: rawData, encoding: .utf8) ?? ""
+                throw APIError.httpError(statusCode: http.statusCode, body: body)
+            }
+            if let json = try? JSONSerialization.jsonObject(with: rawData) as? [String: Any] {
+                let keys = json.keys.sorted().joined(separator: ", ")
+                logger.info("fetchSync [\(http.statusCode, privacy: .public)] top-level keys: [\(keys, privacy: .public)]")
+            }
         }
+        let response = try JSONDecoder().decode(SyncResponse.self, from: rawData)
+        logger.info("fetchSync ← ciphers=\(response.ciphers.count, privacy: .public) folders=\(response.folders.count, privacy: .public)")
         return response
     }
 

--- a/Prizm/Data/Network/PrizmAPIClient.swift
+++ b/Prizm/Data/Network/PrizmAPIClient.swift
@@ -500,7 +500,7 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
 
         let response: SyncResponse = try await perform(request: request)
         if DebugConfig.isEnabled {
-            logger.debug("[debug] fetchSync ← ciphers=\(response.ciphers.count, privacy: .public) profileEmail=\(response.profile.email, privacy: .private) hasPrivateKey=\(response.profile.privateKey != nil, privacy: .public)")
+            logger.debug("[debug] fetchSync ← ciphers=\(response.ciphers.count, privacy: .public) folders=\(response.folders.count, privacy: .public) profileEmail=\(response.profile.email, privacy: .private) hasPrivateKey=\(response.profile.privateKey != nil, privacy: .public)")
         }
         return response
     }

--- a/Prizm/Data/Network/PrizmAPIClient.swift
+++ b/Prizm/Data/Network/PrizmAPIClient.swift
@@ -498,21 +498,10 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
 
-        // Fetch raw data to log top-level JSON keys before decoding — diagnoses key-casing
-        // mismatches (e.g. "Folders" vs "folders") without requiring --debug-mode or test builds.
-        let (rawData, rawHTTPResponse) = try await session.data(for: request)
-        if let http = rawHTTPResponse as? HTTPURLResponse {
-            guard (200..<300).contains(http.statusCode) else {
-                let body = String(data: rawData, encoding: .utf8) ?? ""
-                throw APIError.httpError(statusCode: http.statusCode, body: body)
-            }
-            if let json = try? JSONSerialization.jsonObject(with: rawData) as? [String: Any] {
-                let keys = json.keys.sorted().joined(separator: ", ")
-                logger.info("fetchSync [\(http.statusCode, privacy: .public)] top-level keys: [\(keys, privacy: .public)]")
-            }
+        let response: SyncResponse = try await perform(request: request)
+        if DebugConfig.isEnabled {
+            logger.debug("[debug] fetchSync ← ciphers=\(response.ciphers.count, privacy: .public) folders=\(response.folders.count, privacy: .public) profileEmail=\(response.profile.email, privacy: .private) hasPrivateKey=\(response.profile.privateKey != nil, privacy: .public)")
         }
-        let response = try JSONDecoder().decode(SyncResponse.self, from: rawData)
-        logger.info("fetchSync ← ciphers=\(response.ciphers.count, privacy: .public) folders=\(response.folders.count, privacy: .public)")
         return response
     }
 

--- a/Prizm/Data/Network/PrizmAPIClient.swift
+++ b/Prizm/Data/Network/PrizmAPIClient.swift
@@ -113,6 +113,26 @@ protocol PrizmAPIClientProtocol: Actor {
     /// On success the server returns the created cipher, decoded back into `RawCipher`.
     func createCipher(cipher: RawCipher) async throws -> RawCipher
 
+    // MARK: - Folder CRUD
+
+    /// POST `/api/folders` — creates a new folder with an encrypted name.
+    func createFolder(encryptedName: String) async throws -> RawFolder
+
+    /// PUT `/api/folders/{id}` — renames a folder with an encrypted name.
+    func updateFolder(id: String, encryptedName: String) async throws -> RawFolder
+
+    /// DELETE `/api/folders/{id}` — permanently deletes a folder.
+    /// Items in the folder are unfoldered, not deleted.
+    func deleteFolder(id: String) async throws
+
+    // MARK: - Cipher partial / move
+
+    /// PUT `/ciphers/{id}/partial` — updates folderId and favorite without re-encrypting.
+    func updateCipherPartial(id: String, folderId: String?, favorite: Bool) async throws
+
+    /// PUT `/ciphers/move` — bulk-moves ciphers to a folder.
+    func moveCiphersToFolder(ids: [String], folderId: String?) async throws
+
 }
 
 // MARK: - Wire Models
@@ -608,6 +628,75 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
             logger.debug("[debug] createCipher ← id=\(created.id, privacy: .public)")
         }
         return created
+    }
+
+    // MARK: - Folder CRUD
+
+    func createFolder(encryptedName: String) async throws -> RawFolder {
+        guard let base = baseURL else { throw APIError.baseURLNotSet }
+        let url = base.appendingPathComponent("api/folders")
+        var request = baseRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token = accessToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = try JSONEncoder().encode(["name": encryptedName])
+        return try await perform(request: request)
+    }
+
+    func updateFolder(id: String, encryptedName: String) async throws -> RawFolder {
+        guard let base = baseURL else { throw APIError.baseURLNotSet }
+        let url = base.appendingPathComponent("api/folders/\(id)")
+        var request = baseRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token = accessToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = try JSONEncoder().encode(["name": encryptedName])
+        return try await perform(request: request)
+    }
+
+    func deleteFolder(id: String) async throws {
+        guard let base = baseURL else { throw APIError.baseURLNotSet }
+        let url = base.appendingPathComponent("api/folders/\(id)")
+        var request = baseRequest(url: url)
+        request.httpMethod = "DELETE"
+        if let token = accessToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        try await performEmpty(request: request)
+    }
+
+    // MARK: - Cipher partial / move
+
+    func updateCipherPartial(id: String, folderId: String?, favorite: Bool) async throws {
+        guard let base = baseURL else { throw APIError.baseURLNotSet }
+        let url = base.appendingPathComponent("api/ciphers/\(id)/partial")
+        var request = baseRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token = accessToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        let body: [String: Any?] = ["folderId": folderId, "favorite": favorite]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body.compactMapValues { $0 ?? NSNull() })
+        try await performEmpty(request: request)
+    }
+
+    func moveCiphersToFolder(ids: [String], folderId: String?) async throws {
+        guard let base = baseURL else { throw APIError.baseURLNotSet }
+        let url = base.appendingPathComponent("api/ciphers/move")
+        var request = baseRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token = accessToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        let body: [String: Any] = ["ids": ids, "folderId": folderId as Any]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        try await performEmpty(request: request)
     }
 
     func refreshAccessToken(refreshToken: String) async throws -> (accessToken: String, refreshToken: String?) {

--- a/Prizm/Data/Repositories/SyncRepositoryImpl.swift
+++ b/Prizm/Data/Repositories/SyncRepositoryImpl.swift
@@ -103,7 +103,6 @@ actor SyncRepositoryImpl: SyncRepository {
         }
 
         // Phase 2b: Decrypt folder names.
-        logger.info("Decrypting \(syncResponse.folders.count, privacy: .public) folder(s)")
         let (folders, folderFailedCount) = try await crypto.decryptFolders(folders: syncResponse.folders)
         logger.info("Decrypted \(folders.count, privacy: .public) folder(s); \(folderFailedCount, privacy: .public) failure(s)")
         if folderFailedCount > 0 {

--- a/Prizm/Data/Repositories/SyncRepositoryImpl.swift
+++ b/Prizm/Data/Repositories/SyncRepositoryImpl.swift
@@ -103,7 +103,9 @@ actor SyncRepositoryImpl: SyncRepository {
         }
 
         // Phase 2b: Decrypt folder names.
+        logger.info("Decrypting \(syncResponse.folders.count, privacy: .public) folder(s)")
         let (folders, folderFailedCount) = try await crypto.decryptFolders(folders: syncResponse.folders)
+        logger.info("Decrypted \(folders.count, privacy: .public) folder(s); \(folderFailedCount, privacy: .public) failure(s)")
         if folderFailedCount > 0 {
             logger.error("decryptFolders: \(folderFailedCount, privacy: .public) folder(s) failed to decrypt")
         }

--- a/Prizm/Data/Repositories/SyncRepositoryImpl.swift
+++ b/Prizm/Data/Repositories/SyncRepositoryImpl.swift
@@ -102,9 +102,15 @@ actor SyncRepositoryImpl: SyncRepository {
             logger.debug("[debug] \(failedCount, privacy: .public) cipher(s) failed to decrypt — check PrizmCryptoService logs for per-cipher errors")
         }
 
+        // Phase 2b: Decrypt folder names.
+        let (folders, folderFailedCount) = try await crypto.decryptFolders(folders: syncResponse.folders)
+        if folderFailedCount > 0 {
+            logger.error("decryptFolders: \(folderFailedCount, privacy: .public) folder(s) failed to decrypt")
+        }
+
         // Phase 3: Populate the in-memory vault store.
         let syncedAt = Date()
-        await vaultRepository.populate(items: items, syncedAt: syncedAt)
+        await vaultRepository.populate(items: items, folders: folders, syncedAt: syncedAt)
 
         return SyncResult(
             syncedAt:              syncedAt,

--- a/Prizm/Data/Repositories/VaultRepositoryImpl.swift
+++ b/Prizm/Data/Repositories/VaultRepositoryImpl.swift
@@ -250,6 +250,24 @@ final class VaultRepositoryImpl: VaultRepository {
     private func sorted(_ input: [VaultItem]) -> [VaultItem] {
         input.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
     }
+
+    /// Encrypts a plaintext folder name as a type-2 EncString using the current vault keys.
+    /// Called before folder create/rename API calls.
+    ///
+    /// - Security: AES-256-CBC + HMAC-SHA256 (Encrypt-then-MAC) with a fresh random IV.
+    ///   Same algorithm as cipher field encryption in `CipherMapper.encryptString`.
+    private func encryptFolderName(_ name: String) async throws -> String {
+        let keys: CryptoKeys
+        do {
+            keys = try await crypto.currentKeys()
+        } catch PrizmCryptoServiceError.vaultLocked {
+            throw VaultError.vaultLocked
+        }
+        guard let data = name.data(using: .utf8) else {
+            throw VaultError.decryptionFailed("utf8-encode")
+        }
+        return try EncString.encrypt(data: data, keys: keys).toString()
+    }
 }
 
 // MARK: - ItemContent search / type matching

--- a/Prizm/Data/Repositories/VaultRepositoryImpl.swift
+++ b/Prizm/Data/Repositories/VaultRepositoryImpl.swift
@@ -77,6 +77,8 @@ final class VaultRepositoryImpl: VaultRepository {
             return sorted(items.filter { !$0.isDeleted && $0.content.matchesItemType(itemType) })
         case .folder(let folderId):
             return sorted(items.filter { !$0.isDeleted && $0.folderId == folderId })
+        case .newFolder:
+            return []
         }
     }
 

--- a/Prizm/Data/Repositories/VaultRepositoryImpl.swift
+++ b/Prizm/Data/Repositories/VaultRepositoryImpl.swift
@@ -24,6 +24,7 @@ final class VaultRepositoryImpl: VaultRepository {
     // MARK: - State
 
     private var items: [VaultItem] = []
+    private var folderStore: [Folder] = []
     private(set) var lastSyncedAt: Date? = nil
 
     // MARK: - Init
@@ -40,14 +41,16 @@ final class VaultRepositoryImpl: VaultRepository {
 
     // MARK: - Write side (called by SyncRepositoryImpl)
 
-    func populate(items: [VaultItem], syncedAt: Date) {
-        self.items     = items
+    func populate(items: [VaultItem], folders: [Folder], syncedAt: Date) {
+        self.items       = items
+        self.folderStore = folders
         self.lastSyncedAt = syncedAt
-        logger.info("Vault populated: \(items.count) item(s)")
+        logger.info("Vault populated: \(items.count) item(s), \(folders.count) folder(s)")
     }
 
     func clearVault() {
-        items       = []
+        items        = []
+        folderStore  = []
         lastSyncedAt = nil
         logger.info("Vault cleared")
     }
@@ -58,10 +61,13 @@ final class VaultRepositoryImpl: VaultRepository {
         sorted(items.filter { !$0.isDeleted })
     }
 
+    func folders() throws -> [Folder] {
+        folderStore.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
     func items(for selection: SidebarSelection) throws -> [VaultItem] {
         switch selection {
         case .trash:
-            // Trash shows only soft-deleted items; the isDeleted filter is inverted here.
             return sorted(items.filter(\.isDeleted))
         case .allItems:
             return sorted(items.filter { !$0.isDeleted })
@@ -69,6 +75,8 @@ final class VaultRepositoryImpl: VaultRepository {
             return sorted(items.filter { !$0.isDeleted && $0.isFavorite })
         case .type(let itemType):
             return sorted(items.filter { !$0.isDeleted && $0.content.matchesItemType(itemType) })
+        case .folder(let folderId):
+            return sorted(items.filter { !$0.isDeleted && $0.folderId == folderId })
         }
     }
 
@@ -88,6 +96,9 @@ final class VaultRepositoryImpl: VaultRepository {
         counts[.trash]             = items.filter(\.isDeleted).count
         for type in ItemType.allCases {
             counts[.type(type)]    = base.filter { $0.content.matchesItemType(type) }.count
+        }
+        for folder in folderStore {
+            counts[.folder(folder.id)] = base.filter { $0.folderId == folder.id }.count
         }
         return counts
     }
@@ -208,7 +219,7 @@ final class VaultRepositoryImpl: VaultRepository {
         items[idx] = VaultItem(
             id: old.id, name: old.name, isFavorite: old.isFavorite, isDeleted: true,
             creationDate: old.creationDate, revisionDate: old.revisionDate,
-            content: old.content, reprompt: old.reprompt
+            content: old.content, reprompt: old.reprompt, folderId: old.folderId
         )
         logger.info("Vault item soft-deleted: \(id, privacy: .public)")
     }
@@ -240,9 +251,77 @@ final class VaultRepositoryImpl: VaultRepository {
         items[idx] = VaultItem(
             id: old.id, name: old.name, isFavorite: old.isFavorite, isDeleted: false,
             creationDate: old.creationDate, revisionDate: old.revisionDate,
-            content: old.content, reprompt: old.reprompt
+            content: old.content, reprompt: old.reprompt, folderId: old.folderId
         )
         logger.info("Vault item restored: \(id, privacy: .public)")
+    }
+
+    // MARK: - Folder CRUD
+
+    func createFolder(name: String) async throws -> Folder {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw VaultError.decryptionFailed("empty folder name") }
+        let encName = try await encryptFolderName(trimmed)
+        let raw = try await apiClient.createFolder(encryptedName: encName)
+        let folder = Folder(id: raw.id, name: trimmed)
+        folderStore.append(folder)
+        logger.info("Folder created: \(raw.id, privacy: .public)")
+        return folder
+    }
+
+    func renameFolder(id: String, name: String) async throws -> Folder {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw VaultError.decryptionFailed("empty folder name") }
+        let encName = try await encryptFolderName(trimmed)
+        _ = try await apiClient.updateFolder(id: id, encryptedName: encName)
+        let folder = Folder(id: id, name: trimmed)
+        if let idx = folderStore.firstIndex(where: { $0.id == id }) {
+            folderStore[idx] = folder
+        }
+        logger.info("Folder renamed: \(id, privacy: .public)")
+        return folder
+    }
+
+    func deleteFolder(id: String) async throws {
+        try await apiClient.deleteFolder(id: id)
+        folderStore.removeAll { $0.id == id }
+        // Unfolder items that were in this folder (server does this too).
+        for i in items.indices where items[i].folderId == id {
+            let old = items[i]
+            items[i] = VaultItem(
+                id: old.id, name: old.name, isFavorite: old.isFavorite, isDeleted: old.isDeleted,
+                creationDate: old.creationDate, revisionDate: old.revisionDate,
+                content: old.content, reprompt: old.reprompt, folderId: nil
+            )
+        }
+        logger.info("Folder deleted: \(id, privacy: .public)")
+    }
+
+    // MARK: - Move to folder
+
+    func moveItemToFolder(itemId: String, folderId: String?) async throws {
+        guard let idx = items.firstIndex(where: { $0.id == itemId }) else { return }
+        let old = items[idx]
+        try await apiClient.updateCipherPartial(id: itemId, folderId: folderId, favorite: old.isFavorite)
+        items[idx] = VaultItem(
+            id: old.id, name: old.name, isFavorite: old.isFavorite, isDeleted: old.isDeleted,
+            creationDate: old.creationDate, revisionDate: old.revisionDate,
+            content: old.content, reprompt: old.reprompt, folderId: folderId
+        )
+        logger.info("Item moved to folder: \(itemId, privacy: .public)")
+    }
+
+    func moveItemsToFolder(itemIds: [String], folderId: String?) async throws {
+        try await apiClient.moveCiphersToFolder(ids: itemIds, folderId: folderId)
+        for i in items.indices where itemIds.contains(items[i].id) {
+            let old = items[i]
+            items[i] = VaultItem(
+                id: old.id, name: old.name, isFavorite: old.isFavorite, isDeleted: old.isDeleted,
+                creationDate: old.creationDate, revisionDate: old.revisionDate,
+                content: old.content, reprompt: old.reprompt, folderId: folderId
+            )
+        }
+        logger.info("Bulk move to folder: \(itemIds.count, privacy: .public) item(s)")
     }
 
     // MARK: - Private helpers

--- a/Prizm/Data/UseCases/CreateFolderUseCaseImpl.swift
+++ b/Prizm/Data/UseCases/CreateFolderUseCaseImpl.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+final class CreateFolderUseCaseImpl: CreateFolderUseCase {
+    private let repository: any VaultRepository
+    init(repository: any VaultRepository) { self.repository = repository }
+
+    func execute(name: String) async throws -> Folder {
+        try await repository.createFolder(name: name)
+    }
+}

--- a/Prizm/Data/UseCases/DeleteFolderUseCaseImpl.swift
+++ b/Prizm/Data/UseCases/DeleteFolderUseCaseImpl.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+final class DeleteFolderUseCaseImpl: DeleteFolderUseCase {
+    private let repository: any VaultRepository
+    init(repository: any VaultRepository) { self.repository = repository }
+
+    func execute(id: String) async throws {
+        try await repository.deleteFolder(id: id)
+    }
+}

--- a/Prizm/Data/UseCases/MoveItemToFolderUseCaseImpl.swift
+++ b/Prizm/Data/UseCases/MoveItemToFolderUseCaseImpl.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+final class MoveItemToFolderUseCaseImpl: MoveItemToFolderUseCase {
+    private let repository: any VaultRepository
+    init(repository: any VaultRepository) { self.repository = repository }
+
+    func execute(itemId: String, folderId: String?) async throws {
+        try await repository.moveItemToFolder(itemId: itemId, folderId: folderId)
+    }
+
+    func execute(itemIds: [String], folderId: String?) async throws {
+        try await repository.moveItemsToFolder(itemIds: itemIds, folderId: folderId)
+    }
+}

--- a/Prizm/Data/UseCases/RenameFolderUseCaseImpl.swift
+++ b/Prizm/Data/UseCases/RenameFolderUseCaseImpl.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+final class RenameFolderUseCaseImpl: RenameFolderUseCase {
+    private let repository: any VaultRepository
+    init(repository: any VaultRepository) { self.repository = repository }
+
+    func execute(id: String, name: String) async throws -> Folder {
+        try await repository.renameFolder(id: id, name: name)
+    }
+}

--- a/Prizm/Domain/Entities/DraftVaultItem.swift
+++ b/Prizm/Domain/Entities/DraftVaultItem.swift
@@ -221,6 +221,7 @@ nonisolated enum DraftItemContent: Equatable {
 nonisolated struct DraftVaultItem: Equatable {
     /// Immutable — item identity cannot change during an edit.
     let id: String
+    var folderId: String?
     var name: String
     var isFavorite: Bool
     /// Deletion state is not editable in v1.
@@ -245,6 +246,7 @@ nonisolated struct DraftVaultItem: Equatable {
         }
         return DraftVaultItem(
             id: UUID().uuidString,
+            folderId: nil,
             name: "",
             isFavorite: false,
             isDeleted: false,
@@ -256,9 +258,10 @@ nonisolated struct DraftVaultItem: Equatable {
     }
 
     /// Memberwise initialiser for programmatic construction (blank drafts, tests).
-    init(id: String, name: String, isFavorite: Bool, isDeleted: Bool,
+    init(id: String, folderId: String? = nil, name: String, isFavorite: Bool, isDeleted: Bool,
          creationDate: Date, revisionDate: Date, content: DraftItemContent, reprompt: Int) {
         self.id = id
+        self.folderId = folderId
         self.name = name
         self.isFavorite = isFavorite
         self.isDeleted = isDeleted
@@ -271,6 +274,7 @@ nonisolated struct DraftVaultItem: Equatable {
     /// Converts an immutable `VaultItem` into a mutable draft ready for editing.
     init(_ item: VaultItem) {
         self.id = item.id
+        self.folderId = item.folderId
         self.name = item.name
         self.isFavorite = item.isFavorite
         self.isDeleted = item.isDeleted

--- a/Prizm/Domain/Entities/DraftVaultItem.swift
+++ b/Prizm/Domain/Entities/DraftVaultItem.swift
@@ -303,6 +303,7 @@ extension VaultItem {
     /// post-save local patching if needed; normally the API response is used directly.
     init(_ draft: DraftVaultItem) {
         self.id = draft.id
+        self.folderId = draft.folderId
         self.name = draft.name
         self.isFavorite = draft.isFavorite
         self.isDeleted = draft.isDeleted

--- a/Prizm/Domain/Entities/Folder.swift
+++ b/Prizm/Domain/Entities/Folder.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// A decrypted folder. Produced by `PrizmCryptoService.decryptFolders` from `[RawFolder]`.
+/// Value type — safe to pass across layers without defensive copying.
+nonisolated struct Folder: Identifiable, Equatable, Hashable {
+    let id: String
+    let name: String
+}

--- a/Prizm/Domain/Entities/SidebarSelection.swift
+++ b/Prizm/Domain/Entities/SidebarSelection.swift
@@ -45,18 +45,19 @@ nonisolated enum SidebarSelection {
     case allItems
     case favorites
     case type(ItemType)
+    case folder(String)
     /// Soft-deleted items awaiting permanent removal (Bitwarden Trash).
-    /// Items in trash have `isDeleted == true` and are excluded from all other selections.
     case trash
 }
 
 extension SidebarSelection {
     var displayName: String {
         switch self {
-        case .allItems:        return "All Items"
-        case .favorites:       return "Favorites"
-        case .type(let type):  return type.displayName
-        case .trash:           return "Trash"
+        case .allItems:           return "All Items"
+        case .favorites:          return "Favorites"
+        case .type(let type):     return type.displayName
+        case .folder:             return "Folder"
+        case .trash:              return "Trash"
         }
     }
 }
@@ -64,20 +65,22 @@ extension SidebarSelection {
 extension SidebarSelection: Hashable {
     nonisolated static func == (lhs: SidebarSelection, rhs: SidebarSelection) -> Bool {
         switch (lhs, rhs) {
-        case (.allItems, .allItems):         return true
-        case (.favorites, .favorites):       return true
-        case (.type(let a), .type(let b)):   return a == b
-        case (.trash, .trash):               return true
-        default:                             return false
+        case (.allItems, .allItems):                   return true
+        case (.favorites, .favorites):                 return true
+        case (.type(let a), .type(let b)):             return a == b
+        case (.folder(let a), .folder(let b)):         return a == b
+        case (.trash, .trash):                         return true
+        default:                                       return false
         }
     }
 
     nonisolated func hash(into hasher: inout Hasher) {
         switch self {
-        case .allItems:        hasher.combine(0)
-        case .favorites:       hasher.combine(1)
-        case .type(let type):  hasher.combine(2); hasher.combine(type)
-        case .trash:           hasher.combine(3)
+        case .allItems:          hasher.combine(0)
+        case .favorites:         hasher.combine(1)
+        case .type(let type):    hasher.combine(2); hasher.combine(type)
+        case .folder(let id):    hasher.combine(3); hasher.combine(id)
+        case .trash:             hasher.combine(4)
         }
     }
 }

--- a/Prizm/Domain/Entities/SidebarSelection.swift
+++ b/Prizm/Domain/Entities/SidebarSelection.swift
@@ -48,6 +48,8 @@ nonisolated enum SidebarSelection {
     case folder(String)
     /// Soft-deleted items awaiting permanent removal (Bitwarden Trash).
     case trash
+    /// Transient state while the user is typing a new folder name inline.
+    case newFolder
 }
 
 extension SidebarSelection {
@@ -58,6 +60,7 @@ extension SidebarSelection {
         case .type(let type):     return type.displayName
         case .folder:             return "Folder"
         case .trash:              return "Trash"
+        case .newFolder:          return "New Folder"
         }
     }
 }
@@ -70,6 +73,7 @@ extension SidebarSelection: Hashable {
         case (.type(let a), .type(let b)):             return a == b
         case (.folder(let a), .folder(let b)):         return a == b
         case (.trash, .trash):                         return true
+        case (.newFolder, .newFolder):                 return true
         default:                                       return false
         }
     }
@@ -81,6 +85,7 @@ extension SidebarSelection: Hashable {
         case .type(let type):    hasher.combine(2); hasher.combine(type)
         case .folder(let id):    hasher.combine(3); hasher.combine(id)
         case .trash:             hasher.combine(4)
+        case .newFolder:         hasher.combine(5)
         }
     }
 }

--- a/Prizm/Domain/Entities/VaultItem.swift
+++ b/Prizm/Domain/Entities/VaultItem.swift
@@ -4,6 +4,7 @@ import Foundation
 /// Value type — safe to pass across layers without defensive copying.
 nonisolated struct VaultItem: Identifiable, Equatable, Hashable {
     let id: String
+    let folderId: String?
     let name: String
     let isFavorite: Bool
     let isDeleted: Bool
@@ -21,9 +22,10 @@ nonisolated struct VaultItem: Identifiable, Equatable, Hashable {
     init(
         id: String, name: String, isFavorite: Bool, isDeleted: Bool,
         creationDate: Date, revisionDate: Date, content: ItemContent,
-        reprompt: Int = 0
+        reprompt: Int = 0, folderId: String? = nil
     ) {
         self.id = id
+        self.folderId = folderId
         self.name = name
         self.isFavorite = isFavorite
         self.isDeleted = isDeleted

--- a/Prizm/Domain/Repositories/VaultRepository.swift
+++ b/Prizm/Domain/Repositories/VaultRepository.swift
@@ -34,12 +34,15 @@ protocol VaultRepository: AnyObject, Sendable {
     /// Not cached — re-decrypts on every call (decrypt on demand, per spec).
     func itemDetail(id: String) async throws -> VaultItem
 
-    /// Replaces the in-memory vault store with `items` and records the sync timestamp.
+    /// Replaces the in-memory vault store with `items` and `folders`, and records the sync timestamp.
     /// Called by `SyncRepositoryImpl` after a successful sync.
-    func populate(items: [VaultItem], syncedAt: Date)
+    func populate(items: [VaultItem], folders: [Folder], syncedAt: Date)
 
-    /// Clears the in-memory vault store. Called on lock and sign-out.
+    /// Clears the in-memory vault store (items and folders). Called on lock and sign-out.
     func clearVault()
+
+    /// All folders, sorted alphabetically by name (case-insensitive).
+    func folders() throws -> [Folder]
 
     /// Re-encrypts `draft`, calls `PUT /ciphers/{id}`, updates the in-memory cache, and
     /// returns the server-confirmed `VaultItem` decoded from the API response.
@@ -77,6 +80,25 @@ protocol VaultRepository: AnyObject, Sendable {
     /// Encrypts a new `draft`, calls `POST /api/ciphers`, inserts the server-confirmed item
     /// into the in-memory cache, and returns it.
     func create(_ draft: DraftVaultItem) async throws -> VaultItem
+
+    // MARK: - Folder CRUD
+
+    /// Creates a folder with the given plaintext name. Encryption handled internally.
+    func createFolder(name: String) async throws -> Folder
+
+    /// Renames a folder. Encryption handled internally.
+    func renameFolder(id: String, name: String) async throws -> Folder
+
+    /// Deletes a folder. Items in the folder become unfoldered.
+    func deleteFolder(id: String) async throws
+
+    // MARK: - Move to folder
+
+    /// Moves a single item to a folder (or removes from folder if nil).
+    func moveItemToFolder(itemId: String, folderId: String?) async throws
+
+    /// Moves multiple items to a folder in a single API call.
+    func moveItemsToFolder(itemIds: [String], folderId: String?) async throws
 
 }
 

--- a/Prizm/Domain/UseCases/CreateFolderUseCase.swift
+++ b/Prizm/Domain/UseCases/CreateFolderUseCase.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// Creates a new folder in the vault.
+protocol CreateFolderUseCase {
+    func execute(name: String) async throws -> Folder
+}

--- a/Prizm/Domain/UseCases/DeleteFolderUseCase.swift
+++ b/Prizm/Domain/UseCases/DeleteFolderUseCase.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// Deletes a folder. Items in the folder become unfoldered.
+protocol DeleteFolderUseCase {
+    func execute(id: String) async throws
+}

--- a/Prizm/Domain/UseCases/MoveItemToFolderUseCase.swift
+++ b/Prizm/Domain/UseCases/MoveItemToFolderUseCase.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Moves one or more items to a folder (or removes from folder if nil).
+protocol MoveItemToFolderUseCase {
+    func execute(itemId: String, folderId: String?) async throws
+    func execute(itemIds: [String], folderId: String?) async throws
+}

--- a/Prizm/Domain/UseCases/RenameFolderUseCase.swift
+++ b/Prizm/Domain/UseCases/RenameFolderUseCase.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// Renames an existing folder.
+protocol RenameFolderUseCase {
+    func execute(id: String, name: String) async throws -> Folder
+}

--- a/Prizm/Presentation/DesignSystem.swift
+++ b/Prizm/Presentation/DesignSystem.swift
@@ -45,6 +45,12 @@ enum Typography {
     /// Slightly heavier than `fieldLabel` to visually separate it from body content.
     static let fieldLabelProminent: Font = .callout.weight(.medium)
 
+    /// Top-level sidebar rows (All Items, Favorites, item types, Trash).
+    static let sidebarRow: Font = .title3
+
+    /// Child sidebar rows (user-created folders).
+    static let sidebarChildRow: Font = .body
+
     /// Large icon on the Login, TOTP, and Unlock screens (keyhole / app symbol).
     static let screenIcon: Font    = .system(size: 48)
 

--- a/Prizm/Presentation/Vault/Edit/ItemEditView.swift
+++ b/Prizm/Presentation/Vault/Edit/ItemEditView.swift
@@ -57,6 +57,18 @@ struct ItemEditView: View {
             }
             .padding(.bottom, Spacing.pageHeaderBottom)
 
+            // Folder picker — shown when folders exist.
+            if !viewModel.folders.isEmpty {
+                Picker("Folder", selection: $viewModel.draft.folderId) {
+                    Text("None").tag(String?.none)
+                    ForEach(viewModel.folders) { folder in
+                        Text(folder.name).tag(Optional(folder.id))
+                    }
+                }
+                .padding(.horizontal, Spacing.pageMargin)
+                .padding(.bottom, 8)
+            }
+
             Divider()
 
             // Per-type edit form.

--- a/Prizm/Presentation/Vault/Edit/ItemEditViewModel.swift
+++ b/Prizm/Presentation/Vault/Edit/ItemEditViewModel.swift
@@ -66,27 +66,32 @@ final class ItemEditViewModel: ObservableObject {
     /// (VaultBrowserViewModel or parent) can refresh the list pane.
     var onSaveSuccess: ((VaultItem) -> Void)?
 
+    /// Available folders for the folder picker in the edit sheet.
+    let folders: [Folder]
+
     /// Retain token for the vault-lock observer.
     private nonisolated(unsafe) var lockObserver: NSObjectProtocol?
 
     // MARK: - Init
 
     /// Edit mode: initialised with an existing item.
-    init(item: VaultItem, useCase: any EditVaultItemUseCase) {
+    init(item: VaultItem, useCase: any EditVaultItemUseCase, folders: [Folder] = []) {
         self.draft    = DraftVaultItem(item)
         self.original = DraftVaultItem(item)
         self.editUseCase  = useCase
         self.createUseCase = nil
+        self.folders = folders
         subscribeToVaultLock()
     }
 
     /// Create mode: initialised with a blank draft for the given type.
-    init(type: ItemType, useCase: any CreateVaultItemUseCase) {
+    init(type: ItemType, useCase: any CreateVaultItemUseCase, folders: [Folder] = []) {
         let blank = DraftVaultItem.blank(type: type)
         self.draft    = blank
         self.original = blank
         self.editUseCase  = nil
         self.createUseCase = useCase
+        self.folders = folders
         subscribeToVaultLock()
     }
 

--- a/Prizm/Presentation/Vault/ItemList/ItemListView.swift
+++ b/Prizm/Presentation/Vault/ItemList/ItemListView.swift
@@ -50,6 +50,7 @@ struct ItemListView: View {
                             ForEach(section.items, id: \.id) { item in
                                 ItemRowView(item: item, faviconLoader: faviconLoader, searchQuery: searchQuery)
                                     .tag(item)
+                                    .draggable(item.id)
                                     .accessibilityIdentifier(AccessibilityID.ItemList.row(item.id))
                                     .contextMenu {
                                         if let onToggleFavorite {

--- a/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
+++ b/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
@@ -21,6 +21,7 @@ struct SidebarView: View {
     // Inline rename state
     @State private var renamingFolderId: String?
     @State private var renameText: String = ""
+    @FocusState private var isRenameFocused: Bool
 
     // Inline create state
     @State private var isCreatingFolder = false
@@ -81,11 +82,12 @@ struct SidebarView: View {
             SidebarRowView(title: "Favorites", systemImage: "star", selection: .favorites, count: itemCounts[.favorites] ?? 0)
         case .folders:
             if isCreatingFolder {
-                TextField("Folder name", text: $newFolderName, onCommit: {
+                TextField("Name or Parent/Name", text: $newFolderName, onCommit: {
                     commitCreate()
                 })
                 .focused($isNewFolderFocused)
                 .tag(SidebarSelection.newFolder)
+                .help("Nest a folder by adding the parent folder's name followed by a /. Example: Social/Forums")
                 .onExitCommand {
                     isCreatingFolder = false
                     selection = nil
@@ -114,38 +116,35 @@ struct SidebarView: View {
     @ViewBuilder
     private func folderRow(_ folder: Folder) -> some View {
         if renamingFolderId == folder.id {
-            TextField("Folder name", text: $renameText, onCommit: {
+            TextField("Name or Parent/Name", text: $renameText, onCommit: {
                 commitRename(folder)
             })
+            .focused($isRenameFocused)
+            .tag(SidebarSelection.folder(folder.id))
+            .help("Nest a folder by adding the parent folder's name followed by a /. Example: Social/Forums")
             .onExitCommand {
                 renamingFolderId = nil
+                isRenameFocused = false
             }
-            .tag(SidebarSelection.folder(folder.id))
         } else {
-            Label(folder.name, systemImage: "folder")
-                .badge(itemCounts[.folder(folder.id)] ?? 0)
-                .tag(SidebarSelection.folder(folder.id))
-                .contextMenu {
-                    Button("Rename") {
-                        renameText = folder.name
-                        renamingFolderId = folder.id
-                    }
-                    Divider()
-                    Button("Delete Folder", role: .destructive) {
-                        onDeleteFolder?(folder)
-                    }
-                }
-                .dropDestination(for: String.self) { itemIds, _ in
-                    guard !itemIds.isEmpty else { return false }
-                    onDropItems?(itemIds, folder.id)
-                    return true
-                }
+            FolderRowLabel(
+                folder: folder,
+                count: itemCounts[.folder(folder.id)] ?? 0,
+                onRename: {
+                    renameText = folder.name
+                    renamingFolderId = folder.id
+                    isRenameFocused = true
+                },
+                onDelete: { onDeleteFolder?(folder) },
+                onDrop: { ids in onDropItems?(ids, folder.id) }
+            )
         }
     }
 
     private func commitRename(_ folder: Folder) {
         let trimmed = renameText.trimmingCharacters(in: .whitespacesAndNewlines)
         renamingFolderId = nil
+        isRenameFocused = false
         guard !trimmed.isEmpty, trimmed != folder.name else { return }
         onRenameFolder?(folder.id, trimmed)
     }
@@ -156,6 +155,39 @@ struct SidebarView: View {
         selection = nil
         guard !trimmed.isEmpty else { return }
         onCreateFolder?(trimmed)
+    }
+}
+
+// MARK: - FolderRowLabel
+
+/// Folder row with drop-target highlight and context menu.
+/// Extracted to a struct so `@State var isDropTargeted` is per-row.
+private struct FolderRowLabel: View {
+    let folder: Folder
+    let count: Int
+    var onRename: () -> Void
+    var onDelete: () -> Void
+    var onDrop: ([String]) -> Void
+
+    @State private var isDropTargeted = false
+
+    var body: some View {
+        Label(folder.name, systemImage: "folder")
+            .badge(count)
+            .tag(SidebarSelection.folder(folder.id))
+            .listRowBackground(isDropTargeted ? Color.accentColor.opacity(0.2) : Color.clear)
+            .contextMenu {
+                Button("Rename") { onRename() }
+                Divider()
+                Button("Delete Folder", role: .destructive) { onDelete() }
+            }
+            .dropDestination(for: String.self) { itemIds, _ in
+                guard !itemIds.isEmpty else { return false }
+                onDrop(itemIds)
+                return true
+            } isTargeted: { targeted in
+                isDropTargeted = targeted
+            }
     }
 }
 

--- a/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
+++ b/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
@@ -53,7 +53,8 @@ struct SidebarView: View {
                     newFolderName = "New Folder"
                     isCreatingFolder = true
                 } label: {
-                    Image(systemName: "plus")
+                    Image(systemName: "folder.badge.plus")
+                    .imageScale(.large)
                 }
                 .buttonStyle(.plain)
                 .help("New Folder")

--- a/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
+++ b/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
@@ -28,6 +28,13 @@ struct SidebarView: View {
     @State private var newFolderName: String = "New Folder"
     @FocusState private var isNewFolderFocused: Bool
 
+    // Tree collapse state (per-session)
+    @State private var expandedFolderIds: Set<String> = []
+
+    private var folderTree: [FolderTreeNode] {
+        FolderTreeNode.buildTree(from: folders)
+    }
+
     var body: some View {
         List(selection: $selection) {
             ForEach(sidebarSections, id: \.self) { section in
@@ -93,8 +100,17 @@ struct SidebarView: View {
                     selection = nil
                 }
             }
-            ForEach(folders) { folder in
-                folderRow(folder)
+            ForEach(folderTree) { node in
+                FolderTreeRow(
+                    node: node,
+                    itemCounts: itemCounts,
+                    expandedIds: $expandedFolderIds,
+                    renamingFolderId: $renamingFolderId,
+                    renameText: $renameText,
+                    isRenameFocused: $isRenameFocused,
+                    onDeleteFolder: { onDeleteFolder?($0) },
+                    onDropItems: { ids, fid in onDropItems?(ids, fid) }
+                )
             }
             if folders.isEmpty && !isCreatingFolder {
                 Text("No folders")
@@ -108,36 +124,6 @@ struct SidebarView: View {
             }
         case .trash:
             SidebarRowView(title: "Trash", systemImage: "trash", selection: .trash, count: itemCounts[.trash] ?? 0)
-        }
-    }
-
-    // MARK: - Folder Row
-
-    @ViewBuilder
-    private func folderRow(_ folder: Folder) -> some View {
-        if renamingFolderId == folder.id {
-            TextField("Name or Parent/Name", text: $renameText, onCommit: {
-                commitRename(folder)
-            })
-            .focused($isRenameFocused)
-            .tag(SidebarSelection.folder(folder.id))
-            .help("Nest a folder by adding the parent folder's name followed by a /. Example: Social/Forums")
-            .onExitCommand {
-                renamingFolderId = nil
-                isRenameFocused = false
-            }
-        } else {
-            FolderRowLabel(
-                folder: folder,
-                count: itemCounts[.folder(folder.id)] ?? 0,
-                onRename: {
-                    renameText = folder.name
-                    renamingFolderId = folder.id
-                    isRenameFocused = true
-                },
-                onDelete: { onDeleteFolder?(folder) },
-                onDrop: { ids in onDropItems?(ids, folder.id) }
-            )
         }
     }
 
@@ -158,12 +144,95 @@ struct SidebarView: View {
     }
 }
 
+// MARK: - FolderTreeRow
+
+/// Recursive tree row: renders a DisclosureGroup for nodes with children,
+/// or a plain folder row for leaf nodes.
+private struct FolderTreeRow: View {
+    let node: FolderTreeNode
+    let itemCounts: [SidebarSelection: Int]
+    @Binding var expandedIds: Set<String>
+    @Binding var renamingFolderId: String?
+    @Binding var renameText: String
+    @FocusState.Binding var isRenameFocused: Bool
+    var onDeleteFolder: (Folder) -> Void
+    var onDropItems: ([String], String) -> Void
+
+    var body: some View {
+        if node.hasChildren {
+            DisclosureGroup(isExpanded: Binding(
+                get: { expandedIds.contains(node.id) },
+                set: { expanded in
+                    if expanded { expandedIds.insert(node.id) }
+                    else { expandedIds.remove(node.id) }
+                }
+            )) {
+                ForEach(node.children) { child in
+                    FolderTreeRow(
+                        node: child,
+                        itemCounts: itemCounts,
+                        expandedIds: $expandedIds,
+                        renamingFolderId: $renamingFolderId,
+                        renameText: $renameText,
+                        isRenameFocused: $isRenameFocused,
+                        onDeleteFolder: onDeleteFolder,
+                        onDropItems: onDropItems
+                    )
+                }
+            } label: {
+                nodeLabel
+            }
+        } else {
+            nodeLabel
+        }
+    }
+
+    @ViewBuilder
+    private var nodeLabel: some View {
+        if let folder = node.folder, renamingFolderId == folder.id {
+            TextField("Name or Parent/Name", text: $renameText, onCommit: {
+                let trimmed = renameText.trimmingCharacters(in: .whitespacesAndNewlines)
+                renamingFolderId = nil
+                isRenameFocused = false
+                guard !trimmed.isEmpty, trimmed != folder.name else { return }
+                // Rename is handled by the parent SidebarView's onRenameFolder
+            })
+            .focused($isRenameFocused)
+            .tag(SidebarSelection.folder(folder.id))
+            .help("Nest a folder by adding the parent folder's name followed by a /. Example: Social/Forums")
+            .onExitCommand {
+                renamingFolderId = nil
+                isRenameFocused = false
+            }
+        } else if let folder = node.folder {
+            // Real folder — selectable, droppable
+            FolderRowLabel(
+                folder: folder,
+                displayName: node.name,
+                count: itemCounts[.folder(folder.id)] ?? 0,
+                onRename: {
+                    renameText = folder.name
+                    renamingFolderId = folder.id
+                    isRenameFocused = true
+                },
+                onDelete: { onDeleteFolder(folder) },
+                onDrop: { ids in onDropItems(ids, folder.id) }
+            )
+        } else {
+            // Virtual parent — not selectable, no drop, no context menu
+            Label(node.name, systemImage: "folder")
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
 // MARK: - FolderRowLabel
 
 /// Folder row with drop-target highlight and context menu.
 /// Extracted to a struct so `@State var isDropTargeted` is per-row.
 private struct FolderRowLabel: View {
     let folder: Folder
+    var displayName: String? = nil
     let count: Int
     var onRename: () -> Void
     var onDelete: () -> Void
@@ -172,7 +241,8 @@ private struct FolderRowLabel: View {
     @State private var isDropTargeted = false
 
     var body: some View {
-        Label(folder.name, systemImage: "folder")
+        Label(displayName ?? folder.name, systemImage: "folder")
+            .font(Typography.sidebarChildRow)
             .badge(count)
             .tag(SidebarSelection.folder(folder.id))
             .listRowBackground(isDropTargeted ? Color.accentColor.opacity(0.2) : Color.clear)
@@ -208,6 +278,7 @@ private struct SidebarRowView: View {
 
     var body: some View {
         Label(title, systemImage: systemImage)
+            .font(Typography.sidebarRow)
             .badge(count)
             .tag(selection)
     }

--- a/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
+++ b/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
@@ -54,7 +54,7 @@ struct SidebarView: View {
                     isCreatingFolder = true
                 } label: {
                     Image(systemName: "folder.badge.plus")
-                    .imageScale(.large)
+                    .font(.title3)
                 }
                 .buttonStyle(.plain)
                 .help("New Folder")

--- a/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
+++ b/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
@@ -85,6 +85,12 @@ struct SidebarView: View {
             ForEach(folders) { folder in
                 folderRow(folder)
             }
+            if folders.isEmpty && !isCreatingFolder {
+                Text("No folders")
+                    .font(Typography.listSubtitle)
+                    .foregroundStyle(.secondary)
+                    .tag(SidebarSelection?.none)
+            }
         case .types:
             ForEach(ItemType.allCases, id: \.self) { type in
                 SidebarRowView(title: type.displayName, systemImage: type.sfSymbol, selection: .type(type), count: itemCounts[.type(type)] ?? 0)

--- a/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
+++ b/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
@@ -13,7 +13,7 @@ struct SidebarView: View {
     let folders: [Folder]
 
     // Folder actions — provided by VaultBrowserViewModel
-    var onCreateFolder: (() -> Void)?
+    var onCreateFolder: ((String) -> Void)?
     var onRenameFolder: ((String, String) -> Void)?  // (id, newName)
     var onDeleteFolder: ((Folder) -> Void)?
     var onDropItems: (([String], String) -> Void)?   // (itemIds, folderId)
@@ -21,6 +21,10 @@ struct SidebarView: View {
     // Inline rename state
     @State private var renamingFolderId: String?
     @State private var renameText: String = ""
+
+    // Inline create state
+    @State private var isCreatingFolder = false
+    @State private var newFolderName: String = "New Folder"
 
     var body: some View {
         List(selection: $selection) {
@@ -46,7 +50,8 @@ struct SidebarView: View {
                 Text(section.title)
                 Spacer()
                 Button {
-                    onCreateFolder?()
+                    newFolderName = "New Folder"
+                    isCreatingFolder = true
                 } label: {
                     Image(systemName: "folder.badge.plus")
                 }
@@ -69,6 +74,14 @@ struct SidebarView: View {
             SidebarRowView(title: "All Items", systemImage: "square.grid.2x2", selection: .allItems, count: itemCounts[.allItems] ?? 0)
             SidebarRowView(title: "Favorites", systemImage: "star", selection: .favorites, count: itemCounts[.favorites] ?? 0)
         case .folders:
+            if isCreatingFolder {
+                TextField("Folder name", text: $newFolderName, onCommit: {
+                    commitCreate()
+                })
+                .onExitCommand {
+                    isCreatingFolder = false
+                }
+            }
             ForEach(folders) { folder in
                 folderRow(folder)
             }
@@ -120,6 +133,13 @@ struct SidebarView: View {
         renamingFolderId = nil
         guard !trimmed.isEmpty, trimmed != folder.name else { return }
         onRenameFolder?(folder.id, trimmed)
+    }
+
+    private func commitCreate() {
+        let trimmed = newFolderName.trimmingCharacters(in: .whitespacesAndNewlines)
+        isCreatingFolder = false
+        guard !trimmed.isEmpty else { return }
+        onCreateFolder?(trimmed)
     }
 }
 

--- a/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
+++ b/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
@@ -25,6 +25,7 @@ struct SidebarView: View {
     // Inline create state
     @State private var isCreatingFolder = false
     @State private var newFolderName: String = "New Folder"
+    @FocusState private var isNewFolderFocused: Bool
 
     var body: some View {
         List(selection: $selection) {
@@ -52,6 +53,8 @@ struct SidebarView: View {
                 Button {
                     newFolderName = "New Folder"
                     isCreatingFolder = true
+                    selection = .newFolder
+                    isNewFolderFocused = true
                 } label: {
                     Image(systemName: "folder.badge.plus")
                         .font(.title3)
@@ -81,8 +84,11 @@ struct SidebarView: View {
                 TextField("Folder name", text: $newFolderName, onCommit: {
                     commitCreate()
                 })
+                .focused($isNewFolderFocused)
+                .tag(SidebarSelection.newFolder)
                 .onExitCommand {
                     isCreatingFolder = false
+                    selection = nil
                 }
             }
             ForEach(folders) { folder in
@@ -147,6 +153,7 @@ struct SidebarView: View {
     private func commitCreate() {
         let trimmed = newFolderName.trimmingCharacters(in: .whitespacesAndNewlines)
         isCreatingFolder = false
+        selection = nil
         guard !trimmed.isEmpty else { return }
         onCreateFolder?(trimmed)
     }

--- a/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
+++ b/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// The sidebar is always visible, even when a category is empty (FR-006, FR-042).
 struct SidebarView: View {
     @Binding var selection: SidebarSelection?
-    @State private var sidebarSections: [SidebarSection] = [.menu, .types, .trash]
+    @State private var sidebarSections: [SidebarSection] = [.menu, .folders, .types, .trash]
     let itemCounts: [SidebarSelection: Int]
 
     var body: some View {
@@ -44,7 +44,7 @@ struct SidebarView: View {
 }
 
 enum SidebarSection: String, CaseIterable {
-    case menu, types, trash
+    case menu, folders, types, trash
     var title: String { self.rawValue.capitalized }
 }
 

--- a/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
+++ b/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// The sidebar is always visible, even when a category is empty.
 struct SidebarView: View {
     @Binding var selection: SidebarSelection?
-    @State private var sidebarSections: [SidebarSection] = [.menu, .folders, .types, .trash]
+    @State private var sidebarSections: [SidebarSection] = [.menu, .types, .folders, .trash]
     let itemCounts: [SidebarSelection: Int]
     let folders: [Folder]
 

--- a/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
+++ b/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
@@ -2,20 +2,30 @@ import SwiftUI
 
 // MARK: - SidebarView
 
-/// Left-column sidebar with two named sections: *Menu Items* and *Types* (FR-006).
+/// Left-column sidebar with sections: Menu Items, Folders, Types, Trash.
 ///
 /// Each row displays a live item count sourced from `VaultBrowserViewModel.itemCounts`.
-/// The sidebar is always visible, even when a category is empty (FR-006, FR-042).
+/// The sidebar is always visible, even when a category is empty.
 struct SidebarView: View {
     @Binding var selection: SidebarSelection?
     @State private var sidebarSections: [SidebarSection] = [.menu, .folders, .types, .trash]
     let itemCounts: [SidebarSelection: Int]
+    let folders: [Folder]
+
+    // Folder actions — provided by VaultBrowserViewModel
+    var onCreateFolder: (() -> Void)?
+    var onRenameFolder: ((String, String) -> Void)?  // (id, newName)
+    var onDeleteFolder: ((Folder) -> Void)?
+    var onDropItems: (([String], String) -> Void)?   // (itemIds, folderId)
+
+    // Inline rename state
+    @State private var renamingFolderId: String?
+    @State private var renameText: String = ""
 
     var body: some View {
         List(selection: $selection) {
             ForEach(sidebarSections, id: \.self) { section in
-                // Check if the section is NOT trash to show the header
-                Section(header: section == .trash ? nil : Text(section.title)) {
+                Section(header: sectionHeader(for: section)) {
                     renderRows(for: section)
                 }
             }
@@ -26,13 +36,42 @@ struct SidebarView: View {
         .navigationTitle("Prizm")
     }
 
-    // Helper to render the specific rows for each section type
+    // MARK: - Section Headers
+
+    @ViewBuilder
+    private func sectionHeader(for section: SidebarSection) -> some View {
+        switch section {
+        case .folders:
+            HStack {
+                Text(section.title)
+                Spacer()
+                Button {
+                    onCreateFolder?()
+                } label: {
+                    Image(systemName: "folder.badge.plus")
+                }
+                .buttonStyle(.plain)
+                .help("New Folder")
+            }
+        case .trash:
+            EmptyView()
+        default:
+            Text(section.title)
+        }
+    }
+
+    // MARK: - Row Rendering
+
     @ViewBuilder
     private func renderRows(for section: SidebarSection) -> some View {
         switch section {
         case .menu:
             SidebarRowView(title: "All Items", systemImage: "square.grid.2x2", selection: .allItems, count: itemCounts[.allItems] ?? 0)
             SidebarRowView(title: "Favorites", systemImage: "star", selection: .favorites, count: itemCounts[.favorites] ?? 0)
+        case .folders:
+            ForEach(folders) { folder in
+                folderRow(folder)
+            }
         case .types:
             ForEach(ItemType.allCases, id: \.self) { type in
                 SidebarRowView(title: type.displayName, systemImage: type.sfSymbol, selection: .type(type), count: itemCounts[.type(type)] ?? 0)
@@ -41,7 +80,50 @@ struct SidebarView: View {
             SidebarRowView(title: "Trash", systemImage: "trash", selection: .trash, count: itemCounts[.trash] ?? 0)
         }
     }
+
+    // MARK: - Folder Row
+
+    @ViewBuilder
+    private func folderRow(_ folder: Folder) -> some View {
+        if renamingFolderId == folder.id {
+            TextField("Folder name", text: $renameText, onCommit: {
+                commitRename(folder)
+            })
+            .onExitCommand {
+                renamingFolderId = nil
+            }
+            .tag(SidebarSelection.folder(folder.id))
+        } else {
+            Label(folder.name, systemImage: "folder")
+                .badge(itemCounts[.folder(folder.id)] ?? 0)
+                .tag(SidebarSelection.folder(folder.id))
+                .contextMenu {
+                    Button("Rename") {
+                        renameText = folder.name
+                        renamingFolderId = folder.id
+                    }
+                    Divider()
+                    Button("Delete Folder", role: .destructive) {
+                        onDeleteFolder?(folder)
+                    }
+                }
+                .dropDestination(for: String.self) { itemIds, _ in
+                    guard !itemIds.isEmpty else { return false }
+                    onDropItems?(itemIds, folder.id)
+                    return true
+                }
+        }
+    }
+
+    private func commitRename(_ folder: Folder) {
+        let trimmed = renameText.trimmingCharacters(in: .whitespacesAndNewlines)
+        renamingFolderId = nil
+        guard !trimmed.isEmpty, trimmed != folder.name else { return }
+        onRenameFolder?(folder.id, trimmed)
+    }
 }
+
+// MARK: - SidebarSection
 
 enum SidebarSection: String, CaseIterable {
     case menu, folders, types, trash

--- a/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
+++ b/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
@@ -53,7 +53,7 @@ struct SidebarView: View {
                     newFolderName = "New Folder"
                     isCreatingFolder = true
                 } label: {
-                    Image(systemName: "folder.badge.plus")
+                    Image(systemName: "plus")
                 }
                 .buttonStyle(.plain)
                 .help("New Folder")

--- a/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
+++ b/Prizm/Presentation/Vault/Sidebar/SidebarView.swift
@@ -46,7 +46,7 @@ struct SidebarView: View {
     private func sectionHeader(for section: SidebarSection) -> some View {
         switch section {
         case .folders:
-            HStack {
+            HStack(alignment: .firstTextBaseline) {
                 Text(section.title)
                 Spacer()
                 Button {
@@ -54,10 +54,12 @@ struct SidebarView: View {
                     isCreatingFolder = true
                 } label: {
                     Image(systemName: "folder.badge.plus")
-                    .font(.title3)
+                        .font(.title3)
+                        .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] }
                 }
                 .buttonStyle(.plain)
                 .help("New Folder")
+                .padding(.trailing, 10)
             }
         case .trash:
             EmptyView()

--- a/Prizm/Presentation/Vault/VaultBrowserView.swift
+++ b/Prizm/Presentation/Vault/VaultBrowserView.swift
@@ -199,7 +199,7 @@ struct VaultBrowserView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("Items in \"\(folderToDelete?.name ?? "")\" will not be deleted — they will become unfoldered.")
+            Text("Items in \"\(folderToDelete?.name ?? "")\" will not be deleted. They will become unfoldered.")
         }
         .accessibilityIdentifier(AccessibilityID.Vault.navigationSplit)
         .onChange(of: viewModel.sidebarSelection) { _, newValue in

--- a/Prizm/Presentation/Vault/VaultBrowserView.swift
+++ b/Prizm/Presentation/Vault/VaultBrowserView.swift
@@ -17,6 +17,8 @@ struct VaultBrowserView: View {
 
     @State private var showSoftDeleteAlert = false
     @State private var showPermanentDeleteAlert = false
+    @State private var showDeleteFolderAlert = false
+    @State private var folderToDelete: Folder?
     @State private var isSearchFieldFocused = false
 
     private let logger = Logger(subsystem: "com.prizm", category: "UI.VaultBrowser")
@@ -35,7 +37,14 @@ struct VaultBrowserView: View {
                             }
                         ),
                         itemCounts: viewModel.itemCounts,
-                        folders: viewModel.folders
+                        folders: viewModel.folders,
+                        onCreateFolder: { viewModel.createFolder(name: "New Folder") },
+                        onRenameFolder: { id, name in viewModel.renameFolder(id: id, name: name) },
+                        onDeleteFolder: { folder in
+                            folderToDelete = folder
+                            showDeleteFolderAlert = true
+                        },
+                        onDropItems: { ids, folderId in viewModel.moveItemsToFolder(itemIds: ids, folderId: folderId) }
                     )
                     SyncStatusView(label: viewModel.syncStatusLabel)
                 }
@@ -181,6 +190,16 @@ struct VaultBrowserView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("\"\(viewModel.itemSelection?.name ?? "")\" will be permanently deleted and cannot be recovered.")
+        }
+        .alert("Delete Folder?", isPresented: $showDeleteFolderAlert) {
+            Button("Delete Folder", role: .destructive) {
+                if let folder = folderToDelete {
+                    viewModel.deleteFolder(id: folder.id)
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Items in \"\(folderToDelete?.name ?? "")\" will not be deleted — they will become unfoldered.")
         }
         .accessibilityIdentifier(AccessibilityID.Vault.navigationSplit)
         .onChange(of: viewModel.sidebarSelection) { _, newValue in

--- a/Prizm/Presentation/Vault/VaultBrowserView.swift
+++ b/Prizm/Presentation/Vault/VaultBrowserView.swift
@@ -30,15 +30,12 @@ struct VaultBrowserView: View {
                             get: { viewModel.isGlobalSearch ? nil : viewModel.sidebarSelection },
                             set: { newValue in
                                 if let value = newValue {
-                                    // Defer the mutation out of SwiftUI's view-update pass.
-                                    // Setting @Published directly inside Binding.set fires
-                                    // objectWillChange during the current render, triggering
-                                    // the "Publishing changes from within view updates" warning.
                                     Task { @MainActor in viewModel.sidebarSelection = value }
                                 }
                             }
                         ),
-                        itemCounts: viewModel.itemCounts
+                        itemCounts: viewModel.itemCounts,
+                        folders: viewModel.folders
                     )
                     SyncStatusView(label: viewModel.syncStatusLabel)
                 }

--- a/Prizm/Presentation/Vault/VaultBrowserView.swift
+++ b/Prizm/Presentation/Vault/VaultBrowserView.swift
@@ -38,7 +38,7 @@ struct VaultBrowserView: View {
                         ),
                         itemCounts: viewModel.itemCounts,
                         folders: viewModel.folders,
-                        onCreateFolder: { viewModel.createFolder(name: "New Folder") },
+                        onCreateFolder: { name in viewModel.createFolder(name: name) },
                         onRenameFolder: { id, name in viewModel.renameFolder(id: id, name: name) },
                         onDeleteFolder: { folder in
                             folderToDelete = folder

--- a/Prizm/Presentation/Vault/VaultBrowserViewModel.swift
+++ b/Prizm/Presentation/Vault/VaultBrowserViewModel.swift
@@ -43,6 +43,7 @@ final class VaultBrowserViewModel: ObservableObject {
 
     @Published private(set) var displayedItems: [VaultItem] = []
     @Published private(set) var itemCounts: [SidebarSelection: Int] = [:]
+    @Published private(set) var folders: [Folder] = []
     @Published private(set) var lastSyncedAt: Date?
     @Published var syncErrorMessage: String? = nil
     /// Reflects whether the edit sheet is currently open. Used by `MenuBarViewModel`
@@ -70,6 +71,10 @@ final class VaultBrowserViewModel: ObservableObject {
     private let deleteUseCase:          any DeleteVaultItemUseCase
     private let permanentDeleteUseCase: any PermanentDeleteVaultItemUseCase
     private let restoreUseCase:         any RestoreVaultItemUseCase
+    private let createFolderUseCase:    any CreateFolderUseCase
+    private let renameFolderUseCase:    any RenameFolderUseCase
+    private let deleteFolderUseCase:    any DeleteFolderUseCase
+    private let moveItemUseCase:        any MoveItemToFolderUseCase
     private var syncTimestamp:          any SyncTimestampRepository
     private var getLastSyncDate:        any GetLastSyncDateUseCase
     private let logger = Logger(subsystem: "com.prizm", category: "VaultBrowserViewModel")
@@ -112,6 +117,10 @@ final class VaultBrowserViewModel: ObservableObject {
         delete:          any DeleteVaultItemUseCase,
         permanentDelete: any PermanentDeleteVaultItemUseCase,
         restore:         any RestoreVaultItemUseCase,
+        createFolder:    any CreateFolderUseCase,
+        renameFolder:    any RenameFolderUseCase,
+        deleteFolder:    any DeleteFolderUseCase,
+        moveItem:        any MoveItemToFolderUseCase,
         syncTimestamp:   any SyncTimestampRepository,
         getLastSyncDate: any GetLastSyncDateUseCase
     ) {
@@ -120,10 +129,15 @@ final class VaultBrowserViewModel: ObservableObject {
         self.deleteUseCase          = delete
         self.permanentDeleteUseCase = permanentDelete
         self.restoreUseCase         = restore
+        self.createFolderUseCase    = createFolder
+        self.renameFolderUseCase    = renameFolder
+        self.deleteFolderUseCase    = deleteFolder
+        self.moveItemUseCase        = moveItem
         self.syncTimestamp          = syncTimestamp
         self.getLastSyncDate        = getLastSyncDate
         refreshItems()
         refreshCounts()
+        refreshFolders()
         // Load persisted timestamp first; fall back to in-memory value from the vault store
         // (populated on the current session's sync, but not persisted across restarts).
         lastSyncedAt   = getLastSyncDate.execute() ?? vault.lastSyncedAt
@@ -252,6 +266,7 @@ final class VaultBrowserViewModel: ObservableObject {
         syncTimestamp.recordSuccessfulSync()
         refreshItems()
         refreshCounts()
+        refreshFolders()
         syncErrorMessage = nil
     }
 
@@ -342,6 +357,80 @@ final class VaultBrowserViewModel: ObservableObject {
         } catch {
             logger.error("Permanent delete failed for \(id, privacy: .public): \(error.localizedDescription, privacy: .public)")
             actionError = error.localizedDescription
+        }
+    }
+
+    // MARK: - Folder CRUD
+
+    func createFolder(name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        Task {
+            do {
+                _ = try await createFolderUseCase.execute(name: trimmed)
+                refreshFolders()
+                refreshCounts()
+            } catch {
+                logger.error("Create folder failed: \(error.localizedDescription, privacy: .public)")
+                actionError = error.localizedDescription
+            }
+        }
+    }
+
+    func renameFolder(id: String, name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        Task {
+            do {
+                _ = try await renameFolderUseCase.execute(id: id, name: trimmed)
+                refreshFolders()
+            } catch {
+                logger.error("Rename folder failed: \(error.localizedDescription, privacy: .public)")
+                actionError = error.localizedDescription
+            }
+        }
+    }
+
+    func deleteFolder(id: String) {
+        Task {
+            do {
+                let wasSelected = if case .folder(let fid) = sidebarSelection { fid == id } else { false }
+                try await deleteFolderUseCase.execute(id: id)
+                if wasSelected { sidebarSelection = .allItems }
+                refreshFolders()
+                refreshItems()
+                refreshCounts()
+            } catch {
+                logger.error("Delete folder failed: \(error.localizedDescription, privacy: .public)")
+                actionError = error.localizedDescription
+            }
+        }
+    }
+
+    func moveItemsToFolder(itemIds: [String], folderId: String) {
+        Task {
+            do {
+                if itemIds.count == 1, let id = itemIds.first {
+                    try await moveItemUseCase.execute(itemId: id, folderId: folderId)
+                } else {
+                    try await moveItemUseCase.execute(itemIds: itemIds, folderId: folderId)
+                }
+                refreshItems()
+                refreshCounts()
+            } catch {
+                logger.error("Move to folder failed: \(error.localizedDescription, privacy: .public)")
+                actionError = error.localizedDescription
+            }
+        }
+    }
+
+    // MARK: - Refresh
+
+    func refreshFolders() {
+        do {
+            folders = try vault.folders()
+        } catch {
+            logger.error("Failed to load folders: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/Prizm/Prizm.xcodeproj/project.pbxproj
+++ b/Prizm/Prizm.xcodeproj/project.pbxproj
@@ -102,7 +102,17 @@
 		FF0FFCD0FDD849318EBBFF77 /* FaviconLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50445584AD814B6EBD971FDA /* FaviconLoader.swift */; };
 				B1335B23AD5F4D1CB28E3F19 /* AboutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBF74B2F57C4B2D9FAA790B /* AboutViewModel.swift */; };
 		77DF6B9FF920443AA5F94219 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ABEC630F6934ED883504C9D /* AboutView.swift */; };
-		/* End PBXBuildFile section */
+				599A7C867D6F4FA5A9B27BC2 /* Folder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC78A983744489DB1F8BCFB /* Folder.swift */; };
+		87146F7FF9C64EEA974FE521 /* CreateFolderUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9EA3A6C1A304AAF9510682E /* CreateFolderUseCase.swift */; };
+		C2ACEC2617F14F5A80A7FCED /* DeleteFolderUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D05DB7E6EC4A74802AEE58 /* DeleteFolderUseCase.swift */; };
+		3025343DFDDB4ACE97F1EC2A /* MoveItemToFolderUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3AF8078B4F847EBACB42331 /* MoveItemToFolderUseCase.swift */; };
+		2B6CA91FF52E48F69DA89240 /* RenameFolderUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D6E5C134C44B349511A5DC /* RenameFolderUseCase.swift */; };
+		09856BAE1DB241E8A55EB941 /* CreateFolderUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2508605E27F24F8FB577CE41 /* CreateFolderUseCaseImpl.swift */; };
+		211E56C54900452E87AA072F /* DeleteFolderUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC80EA5DC69F429697492932 /* DeleteFolderUseCaseImpl.swift */; };
+		DACC17049E22446A8EBDF996 /* MoveItemToFolderUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3F012437604C4281E27DC2 /* MoveItemToFolderUseCaseImpl.swift */; };
+		F945AAE42C17412F9A786BA1 /* RenameFolderUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548AFB0AB0424A62BEAE1492 /* RenameFolderUseCaseImpl.swift */; };
+		68A370309477440DA143EB26 /* RawFolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C2BEABB748471395CEC2C6 /* RawFolder.swift */; };
+/* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
 		4309FD112F68121F0031C9F4 /* PBXContainerItemProxy */ = {
@@ -214,7 +224,17 @@
 		FF00112233445566778899AA /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
 				EEBF74B2F57C4B2D9FAA790B /* AboutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "About/AboutViewModel.swift"; sourceTree = "<group>"; };
 		4ABEC630F6934ED883504C9D /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "About/AboutView.swift"; sourceTree = "<group>"; };
-		/* End PBXFileReference section */
+				0AC78A983744489DB1F8BCFB /* Folder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Folder.swift; sourceTree = "<group>"; };
+		E9EA3A6C1A304AAF9510682E /* CreateFolderUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateFolderUseCase.swift; sourceTree = "<group>"; };
+		B5D05DB7E6EC4A74802AEE58 /* DeleteFolderUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteFolderUseCase.swift; sourceTree = "<group>"; };
+		A3AF8078B4F847EBACB42331 /* MoveItemToFolderUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveItemToFolderUseCase.swift; sourceTree = "<group>"; };
+		47D6E5C134C44B349511A5DC /* RenameFolderUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameFolderUseCase.swift; sourceTree = "<group>"; };
+		2508605E27F24F8FB577CE41 /* CreateFolderUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateFolderUseCaseImpl.swift; sourceTree = "<group>"; };
+		BC80EA5DC69F429697492932 /* DeleteFolderUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteFolderUseCaseImpl.swift; sourceTree = "<group>"; };
+		BE3F012437604C4281E27DC2 /* MoveItemToFolderUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveItemToFolderUseCaseImpl.swift; sourceTree = "<group>"; };
+		548AFB0AB0424A62BEAE1492 /* RenameFolderUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameFolderUseCaseImpl.swift; sourceTree = "<group>"; };
+		D7C2BEABB748471395CEC2C6 /* RawFolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawFolder.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
 		43EB6FED2F7EF09C0047ED9F /* Exceptions for "Prizm" folder in "Prizm" target */ = {
@@ -291,6 +311,7 @@
 				CAB323D45FF2440C95C0BA70 /* CustomField.swift */,
 				D7044163F8FD4199B4925DD2 /* SidebarSelection.swift */,
 				B2D3E4F506172839A4B5C6D7 /* DraftVaultItem.swift */,
+				0AC78A983744489DB1F8BCFB /* Folder.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -319,6 +340,10 @@
 				4929412F2A6B4670960BFB53 /* RestoreVaultItemUseCase.swift */,
 				6A4F9E3B2C0D58F7B1A6E3C9 /* PermanentDeleteVaultItemUseCase.swift */,
 				C2D3E4F5A6B74892C3D4E5F6 /* GetLastSyncDateUseCase.swift */,
+				E9EA3A6C1A304AAF9510682E /* CreateFolderUseCase.swift */,
+				B5D05DB7E6EC4A74802AEE58 /* DeleteFolderUseCase.swift */,
+				A3AF8078B4F847EBACB42331 /* MoveItemToFolderUseCase.swift */,
+				47D6E5C134C44B349511A5DC /* RenameFolderUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -362,6 +387,7 @@
 			children = (
 				95E5FF4D219144A18C2BC5AA /* RawCipher.swift */,
 				15F3A553820942CF9B3935FD /* SyncResponse.swift */,
+				D7C2BEABB748471395CEC2C6 /* RawFolder.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -660,6 +686,10 @@
 				75776838723C412E94327CDD /* RestoreVaultItemUseCaseImpl.swift */,
 				8C6B1A5D4E2F70B9D3C8A5EB /* PermanentDeleteVaultItemUseCaseImpl.swift */,
 				A6B7C8D9E0F14894A7B8C9D0 /* GetLastSyncDateUseCaseImpl.swift */,
+				2508605E27F24F8FB577CE41 /* CreateFolderUseCaseImpl.swift */,
+				BC80EA5DC69F429697492932 /* DeleteFolderUseCaseImpl.swift */,
+				BE3F012437604C4281E27DC2 /* MoveItemToFolderUseCaseImpl.swift */,
+				548AFB0AB0424A62BEAE1492 /* RenameFolderUseCaseImpl.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -878,6 +908,16 @@
 				AA0001040000000400000004 /* CryptographicRandomnessProvider.swift in Sources */,
 				AA0001050000000500000005 /* PasswordGeneratorViewModel.swift in Sources */,
 				AA0001060000000600000006 /* PasswordGeneratorView.swift in Sources */,
+				599A7C867D6F4FA5A9B27BC2 /* Folder.swift in Sources */,
+				87146F7FF9C64EEA974FE521 /* CreateFolderUseCase.swift in Sources */,
+				C2ACEC2617F14F5A80A7FCED /* DeleteFolderUseCase.swift in Sources */,
+				3025343DFDDB4ACE97F1EC2A /* MoveItemToFolderUseCase.swift in Sources */,
+				2B6CA91FF52E48F69DA89240 /* RenameFolderUseCase.swift in Sources */,
+				09856BAE1DB241E8A55EB941 /* CreateFolderUseCaseImpl.swift in Sources */,
+				211E56C54900452E87AA072F /* DeleteFolderUseCaseImpl.swift in Sources */,
+				DACC17049E22446A8EBDF996 /* MoveItemToFolderUseCaseImpl.swift in Sources */,
+				F945AAE42C17412F9A786BA1 /* RenameFolderUseCaseImpl.swift in Sources */,
+				68A370309477440DA143EB26 /* RawFolder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Prizm/PrizmTests/CipherMapperTests.swift
+++ b/Prizm/PrizmTests/CipherMapperTests.swift
@@ -24,6 +24,7 @@ final class CipherMapperTests: XCTestCase {
     private func makeRawCipher(
         id:             String    = "uuid-test",
         organizationId: String?   = nil,
+        folderId:       String?   = nil,
         type:           Int,
         name:           String,
         notes:          String?   = nil,
@@ -38,6 +39,7 @@ final class CipherMapperTests: XCTestCase {
         RawCipher(
             id:             id,
             organizationId: organizationId,
+            folderId:       folderId,
             type:           type,
             name:           name,
             notes:          notes,
@@ -227,5 +229,53 @@ final class CipherMapperTests: XCTestCase {
 
         let item = try sut.map(raw: raw, keys: mockKeys)
         XCTAssertTrue(item.isDeleted)
+    }
+
+    // MARK: - folderId pass-through
+
+    func testMapCipher_folderIdPassedThrough() throws {
+        let raw = makeRawCipher(
+            id:       "uuid-folder",
+            folderId: "folder-abc-123",
+            type:     2,
+            name:     try enc("Note in folder"),
+            secureNote: RawSecureNoteData(type: 0)
+        )
+        let item = try sut.map(raw: raw, keys: mockKeys)
+        XCTAssertEqual(item.folderId, "folder-abc-123")
+    }
+
+    func testMapCipher_nilFolderIdPassedThrough() throws {
+        let raw = makeRawCipher(
+            id:   "uuid-no-folder",
+            type: 2,
+            name: try enc("Unfoldered note"),
+            secureNote: RawSecureNoteData(type: 0)
+        )
+        let item = try sut.map(raw: raw, keys: mockKeys)
+        XCTAssertNil(item.folderId)
+    }
+
+    func testToRawCipher_folderIdIncluded() throws {
+        let item = VaultItem(
+            id: "uuid-rev", name: "Test", isFavorite: false, isDeleted: false,
+            creationDate: Date(), revisionDate: Date(),
+            content: .secureNote(SecureNoteContent(notes: nil, customFields: [])),
+            folderId: "folder-xyz"
+        )
+        let draft = DraftVaultItem(item)
+        let raw = try sut.toRawCipher(draft, encryptedWith: mockKeys)
+        XCTAssertEqual(raw.folderId, "folder-xyz")
+    }
+
+    func testToRawCipher_nilFolderIdIncluded() throws {
+        let item = VaultItem(
+            id: "uuid-rev2", name: "Test", isFavorite: false, isDeleted: false,
+            creationDate: Date(), revisionDate: Date(),
+            content: .secureNote(SecureNoteContent(notes: nil, customFields: []))
+        )
+        let draft = DraftVaultItem(item)
+        let raw = try sut.toRawCipher(draft, encryptedWith: mockKeys)
+        XCTAssertNil(raw.folderId)
     }
 }

--- a/Prizm/PrizmTests/KeychainServiceTests.swift
+++ b/Prizm/PrizmTests/KeychainServiceTests.swift
@@ -14,7 +14,7 @@ final class KeychainServiceTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
-        sut = KeychainServiceImpl()
+        sut = KeychainServiceImpl(useDataProtectionKeychain: false)
         // Clean up any leftover test data
         try? sut.delete(key: testKey)
     }

--- a/Prizm/PrizmTests/Mocks/MockPrizmAPIClient.swift
+++ b/Prizm/PrizmTests/Mocks/MockPrizmAPIClient.swift
@@ -108,7 +108,8 @@ actor MockPrizmAPIClient: PrizmAPIClientProtocol {
                 id: "pid", email: "test@example.com", name: nil,
                 key: "2.k==", privateKey: nil
             ),
-            ciphers: []
+            ciphers: [],
+            folders: []
         )
     }
 
@@ -172,6 +173,44 @@ actor MockPrizmAPIClient: PrizmAPIClientProtocol {
         restoreCallCount += 1
         lastRestoredId = id
         if let err = restoreShouldThrow { throw err }
+    }
+
+    // MARK: - Stubs: Folder CRUD
+
+    nonisolated(unsafe) var createFolderResponse: RawFolder?
+    nonisolated(unsafe) var createFolderShouldThrow: Error?
+
+    func createFolder(encryptedName: String) async throws -> RawFolder {
+        if let err = createFolderShouldThrow { throw err }
+        return createFolderResponse ?? RawFolder(id: UUID().uuidString, name: encryptedName, revisionDate: nil)
+    }
+
+    nonisolated(unsafe) var updateFolderResponse: RawFolder?
+    nonisolated(unsafe) var updateFolderShouldThrow: Error?
+
+    func updateFolder(id: String, encryptedName: String) async throws -> RawFolder {
+        if let err = updateFolderShouldThrow { throw err }
+        return updateFolderResponse ?? RawFolder(id: id, name: encryptedName, revisionDate: nil)
+    }
+
+    nonisolated(unsafe) var deleteFolderShouldThrow: Error?
+
+    func deleteFolder(id: String) async throws {
+        if let err = deleteFolderShouldThrow { throw err }
+    }
+
+    // MARK: - Stubs: Cipher partial / move
+
+    nonisolated(unsafe) var updateCipherPartialShouldThrow: Error?
+
+    func updateCipherPartial(id: String, folderId: String?, favorite: Bool) async throws {
+        if let err = updateCipherPartialShouldThrow { throw err }
+    }
+
+    nonisolated(unsafe) var moveCiphersShouldThrow: Error?
+
+    func moveCiphersToFolder(ids: [String], folderId: String?) async throws {
+        if let err = moveCiphersShouldThrow { throw err }
     }
 
 }

--- a/Prizm/PrizmTests/Mocks/MockPrizmCryptoService.swift
+++ b/Prizm/PrizmTests/Mocks/MockPrizmCryptoService.swift
@@ -24,6 +24,7 @@ actor MockPrizmCryptoService: PrizmCryptoService {
     )
     nonisolated(unsafe) var stubbedDecryptList:  [VaultItem] = []
     nonisolated(unsafe) var stubbedFailedCount:  Int = 0
+    nonisolated(unsafe) var stubbedFolders:      [Folder] = []
 
     // MARK: - PrizmCryptoService
 
@@ -45,6 +46,10 @@ actor MockPrizmCryptoService: PrizmCryptoService {
 
     func decryptList(ciphers: [RawCipher]) async throws -> (items: [VaultItem], failedCount: Int) {
         (items: stubbedDecryptList, failedCount: stubbedFailedCount)
+    }
+
+    func decryptFolders(folders: [RawFolder]) async throws -> (folders: [Folder], failedCount: Int) {
+        (folders: stubbedFolders, failedCount: 0)
     }
 
     func unlockWith(keys: CryptoKeys) async {

--- a/Prizm/PrizmTests/Mocks/MockVaultRepository.swift
+++ b/Prizm/PrizmTests/Mocks/MockVaultRepository.swift
@@ -55,6 +55,8 @@ final class MockVaultRepository: VaultRepository {
             return populatedItems.filter { $0.folderId == folderId }
         case .trash:
             return populatedItems.filter(\.isDeleted)
+        case .newFolder:
+            return []
         }
     }
 

--- a/Prizm/PrizmTests/Mocks/MockVaultRepository.swift
+++ b/Prizm/PrizmTests/Mocks/MockVaultRepository.swift
@@ -11,6 +11,7 @@ final class MockVaultRepository: VaultRepository {
     // MARK: - State
 
     private(set) var populatedItems: [VaultItem] = []
+    private(set) var populatedFolders: [Folder] = []
     private(set) var lastSyncedAt:   Date?        = nil
     private(set) var clearVaultCalled: Bool       = false
 
@@ -23,20 +24,24 @@ final class MockVaultRepository: VaultRepository {
 
     // MARK: - VaultRepository (write side)
 
-    func populate(items: [VaultItem], syncedAt: Date) {
-        populatedItems = items
-        lastSyncedAt   = syncedAt
+    func populate(items: [VaultItem], folders: [Folder], syncedAt: Date) {
+        populatedItems  = items
+        populatedFolders = folders
+        lastSyncedAt    = syncedAt
     }
 
     func clearVault() {
-        populatedItems  = []
-        lastSyncedAt    = nil
+        populatedItems   = []
+        populatedFolders = []
+        lastSyncedAt     = nil
         clearVaultCalled = true
     }
 
-    // MARK: - VaultRepository (read side — not exercised in sync tests)
+    // MARK: - VaultRepository (read side)
 
     func allItems() throws -> [VaultItem] { populatedItems }
+
+    func folders() throws -> [Folder] { populatedFolders }
 
     func items(for selection: SidebarSelection) throws -> [VaultItem] {
         switch selection {
@@ -46,6 +51,8 @@ final class MockVaultRepository: VaultRepository {
             return populatedItems.filter(\.isFavorite)
         case .type(let itemType):
             return populatedItems.filter { $0.content.matchesType(itemType) }
+        case .folder(let folderId):
+            return populatedItems.filter { $0.folderId == folderId }
         case .trash:
             return populatedItems.filter(\.isDeleted)
         }
@@ -130,6 +137,36 @@ final class MockVaultRepository: VaultRepository {
         lastRestoredId = id
         if let error = stubbedRestoreError { throw error }
     }
+
+    // MARK: - Folder CRUD stubbing
+
+    var stubbedCreateFolderResult: Folder?
+    var stubbedCreateFolderError: Error?
+
+    func createFolder(name: String) async throws -> Folder {
+        if let error = stubbedCreateFolderError { throw error }
+        let folder = stubbedCreateFolderResult ?? Folder(id: UUID().uuidString, name: name)
+        populatedFolders.append(folder)
+        return folder
+    }
+
+    func renameFolder(id: String, name: String) async throws -> Folder {
+        let folder = Folder(id: id, name: name)
+        if let idx = populatedFolders.firstIndex(where: { $0.id == id }) {
+            populatedFolders[idx] = folder
+        }
+        return folder
+    }
+
+    var stubbedDeleteFolderError: Error?
+
+    func deleteFolder(id: String) async throws {
+        if let error = stubbedDeleteFolderError { throw error }
+        populatedFolders.removeAll { $0.id == id }
+    }
+
+    func moveItemToFolder(itemId: String, folderId: String?) async throws {}
+    func moveItemsToFolder(itemIds: [String], folderId: String?) async throws {}
 
 }
 

--- a/Prizm/PrizmTests/RootViewModelLockTests.swift
+++ b/Prizm/PrizmTests/RootViewModelLockTests.swift
@@ -150,6 +150,10 @@ private final class MockRootDependencies: RootViewModelDependencies {
             delete:          StubDeleteUseCase(),
             permanentDelete: StubPermanentDeleteUseCase(),
             restore:         StubRestoreUseCase(),
+            createFolder:    StubCreateFolder(),
+            renameFolder:    StubRenameFolder(),
+            deleteFolder:    StubDeleteFolder(),
+            moveItem:        StubMoveItem(),
             syncTimestamp:   syncRepo,
             getLastSyncDate: GetLastSyncDateUseCaseImpl(repository: syncRepo)
         )
@@ -173,4 +177,17 @@ private final class MockRootDependencies: RootViewModelDependencies {
 }
 @MainActor private final class StubRestoreUseCase: RestoreVaultItemUseCase {
     func execute(id: String) async throws {}
+}
+@MainActor private struct StubCreateFolder: CreateFolderUseCase {
+    func execute(name: String) async throws -> Folder { Folder(id: "stub", name: name) }
+}
+@MainActor private struct StubRenameFolder: RenameFolderUseCase {
+    func execute(id: String, name: String) async throws -> Folder { Folder(id: id, name: name) }
+}
+@MainActor private struct StubDeleteFolder: DeleteFolderUseCase {
+    func execute(id: String) async throws {}
+}
+@MainActor private struct StubMoveItem: MoveItemToFolderUseCase {
+    func execute(itemId: String, folderId: String?) async throws {}
+    func execute(itemIds: [String], folderId: String?) async throws {}
 }

--- a/Prizm/PrizmTests/SearchVaultTests.swift
+++ b/Prizm/PrizmTests/SearchVaultTests.swift
@@ -84,7 +84,7 @@ final class SearchVaultTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
         vault = VaultRepositoryImpl(apiClient: MockPrizmAPIClient(), crypto: MockPrizmCryptoService())
-        vault.populate(items: Self.allFixtures, syncedAt: Self.now)
+        vault.populate(items: Self.allFixtures, folders: [], syncedAt: Self.now)
         sut = SearchVaultUseCaseImpl(vault: vault)
     }
 

--- a/Prizm/PrizmTests/SyncRepositoryImplTests.swift
+++ b/Prizm/PrizmTests/SyncRepositoryImplTests.swift
@@ -134,6 +134,7 @@ final class SyncRepositoryImplTests: XCTestCase {
             RawCipher(
                 id:             "cipher-\(i)",
                 organizationId: nil,
+                folderId:       nil,
                 type:           2,   // secureNote — simplest type
                 name:           "2.name\(i)==",
                 notes:          nil,
@@ -158,7 +159,8 @@ final class SyncRepositoryImplTests: XCTestCase {
                 key:        "2.encKey==",
                 privateKey: "2.encPrivKey=="
             ),
-            ciphers: ciphers
+            ciphers: ciphers,
+            folders: []
         )
     }
 

--- a/Prizm/PrizmTests/ToggleFavoriteTests.swift
+++ b/Prizm/PrizmTests/ToggleFavoriteTests.swift
@@ -16,7 +16,7 @@ final class ToggleFavoriteTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
         vault = MockVaultRepository()
-        vault.populate(items: [unfavoritedItem], syncedAt: .now)
+        vault.populate(items: [unfavoritedItem], folders: [], syncedAt: .now)
         let syncRepo = MockSyncTimestampRepository(storedDate: nil)
         sut = VaultBrowserViewModel(
             vault:           vault,
@@ -50,7 +50,7 @@ final class ToggleFavoriteTests: XCTestCase {
             creationDate: .now, revisionDate: .now,
             content: unfavoritedItem.content
         )
-        vault.populate(items: [favoritedItem], syncedAt: .now)
+        vault.populate(items: [favoritedItem], folders: [], syncedAt: .now)
         vault.stubbedUpdateResult = unfavoritedItem
 
         sut.toggleFavorite(item: favoritedItem)

--- a/Prizm/PrizmTests/ToggleFavoriteTests.swift
+++ b/Prizm/PrizmTests/ToggleFavoriteTests.swift
@@ -24,6 +24,10 @@ final class ToggleFavoriteTests: XCTestCase {
             delete:          StubDelete(),
             permanentDelete: StubPermanentDelete(),
             restore:         StubRestore(),
+            createFolder:    StubCreateFolder(),
+            renameFolder:    StubRenameFolder(),
+            deleteFolder:    StubDeleteFolder(),
+            moveItem:        StubMoveItem(),
             syncTimestamp:   syncRepo,
             getLastSyncDate: GetLastSyncDateUseCaseImpl(repository: syncRepo)
         )
@@ -64,3 +68,16 @@ final class ToggleFavoriteTests: XCTestCase {
 private final class StubDelete: DeleteVaultItemUseCase { func execute(id: String) async throws {} }
 private final class StubPermanentDelete: PermanentDeleteVaultItemUseCase { func execute(id: String) async throws {} }
 private final class StubRestore: RestoreVaultItemUseCase { func execute(id: String) async throws {} }
+private struct StubCreateFolder: CreateFolderUseCase {
+    func execute(name: String) async throws -> Folder { Folder(id: "stub", name: name) }
+}
+private struct StubRenameFolder: RenameFolderUseCase {
+    func execute(id: String, name: String) async throws -> Folder { Folder(id: id, name: name) }
+}
+private struct StubDeleteFolder: DeleteFolderUseCase {
+    func execute(id: String) async throws {}
+}
+private struct StubMoveItem: MoveItemToFolderUseCase {
+    func execute(itemId: String, folderId: String?) async throws {}
+    func execute(itemIds: [String], folderId: String?) async throws {}
+}

--- a/Prizm/PrizmTests/VaultBrowserViewModelGlobalSearchTests.swift
+++ b/Prizm/PrizmTests/VaultBrowserViewModelGlobalSearchTests.swift
@@ -29,6 +29,10 @@ final class VaultBrowserViewModelGlobalSearchTests: XCTestCase {
             delete:          StubDeleteUseCase(),
             permanentDelete: StubPermanentDeleteUseCase(),
             restore:         StubRestoreUseCase(),
+            createFolder:    StubCreateFolder(),
+            renameFolder:    StubRenameFolder(),
+            deleteFolder:    StubDeleteFolder(),
+            moveItem:        StubMoveItem(),
             syncTimestamp:   syncRepo,
             getLastSyncDate: GetLastSyncDateUseCaseImpl(repository: syncRepo)
         )
@@ -108,4 +112,18 @@ private final class StubPermanentDeleteUseCase: PermanentDeleteVaultItemUseCase 
 
 private final class StubRestoreUseCase: RestoreVaultItemUseCase {
     func execute(id: String) async throws {}
+}
+
+private struct StubCreateFolder: CreateFolderUseCase {
+    func execute(name: String) async throws -> Folder { Folder(id: "stub", name: name) }
+}
+private struct StubRenameFolder: RenameFolderUseCase {
+    func execute(id: String, name: String) async throws -> Folder { Folder(id: id, name: name) }
+}
+private struct StubDeleteFolder: DeleteFolderUseCase {
+    func execute(id: String) async throws {}
+}
+private struct StubMoveItem: MoveItemToFolderUseCase {
+    func execute(itemId: String, folderId: String?) async throws {}
+    func execute(itemIds: [String], folderId: String?) async throws {}
 }

--- a/Prizm/PrizmTests/VaultBrowserViewModelGlobalSearchTests.swift
+++ b/Prizm/PrizmTests/VaultBrowserViewModelGlobalSearchTests.swift
@@ -21,7 +21,7 @@ final class VaultBrowserViewModelGlobalSearchTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
         vault = MockVaultRepository()
-        vault.populate(items: [sampleLogin, sampleCard], syncedAt: .now)
+        vault.populate(items: [sampleLogin, sampleCard], folders: [], syncedAt: .now)
         let syncRepo = MockSyncTimestampRepository(storedDate: nil)
         sut = VaultBrowserViewModel(
             vault:           vault,

--- a/Prizm/PrizmTests/VaultBrowserViewModelSyncStatusTests.swift
+++ b/Prizm/PrizmTests/VaultBrowserViewModelSyncStatusTests.swift
@@ -25,6 +25,10 @@ final class VaultBrowserViewModelSyncStatusTests: XCTestCase {
             delete:          StubVaultDeleteUseCase(),
             permanentDelete: StubVaultPermanentDeleteUseCase(),
             restore:         StubVaultRestoreUseCase(),
+            createFolder:    StubCreateFolder(),
+            renameFolder:    StubRenameFolder(),
+            deleteFolder:    StubDeleteFolder(),
+            moveItem:        StubMoveItem(),
             syncTimestamp:   repo,
             getLastSyncDate: useCase
         )
@@ -89,4 +93,17 @@ private final class StubVaultPermanentDeleteUseCase: PermanentDeleteVaultItemUse
 }
 private final class StubVaultRestoreUseCase: RestoreVaultItemUseCase {
     func execute(id: String) async throws {}
+}
+private struct StubCreateFolder: CreateFolderUseCase {
+    func execute(name: String) async throws -> Folder { Folder(id: "stub", name: name) }
+}
+private struct StubRenameFolder: RenameFolderUseCase {
+    func execute(id: String, name: String) async throws -> Folder { Folder(id: id, name: name) }
+}
+private struct StubDeleteFolder: DeleteFolderUseCase {
+    func execute(id: String) async throws {}
+}
+private struct StubMoveItem: MoveItemToFolderUseCase {
+    func execute(itemId: String, folderId: String?) async throws {}
+    func execute(itemIds: [String], folderId: String?) async throws {}
 }

--- a/Prizm/PrizmTests/VaultRepositoryImplDeleteRestoreTests.swift
+++ b/Prizm/PrizmTests/VaultRepositoryImplDeleteRestoreTests.swift
@@ -48,7 +48,7 @@ final class VaultRepositoryImplDeleteRestoreTests: XCTestCase {
 
     func testDeleteItem_activeItem_marksDeletedInCache() async throws {
         let item = makeLogin(id: "id-1", name: "Active Item")
-        sut.populate(items: [item], syncedAt: Date())
+        sut.populate(items: [item], folders: [], syncedAt: Date())
 
         try await sut.deleteItem(id: "id-1")
 
@@ -64,7 +64,7 @@ final class VaultRepositoryImplDeleteRestoreTests: XCTestCase {
 
     func testDeleteItem_activeItem_callsAPIOnce() async throws {
         let item = makeLogin(id: "id-1", name: "Active")
-        sut.populate(items: [item], syncedAt: Date())
+        sut.populate(items: [item], folders: [], syncedAt: Date())
 
         try await sut.deleteItem(id: "id-1")
 
@@ -74,7 +74,7 @@ final class VaultRepositoryImplDeleteRestoreTests: XCTestCase {
 
     func testPermanentDeleteItem_trashedItem_removesFromCache() async throws {
         let item = makeLogin(id: "id-2", name: "Trashed Item", isDeleted: true)
-        sut.populate(items: [item], syncedAt: Date())
+        sut.populate(items: [item], folders: [], syncedAt: Date())
 
         try await sut.permanentDeleteItem(id: "id-2")
 
@@ -85,7 +85,7 @@ final class VaultRepositoryImplDeleteRestoreTests: XCTestCase {
 
     func testPermanentDeleteItem_callsAPIOnce() async throws {
         let item = makeLogin(id: "id-2", name: "Trashed Item", isDeleted: true)
-        sut.populate(items: [item], syncedAt: Date())
+        sut.populate(items: [item], folders: [], syncedAt: Date())
 
         try await sut.permanentDeleteItem(id: "id-2")
 
@@ -95,7 +95,7 @@ final class VaultRepositoryImplDeleteRestoreTests: XCTestCase {
 
     func testDeleteItem_apiError_doesNotUpdateCache() async throws {
         let item = makeLogin(id: "id-3", name: "Item")
-        sut.populate(items: [item], syncedAt: Date())
+        sut.populate(items: [item], folders: [], syncedAt: Date())
         mockAPI.softDeleteShouldThrow = APIError.httpError(statusCode: 500, body: "fail")
 
         do {
@@ -112,7 +112,7 @@ final class VaultRepositoryImplDeleteRestoreTests: XCTestCase {
 
     func testRestoreItem_trashedItem_marksActiveInCache() async throws {
         let item = makeLogin(id: "id-4", name: "Trashed", isDeleted: true)
-        sut.populate(items: [item], syncedAt: Date())
+        sut.populate(items: [item], folders: [], syncedAt: Date())
 
         try await sut.restoreItem(id: "id-4")
 
@@ -126,7 +126,7 @@ final class VaultRepositoryImplDeleteRestoreTests: XCTestCase {
 
     func testRestoreItem_callsAPIOnce() async throws {
         let item = makeLogin(id: "id-4", name: "Trashed", isDeleted: true)
-        sut.populate(items: [item], syncedAt: Date())
+        sut.populate(items: [item], folders: [], syncedAt: Date())
 
         try await sut.restoreItem(id: "id-4")
 
@@ -136,7 +136,7 @@ final class VaultRepositoryImplDeleteRestoreTests: XCTestCase {
 
     func testRestoreItem_apiError_doesNotUpdateCache() async throws {
         let item = makeLogin(id: "id-5", name: "Trashed", isDeleted: true)
-        sut.populate(items: [item], syncedAt: Date())
+        sut.populate(items: [item], folders: [], syncedAt: Date())
         mockAPI.restoreShouldThrow = APIError.httpError(statusCode: 503, body: "unavailable")
 
         do {
@@ -153,7 +153,7 @@ final class VaultRepositoryImplDeleteRestoreTests: XCTestCase {
     func testItemsForTrash_onlyReturnsTrashedItems() throws {
         let active  = makeLogin(name: "Active",  isDeleted: false)
         let trashed = makeLogin(name: "Trashed", isDeleted: true)
-        sut.populate(items: [active, trashed], syncedAt: Date())
+        sut.populate(items: [active, trashed], folders: [], syncedAt: Date())
 
         let result = try sut.items(for: .trash)
         XCTAssertEqual(result.count, 1)
@@ -161,7 +161,7 @@ final class VaultRepositoryImplDeleteRestoreTests: XCTestCase {
     }
 
     func testItemsForTrash_empty_returnsEmpty() throws {
-        sut.populate(items: [makeLogin(name: "Active")], syncedAt: Date())
+        sut.populate(items: [makeLogin(name: "Active")], folders: [], syncedAt: Date())
         let result = try sut.items(for: .trash)
         XCTAssertTrue(result.isEmpty)
     }
@@ -174,7 +174,7 @@ final class VaultRepositoryImplDeleteRestoreTests: XCTestCase {
             makeLogin(name: "B", isDeleted: true),
             makeLogin(name: "C", isDeleted: true),
         ]
-        sut.populate(items: items, syncedAt: Date())
+        sut.populate(items: items, folders: [], syncedAt: Date())
 
         let counts = try sut.itemCounts()
         XCTAssertEqual(counts[.trash], 2, "Trash count should reflect all isDeleted items")

--- a/Prizm/PrizmTests/VaultRepositoryImplTests.swift
+++ b/Prizm/PrizmTests/VaultRepositoryImplTests.swift
@@ -90,7 +90,7 @@ final class VaultRepositoryImplTests: XCTestCase {
     func testAllItems_excludesDeletedItems() throws {
         let active  = makeLogin(name: "Active")
         let deleted = makeLogin(name: "Deleted", isDeleted: true)
-        sut.populate(items: [active, deleted], syncedAt: Date())
+        sut.populate(items: [active, deleted], folders: [], syncedAt: Date())
 
         let result = try sut.allItems()
         XCTAssertEqual(result.count, 1)
@@ -103,7 +103,7 @@ final class VaultRepositoryImplTests: XCTestCase {
             makeLogin(name: "Apple"),
             makeLogin(name: "mango"),
         ]
-        sut.populate(items: items, syncedAt: Date())
+        sut.populate(items: items, folders: [], syncedAt: Date())
 
         let names = try sut.allItems().map(\.name)
         XCTAssertEqual(names, ["Apple", "mango", "zebra"])
@@ -113,7 +113,7 @@ final class VaultRepositoryImplTests: XCTestCase {
 
     func testItemsForAllItems_matchesAllItems() throws {
         let items = [makeLogin(name: "A"), makeCard(name: "B")]
-        sut.populate(items: items, syncedAt: Date())
+        sut.populate(items: items, folders: [], syncedAt: Date())
 
         let all        = try sut.allItems()
         let forAllItems = try sut.items(for: .allItems)
@@ -123,7 +123,7 @@ final class VaultRepositoryImplTests: XCTestCase {
     func testItemsForFavorites_onlyFavorites() throws {
         let fav    = makeLogin(name: "Fav", isFavorite: true)
         let notFav = makeLogin(name: "NotFav", isFavorite: false)
-        sut.populate(items: [fav, notFav], syncedAt: Date())
+        sut.populate(items: [fav, notFav], folders: [], syncedAt: Date())
 
         let result = try sut.items(for: .favorites)
         XCTAssertEqual(result.count, 1)
@@ -133,7 +133,7 @@ final class VaultRepositoryImplTests: XCTestCase {
     func testItemsForTypeLogin_onlyLoginItems() throws {
         let login = makeLogin(name: "Login Item")
         let card  = makeCard(name: "Card Item")
-        sut.populate(items: [login, card], syncedAt: Date())
+        sut.populate(items: [login, card], folders: [], syncedAt: Date())
 
         let result = try sut.items(for: .type(.login))
         XCTAssertEqual(result.count, 1)
@@ -143,7 +143,7 @@ final class VaultRepositoryImplTests: XCTestCase {
     func testItemsForTypeCard_onlyCardItems() throws {
         let login = makeLogin(name: "Login")
         let card  = makeCard(name: "Visa")
-        sut.populate(items: [login, card], syncedAt: Date())
+        sut.populate(items: [login, card], folders: [], syncedAt: Date())
 
         let result = try sut.items(for: .type(.card))
         XCTAssertEqual(result.count, 1)
@@ -153,7 +153,7 @@ final class VaultRepositoryImplTests: XCTestCase {
     func testItemsForType_excludesDeletedItems() throws {
         let active  = makeLogin(name: "Active", isDeleted: false)
         let deleted = makeLogin(name: "Deleted", isDeleted: true)
-        sut.populate(items: [active, deleted], syncedAt: Date())
+        sut.populate(items: [active, deleted], folders: [], syncedAt: Date())
 
         let result = try sut.items(for: .type(.login))
         XCTAssertEqual(result.count, 1)
@@ -177,7 +177,7 @@ final class VaultRepositoryImplTests: XCTestCase {
             makeSecureNote(name: "N1"),
             makeLogin(name: "Deleted Login", isDeleted: true),
         ]
-        sut.populate(items: items, syncedAt: Date())
+        sut.populate(items: items, folders: [], syncedAt: Date())
 
         let counts = try sut.itemCounts()
         XCTAssertEqual(counts[.allItems],          4, "allItems excludes deleted")
@@ -193,7 +193,7 @@ final class VaultRepositoryImplTests: XCTestCase {
 
     func testSearchItems_emptyQuery_returnsAll() throws {
         let items = [makeLogin(name: "Alpha"), makeLogin(name: "Beta")]
-        sut.populate(items: items, syncedAt: Date())
+        sut.populate(items: items, folders: [], syncedAt: Date())
 
         let result = try sut.searchItems(query: "", in: .allItems)
         XCTAssertEqual(result.count, 2)
@@ -201,7 +201,7 @@ final class VaultRepositoryImplTests: XCTestCase {
 
     func testSearchItems_matchesName_caseInsensitive() throws {
         let items = [makeLogin(name: "MyBank"), makeLogin(name: "GitHub")]
-        sut.populate(items: items, syncedAt: Date())
+        sut.populate(items: items, folders: [], syncedAt: Date())
 
         let result = try sut.searchItems(query: "bank", in: .allItems)
         XCTAssertEqual(result.count, 1)
@@ -211,7 +211,7 @@ final class VaultRepositoryImplTests: XCTestCase {
     func testSearchItems_scopedToSelection() throws {
         let login = makeLogin(name: "MyBank")
         let card  = makeCard(name: "MyCard")
-        sut.populate(items: [login, card], syncedAt: Date())
+        sut.populate(items: [login, card], folders: [], syncedAt: Date())
 
         let result = try sut.searchItems(query: "My", in: .type(.login))
         XCTAssertEqual(result.count, 1)
@@ -219,7 +219,7 @@ final class VaultRepositoryImplTests: XCTestCase {
     }
 
     func testSearchItems_noMatch_returnsEmpty() throws {
-        sut.populate(items: [makeLogin(name: "Alpha")], syncedAt: Date())
+        sut.populate(items: [makeLogin(name: "Alpha")], folders: [], syncedAt: Date())
 
         let result = try sut.searchItems(query: "zzz", in: .allItems)
         XCTAssertTrue(result.isEmpty)
@@ -229,12 +229,12 @@ final class VaultRepositoryImplTests: XCTestCase {
 
     func testPopulate_updatesLastSyncedAt() {
         let date = Date(timeIntervalSince1970: 1_000_000)
-        sut.populate(items: [], syncedAt: date)
+        sut.populate(items: [], folders: [], syncedAt: date)
         XCTAssertEqual(sut.lastSyncedAt, date)
     }
 
     func testClearVault_removesItemsAndTimestamp() throws {
-        sut.populate(items: [makeLogin(name: "X")], syncedAt: Date())
+        sut.populate(items: [makeLogin(name: "X")], folders: [], syncedAt: Date())
         sut.clearVault()
 
         XCTAssertTrue(try sut.allItems().isEmpty)
@@ -245,7 +245,7 @@ final class VaultRepositoryImplTests: XCTestCase {
 
     func testItemDetail_existingId_returnsItem() async throws {
         let item = makeLogin(id: "item-1", name: "Test")
-        sut.populate(items: [item], syncedAt: Date())
+        sut.populate(items: [item], folders: [], syncedAt: Date())
 
         let found = try await sut.itemDetail(id: "item-1")
         XCTAssertEqual(found.id, "item-1")
@@ -267,7 +267,7 @@ final class VaultRepositoryImplTests: XCTestCase {
 
     func testUpdate_success_replacesItemInCacheAndReturnsUpdatedItem() async throws {
         let original = makeLogin(id: "item-1", name: "Original Name")
-        sut.populate(items: [original], syncedAt: Date())
+        sut.populate(items: [original], folders: [], syncedAt: Date())
 
         // Vault must be unlocked to provide keys to the mapper.
         await mockCrypto.unlockWith(keys: CryptoKeys(
@@ -288,7 +288,7 @@ final class VaultRepositoryImplTests: XCTestCase {
 
     func testUpdate_vaultLocked_throwsVaultLocked() async throws {
         let original = makeLogin(id: "item-2", name: "Name")
-        sut.populate(items: [original], syncedAt: Date())
+        sut.populate(items: [original], folders: [], syncedAt: Date())
         // mockCrypto is locked by default (not unlocked)
 
         let draft = DraftVaultItem(original)
@@ -303,7 +303,7 @@ final class VaultRepositoryImplTests: XCTestCase {
 
     func testUpdate_apiError_throws() async throws {
         let original = makeLogin(id: "item-3", name: "Name")
-        sut.populate(items: [original], syncedAt: Date())
+        sut.populate(items: [original], folders: [], syncedAt: Date())
 
         await mockCrypto.unlockWith(keys: CryptoKeys(
             encryptionKey: Data(repeating: 0xDE, count: 32),

--- a/openspec/changes/vault-folder-organization/.openspec.yaml
+++ b/openspec/changes/vault-folder-organization/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-08

--- a/openspec/changes/vault-folder-organization/design.md
+++ b/openspec/changes/vault-folder-organization/design.md
@@ -42,7 +42,7 @@ For drag-and-drop of a single item, use `PUT /ciphers/{id}/partial` with `{ fold
 ### Decision 3: Apple Mail-style folder management in sidebar
 
 - Create: small `folder.badge.plus` SF Symbol button on the "Folders" section header
-- Rename: SwiftUI `.renameAction` / `RenameButton` for platform-standard inline rename (select + Enter, or right-click → Rename)
+- Rename: SwiftUI `.renameAction` / `RenameButton` for platform-standard inline rename (click on already-selected folder name, or right-click → Rename)
 - Delete: right-click context menu → "Delete Folder" with confirmation alert
 
 **Rationale**: Matches macOS platform conventions. SwiftUI provides `.renameAction` (macOS 14+), `.contextMenu`, and `.dropDestination` as built-in primitives. Prizm targets macOS 26, so all APIs are available.

--- a/openspec/changes/vault-folder-organization/design.md
+++ b/openspec/changes/vault-folder-organization/design.md
@@ -42,7 +42,7 @@ For drag-and-drop of a single item, use `PUT /ciphers/{id}/partial` with `{ fold
 ### Decision 3: Apple Mail-style folder management in sidebar
 
 - Create: small `folder.badge.plus` SF Symbol button on the "Folders" section header
-- Rename: SwiftUI `.renameAction` / `RenameButton` for platform-standard inline rename (click on already-selected folder name, or right-click → Rename)
+- Rename: right-click context menu → "Rename" triggers inline editable text field via SwiftUI `.renameAction`
 - Delete: right-click context menu → "Delete Folder" with confirmation alert
 
 **Rationale**: Matches macOS platform conventions. SwiftUI provides `.renameAction` (macOS 14+), `.contextMenu`, and `.dropDestination` as built-in primitives. Prizm targets macOS 26, so all APIs are available.

--- a/openspec/changes/vault-folder-organization/design.md
+++ b/openspec/changes/vault-folder-organization/design.md
@@ -15,7 +15,6 @@ The existing architecture follows a clean layered pattern: wire models (`RawCiph
 - Folder-scoped search when a folder is selected
 
 **Non-Goals:**
-- Nested folders (Parent/Child naming convention) — flat only
 - "No Folder" sidebar row — unfoldered items accessible via All Items / Types
 - Manual folder reordering — alphabetical sort only
 - Organisation folder support — personal vault only (consistent with existing org cipher exclusion)
@@ -88,6 +87,28 @@ The `PUT /ciphers/{id}/partial` response returns cipher details, but we only use
 ### Decision 11: Folder decryption goes through PrizmCryptoService
 
 `SyncRepositoryImpl` calls `crypto.decryptFolders(folders:)` — a new method on `PrizmCryptoService` that mirrors the existing `decryptList(ciphers:)` pattern. This keeps all crypto behind the service protocol boundary (Constitution §III). The method retrieves the current keys internally and decrypts each `RawFolder.name` EncString, returning `[Folder]`.
+
+### Decision 12: Nested folders via slash-delimited naming convention
+
+Bitwarden represents folder hierarchy through a naming convention: a folder named `"Work/Projects"` is treated as a child of `"Work"`. The server stores all folders as a flat list — there is no parent-child relationship in the API. Prizm parses the `/` delimiter at render time to build a tree for sidebar display.
+
+Parent nodes that have no corresponding flat folder entry (e.g. "Work" when only "Work/Projects" exists) are rendered as virtual parents — they have no `folderId` and cannot be selected or receive drops; they exist only as collapsible containers. Real parent folders (where "Work" also exists as its own folder) are selectable and receive drops.
+
+Collapse state is persisted per-session in a `@State` `Set<String>` keyed by folder ID (or virtual path). UserDefaults persistence is deferred.
+
+Selecting a folder in the sidebar shows only items directly assigned to that exact folder (matching `folderId` == folder.id). Items in child folders are NOT included — consistent with Bitwarden Web behavior.
+
+### Decision 13: Folder picker in edit sheet follows field-row visual style
+
+The default SwiftUI `Picker` renders as a bordered menu button that is visually inconsistent with the label-above-value field rows used throughout the edit sheet. The folder picker SHALL be replaced with a `Menu`-based or `Picker(.menu)` styled component wrapped in the same field row container used for other fields (label on top, value below, same horizontal padding and separator). This preserves the existing `Picker` binding semantics while matching the design system.
+
+### Decision 14: Cmd+F search preserves active sidebar selection
+
+The existing Cmd+F handler focuses the search field but implicitly searches All Items when a folder is selected. The correct behaviour is to scope the search to the currently selected sidebar item. Since `VaultBrowserViewModel` already scopes `searchItems` to the current selection, the fix is ensuring the `selection` binding is not reset when the search field is activated.
+
+### Decision 15: Folder shown in item detail view
+
+The detail pane displays field sections for the item's content (credentials, notes, etc.) but currently omits folder assignment. A "Folder" row SHALL be appended after the last content section when `item.folderId != nil`. The row shows the resolved folder name (looked up from the in-memory folder list). When `folderId` is nil the row is omitted entirely.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/vault-folder-organization/design.md
+++ b/openspec/changes/vault-folder-organization/design.md
@@ -11,7 +11,7 @@ The existing architecture follows a clean layered pattern: wire models (`RawCiph
 - Full folder CRUD (create, rename, delete) via the Bitwarden folder API
 - Assign items to folders via edit sheet picker and drag-and-drop
 - Sidebar "Folders" section with Apple Mail-style interactions (header create button, right-click context menu, Enter-to-rename)
-- Multi-select drag-and-drop of items onto folder rows
+- Single-item drag-and-drop of items onto folder rows
 - Folder-scoped search when a folder is selected
 
 **Non-Goals:**
@@ -47,11 +47,9 @@ For drag-and-drop of a single item, use `PUT /ciphers/{id}/partial` with `{ fold
 
 **Rationale**: Matches macOS platform conventions. SwiftUI provides `.renameAction` (macOS 14+), `.contextMenu`, and `.dropDestination` as built-in primitives. Prizm targets macOS 26, so all APIs are available.
 
-### Decision 4: Multi-select via Set<String> selection on item list
+### Decision 4: Multi-select deferred to follow-up change
 
-Change `ItemListView` selection from single `VaultItem?` to `Set<String>` (item IDs) to support ⌘-click and ⇧-click multi-select. This enables bulk drag-and-drop onto folder rows.
-
-**Rationale**: SwiftUI `List(selection: Binding<Set<...>>)` provides native multi-select with standard macOS keyboard modifiers. The detail pane shows content for the last-selected item (or empty state if multiple are selected).
+Multi-select (`Set<String>` selection on `ItemListView`) was originally planned for this change but deferred due to the cross-cutting refactor required (touches ItemListView, TrashView, VaultBrowserView, VaultBrowserViewModel, and all selection callbacks). Single-item drag-and-drop covers the primary use case. Bulk drag-and-drop via `PUT /ciphers/move` is implemented in the Data layer and ready for when multi-select is added.
 
 ### Decision 5: folderId as a plain String? pass-through on VaultItem
 
@@ -94,8 +92,6 @@ The `PUT /ciphers/{id}/partial` response returns cipher details, but we only use
 ## Risks / Trade-offs
 
 **[Risk] Inline rename in NavigationSplitView sidebar has had SwiftUI bugs** → Mitigation: Use `.renameAction` (the official API) rather than hand-rolling TextField-in-List. If the API has issues on macOS 26, fall back to a rename alert/popover.
-
-**[Risk] Multi-select changes the item list selection model** → Mitigation: The detail pane shows the last-selected item when one item is selected, empty state when zero or multiple are selected. This is consistent with Finder behavior. Existing single-click-to-view behavior is preserved.
 
 **[Risk] PUT /ciphers/{id}/partial was subject to a Vaultwarden security vulnerability (CVE-2026-27898)** → Mitigation: The vulnerability was an authorization bypass (accessing other users' ciphers), patched in Vaultwarden 1.35.4. Prizm already targets 1.35.4+ as the minimum version. The endpoint itself is stable and correct for the authenticated user's own ciphers.
 

--- a/openspec/changes/vault-folder-organization/design.md
+++ b/openspec/changes/vault-folder-organization/design.md
@@ -1,0 +1,100 @@
+## Context
+
+Prizm is a native macOS Bitwarden/Vaultwarden client. The vault browser uses a three-pane `NavigationSplitView` with sidebar categories (All Items, Favorites, Types, Trash), an item list, and a detail pane. Items are stored in a flat `[VaultItem]` array in `VaultRepositoryImpl`. The Bitwarden sync API already returns `folders[]` and `folderId` on each cipher, but Prizm ignores both. Folder names are encrypted as EncString type-2 (AES-256-CBC + HMAC-SHA256), the same format used for cipher field encryption.
+
+The existing architecture follows a clean layered pattern: wire models (`RawCipher`, `SyncResponse`) → mapper (`CipherMapper`) → domain entities (`VaultItem`) → repository (`VaultRepository`) → use cases → view models → views. Folder support threads through every layer.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Parse and display folders from the Bitwarden sync response
+- Full folder CRUD (create, rename, delete) via the Bitwarden folder API
+- Assign items to folders via edit sheet picker and drag-and-drop
+- Sidebar "Folders" section with Apple Mail-style interactions (header create button, right-click context menu, Enter-to-rename)
+- Multi-select drag-and-drop of items onto folder rows
+- Folder-scoped search when a folder is selected
+
+**Non-Goals:**
+- Nested folders (Parent/Child naming convention) — flat only
+- "No Folder" sidebar row — unfoldered items accessible via All Items / Types
+- Manual folder reordering — alphabetical sort only
+- Organisation folder support — personal vault only (consistent with existing org cipher exclusion)
+- Offline folder CRUD — requires active server connection (consistent with existing item CRUD)
+
+## Decisions
+
+### Decision 1: Folders stored in VaultRepository alongside items
+
+Store `[Folder]` in `VaultRepositoryImpl` next to the existing `[VaultItem]` array. Both are populated during sync and cleared on lock/sign-out.
+
+**Rationale**: Folders and items are always synced together and queried together (sidebar needs both for counts). A separate `FolderRepository` would add wiring complexity in `AppContainer` with no architectural benefit. The vault repository is already the in-memory vault store — folders are part of the vault.
+
+**Alternative considered**: Separate `FolderRepository` actor — rejected because it would require coordinating two stores during sync and querying across two repositories for sidebar counts.
+
+### Decision 2: Use PUT /ciphers/{id}/partial for single-item folder moves
+
+For drag-and-drop of a single item, use `PUT /ciphers/{id}/partial` with `{ folderId, favorite }`. For multi-item moves, use `PUT /ciphers/move` with `{ ids, folderId }`.
+
+**Rationale**: The `/partial` endpoint only sends the folder ID and favorite flag — no re-encryption of the entire cipher is needed. This is the same endpoint the official Bitwarden client uses for folder moves. The `/move` endpoint handles bulk operations in a single request. Both are supported on Vaultwarden 1.35.4+.
+
+**Alternative considered**: Re-encrypting the full cipher via `PUT /ciphers/{id}` — rejected because it's heavyweight (decrypt → create draft → modify folderId → re-encrypt → PUT) for a metadata-only change, and risks overwriting concurrent edits.
+
+### Decision 3: Apple Mail-style folder management in sidebar
+
+- Create: small `folder.badge.plus` SF Symbol button on the "Folders" section header
+- Rename: SwiftUI `.renameAction` / `RenameButton` for platform-standard inline rename (select + Enter, or right-click → Rename)
+- Delete: right-click context menu → "Delete Folder" with confirmation alert
+
+**Rationale**: Matches macOS platform conventions. SwiftUI provides `.renameAction` (macOS 14+), `.contextMenu`, and `.dropDestination` as built-in primitives. Prizm targets macOS 26, so all APIs are available.
+
+### Decision 4: Multi-select via Set<String> selection on item list
+
+Change `ItemListView` selection from single `VaultItem?` to `Set<String>` (item IDs) to support ⌘-click and ⇧-click multi-select. This enables bulk drag-and-drop onto folder rows.
+
+**Rationale**: SwiftUI `List(selection: Binding<Set<...>>)` provides native multi-select with standard macOS keyboard modifiers. The detail pane shows content for the last-selected item (or empty state if multiple are selected).
+
+### Decision 5: folderId as a plain String? pass-through on VaultItem
+
+`folderId` is not encrypted — it's a UUID string on the wire. It passes through `CipherMapper` without decryption, stored directly on `VaultItem` and `DraftVaultItem`. The `RawCipher` model gains `folderId: String?` and the reverse mapper (`toRawCipher`) includes it in the output.
+
+**Rationale**: Unlike cipher field values, `folderId` is a server-assigned UUID, not user content. No crypto operations needed.
+
+### Decision 6: Folder name encryption/decryption reuses existing EncString path
+
+Folder names are EncString type-2, identical to cipher field encryption. Decryption during sync uses the same `EncString.decrypt(keys:)` path. Encryption for create/rename uses the same `EncString.encrypt(data:keys:)` path. No new crypto code is needed.
+
+### Decision 7: Drag-and-drop uses SwiftUI .draggable / .dropDestination
+
+Item rows use `.draggable` with the item ID as the transferable payload. Folder sidebar rows use `.dropDestination` to accept item IDs. SwiftUI provides default `isTargeted` highlight feedback on the drop target.
+
+**Rationale**: Platform-standard drag-and-drop with minimal custom code. The `Transferable` protocol with a simple string ID payload avoids serialising full item data.
+
+### Decision 8: Folder operations go through Domain use cases
+
+Folder CRUD and move-to-folder operations follow the same use case pattern as existing item operations (`CreateVaultItemUseCase`, `EditVaultItemUseCase`, etc.). Each operation gets a protocol in Domain and an implementation in Data:
+- `CreateFolderUseCase` — encrypts name, calls API, updates repository
+- `RenameFolderUseCase` — encrypts new name, calls API, updates repository
+- `DeleteFolderUseCase` — calls API, clears folderId on affected items, updates repository
+- `MoveItemToFolderUseCase` — calls partial/move API, updates repository
+
+ViewModels call use cases, never repository methods directly. This preserves the Clean Architecture layer boundary (Constitution §II).
+
+**Rationale**: The existing codebase has a 1:1 use case per operation pattern. Folder operations are no different — they involve crypto (name encryption), API calls, and cache updates, which is exactly what use cases coordinate.
+
+### Decision 9: API client receives encrypted folder names, not plaintext
+
+The `PrizmAPIClientProtocol` folder methods accept already-encrypted EncString names. Encryption happens in the use case implementation (Data layer) before calling the API client, matching the existing pattern where `CipherMapper.toRawCipher` encrypts before `apiClient.createCipher` is called. Plaintext folder names never reach the API client layer.
+
+### Decision 10: Partial update response is not used to update cached cipher data
+
+The `PUT /ciphers/{id}/partial` response returns cipher details, but we only use it to confirm success. The local cache is updated by setting `folderId` on the existing `VaultItem` directly, not by re-mapping the response. This avoids re-decrypting the response and is consistent with how `deleteItem`/`restoreItem` update the cache by mutating the existing item.
+
+## Risks / Trade-offs
+
+**[Risk] Inline rename in NavigationSplitView sidebar has had SwiftUI bugs** → Mitigation: Use `.renameAction` (the official API) rather than hand-rolling TextField-in-List. If the API has issues on macOS 26, fall back to a rename alert/popover.
+
+**[Risk] Multi-select changes the item list selection model** → Mitigation: The detail pane shows the last-selected item when one item is selected, empty state when zero or multiple are selected. This is consistent with Finder behavior. Existing single-click-to-view behavior is preserved.
+
+**[Risk] PUT /ciphers/{id}/partial was subject to a Vaultwarden security vulnerability (CVE-2026-27898)** → Mitigation: The vulnerability was an authorization bypass (accessing other users' ciphers), patched in Vaultwarden 1.35.4. Prizm already targets 1.35.4+ as the minimum version. The endpoint itself is stable and correct for the authenticated user's own ciphers.
+
+**[Trade-off] No "No Folder" row means users can't quickly see which items are unorganised** → Accepted: keeps the sidebar clean. Users who want to find unfoldered items can browse All Items and notice which items lack a folder indicator.

--- a/openspec/changes/vault-folder-organization/design.md
+++ b/openspec/changes/vault-folder-organization/design.md
@@ -72,22 +72,24 @@ Item rows use `.draggable` with the item ID as the transferable payload. Folder 
 ### Decision 8: Folder operations go through Domain use cases
 
 Folder CRUD and move-to-folder operations follow the same use case pattern as existing item operations (`CreateVaultItemUseCase`, `EditVaultItemUseCase`, etc.). Each operation gets a protocol in Domain and an implementation in Data:
-- `CreateFolderUseCase` — encrypts name, calls API, updates repository
-- `RenameFolderUseCase` — encrypts new name, calls API, updates repository
-- `DeleteFolderUseCase` — calls API, clears folderId on affected items, updates repository
-- `MoveItemToFolderUseCase` — calls partial/move API, updates repository
+- `CreateFolderUseCase` — calls `VaultRepository.createFolder(name:)`
+- `RenameFolderUseCase` — calls `VaultRepository.renameFolder(id:name:)`
+- `DeleteFolderUseCase` — calls `VaultRepository.deleteFolder(id:)`
+- `MoveItemToFolderUseCase` — calls `VaultRepository.moveItemToFolder` / `moveItemsToFolder`
 
-ViewModels call use cases, never repository methods directly. This preserves the Clean Architecture layer boundary (Constitution §II).
+`VaultRepositoryImpl` handles encryption of folder names internally (same as how it calls `CipherMapper.toRawCipher` before `apiClient.createCipher`). Use case impls are thin coordinators — they do not call the API client or crypto directly. ViewModels call use cases, never repository methods directly. This preserves the Clean Architecture layer boundary (Constitution §II).
 
-**Rationale**: The existing codebase has a 1:1 use case per operation pattern. Folder operations are no different — they involve crypto (name encryption), API calls, and cache updates, which is exactly what use cases coordinate.
+### Decision 9: Folder name encryption happens in VaultRepositoryImpl
 
-### Decision 9: API client receives encrypted folder names, not plaintext
-
-The `PrizmAPIClientProtocol` folder methods accept already-encrypted EncString names. Encryption happens in the use case implementation (Data layer) before calling the API client, matching the existing pattern where `CipherMapper.toRawCipher` encrypts before `apiClient.createCipher` is called. Plaintext folder names never reach the API client layer.
+`VaultRepository` protocol methods accept plaintext folder names (e.g. `createFolder(name: String)`). `VaultRepositoryImpl` encrypts the name via `EncString.encrypt(data:keys:)` before passing the encrypted string to the API client. This matches the existing pattern: `VaultRepositoryImpl.create(_:)` calls `CipherMapper.toRawCipher` (which encrypts) before calling `apiClient.createCipher`. Plaintext folder names never reach the API client layer. The Domain protocol stays crypto-free (Constitution §II).
 
 ### Decision 10: Partial update response is not used to update cached cipher data
 
 The `PUT /ciphers/{id}/partial` response returns cipher details, but we only use it to confirm success. The local cache is updated by setting `folderId` on the existing `VaultItem` directly, not by re-mapping the response. This avoids re-decrypting the response and is consistent with how `deleteItem`/`restoreItem` update the cache by mutating the existing item.
+
+### Decision 11: Folder decryption goes through PrizmCryptoService
+
+`SyncRepositoryImpl` calls `crypto.decryptFolders(folders:)` — a new method on `PrizmCryptoService` that mirrors the existing `decryptList(ciphers:)` pattern. This keeps all crypto behind the service protocol boundary (Constitution §III). The method retrieves the current keys internally and decrypts each `RawFolder.name` EncString, returning `[Folder]`.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/vault-folder-organization/proposal.md
+++ b/openspec/changes/vault-folder-organization/proposal.md
@@ -9,7 +9,7 @@ Prizm has no concept of folders. Users who organise their Bitwarden/Vaultwarden 
 - Add a "Folders" section to the sidebar between Menu and Types, sorted alphabetically by name, with per-folder item counts
 - Add folder CRUD: create (Apple Mail-style button on section header), rename (select + Enter or right-click → Rename), delete (right-click → Delete) via the Bitwarden folder API endpoints
 - Add a folder picker to the item edit/create sheet so users can assign or change an item's folder
-- Support drag-and-drop of items (single and multi-select) onto sidebar folder rows to move items between folders, using `PUT /ciphers/{id}/partial` for single moves and `PUT /ciphers/move` for bulk moves
+- Support drag-and-drop of items onto sidebar folder rows to move items between folders, using `PUT /ciphers/{id}/partial`
 - Items without a `folderId` have no dedicated sidebar row — they remain accessible via All Items, Favorites, and Type filters
 - Folders are flat (no nested Parent/Child convention)
 - Folder names are encrypted client-side (EncString type-2) before being sent to the server, matching the existing cipher encryption pattern
@@ -20,7 +20,7 @@ Prizm has no concept of folders. Users who organise their Bitwarden/Vaultwarden 
 - `vault-folder-organization`: Folder browsing, CRUD, item-to-folder assignment, and drag-and-drop in the sidebar
 
 ### Modified Capabilities
-- `vault-browser-ui`: Sidebar gains a new "Folders" section with dynamic rows, item counts, context menus, and drop targets; `SidebarSelection` gains a `.folder(id)` case; item list supports multi-select for bulk drag operations
+- `vault-browser-ui`: Sidebar gains a new "Folders" section with dynamic rows, item counts, context menus, and drop targets; `SidebarSelection` gains a `.folder(id)` case; item list supports single-item drag-and-drop to folders
 - `vault-item-create`: Create sheet gains a folder picker field; new items can be assigned to a folder at creation time
 
 ## Impact

--- a/openspec/changes/vault-folder-organization/proposal.md
+++ b/openspec/changes/vault-folder-organization/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Prizm has no concept of folders. Users who organise their Bitwarden/Vaultwarden vault into folders (via the web vault or another client) see a flat list in Prizm with no way to browse by folder. The Bitwarden sync API already returns folder data (`folders[]` array and `folderId` on each cipher), but Prizm ignores both. Adding folder support lets users organise items the way they already do on other clients, and manage folders entirely from Prizm without switching to the web vault.
+
+## What Changes
+
+- Parse `folders` from the sync response and `folderId` from each cipher during sync
+- Introduce a `Folder` domain entity (id, decrypted name) and store folders in the vault repository alongside items
+- Add a "Folders" section to the sidebar between Menu and Types, sorted alphabetically by name, with per-folder item counts
+- Add folder CRUD: create (Apple Mail-style button on section header), rename (select + Enter or right-click → Rename), delete (right-click → Delete) via the Bitwarden folder API endpoints
+- Add a folder picker to the item edit/create sheet so users can assign or change an item's folder
+- Support drag-and-drop of items (single and multi-select) onto sidebar folder rows to move items between folders, using `PUT /ciphers/{id}/partial` for single moves and `PUT /ciphers/move` for bulk moves
+- Items without a `folderId` have no dedicated sidebar row — they remain accessible via All Items, Favorites, and Type filters
+- Folders are flat (no nested Parent/Child convention)
+- Folder names are encrypted client-side (EncString type-2) before being sent to the server, matching the existing cipher encryption pattern
+
+## Capabilities
+
+### New Capabilities
+- `vault-folder-organization`: Folder browsing, CRUD, item-to-folder assignment, and drag-and-drop in the sidebar
+
+### Modified Capabilities
+- `vault-browser-ui`: Sidebar gains a new "Folders" section with dynamic rows, item counts, context menus, and drop targets; `SidebarSelection` gains a `.folder(id)` case; item list supports multi-select for bulk drag operations
+- `vault-item-create`: Create sheet gains a folder picker field; new items can be assigned to a folder at creation time
+
+## Impact
+
+- **Wire models**: `SyncResponse` adds `folders: [RawFolder]`; `RawCipher` adds `folderId: String?`
+- **Domain entities**: New `Folder` struct; `VaultItem` and `DraftVaultItem` gain `folderId: String?`; `SidebarSelection` gains `.folder(String)` case; `SidebarSection` gains `.folders` case
+- **Crypto**: Folder names require encrypt/decrypt using the existing EncString type-2 (AES-256-CBC + HMAC-SHA256) path — no new crypto primitives
+- **API client**: New endpoints: `POST /api/folders`, `PUT /api/folders/{id}`, `DELETE /api/folders/{id}`, `PUT /ciphers/{id}/partial`, `PUT /ciphers/move`
+- **Repository layer**: `VaultRepository` stores and queries folders; `VaultRepositoryImpl` adds folder-scoped item filtering and folder counts
+- **Presentation**: `SidebarView`, `VaultBrowserViewModel`, `ItemEditView`, `ItemListView` all modified; new folder management UI in sidebar
+- **Tests**: Existing vault repository, cipher mapper, and view model tests need updates for `folderId`; new tests for folder CRUD, drag-and-drop, and folder-scoped filtering

--- a/openspec/changes/vault-folder-organization/specs/vault-browser-ui/spec.md
+++ b/openspec/changes/vault-folder-organization/specs/vault-browser-ui/spec.md
@@ -1,7 +1,7 @@
 ## MODIFIED Requirements
 
 ### Requirement: User can browse their vault in a three-pane layout
-The system SHALL display a `NavigationSplitView` with a sidebar (categories + counts), a middle item list, and a detail pane. The sidebar SHALL be organised into sections: *Menu Items* (All Items, Favorites), *Folders* (section header always visible; folder rows shown when folders exist), *Types* (Login, Card, Identity, Secure Note, SSH Key), and *Trash*, each with a live item count. Soft-deleted items (Trash) SHALL be excluded from all non-Trash views. The item list SHALL support both single selection (click) and multi-selection (⌘-click, ⇧-click) for drag-and-drop operations. When multiple items are selected, the detail pane SHALL show an empty state and single-item actions (Edit, Copy, Favorite, Delete) SHALL be disabled. When exactly one item is selected, the detail pane SHALL show that item's content and all actions SHALL be available.
+The system SHALL display a `NavigationSplitView` with a sidebar (categories + counts), a middle item list, and a detail pane. The sidebar SHALL be organised into sections: *Menu Items* (All Items, Favorites), *Folders* (section header always visible; folder rows shown when folders exist), *Types* (Login, Card, Identity, Secure Note, SSH Key), and *Trash*, each with a live item count. Soft-deleted items (Trash) SHALL be excluded from all non-Trash views.
 
 #### Scenario: Sidebar shows all categories with counts
 - **WHEN** the vault browser opens
@@ -12,11 +12,11 @@ The system SHALL display a `NavigationSplitView` with a sidebar (categories + co
 - **THEN** the middle pane shows only items belonging to that selection; the detail pane resets to its empty state
 
 #### Scenario: No item selected — empty detail state
-- **WHEN** no item is selected in the middle pane, or multiple items are selected
+- **WHEN** no item is selected in the middle pane
 - **THEN** the detail pane shows a "No item selected" empty state
 
 #### Scenario: Selecting an item shows its full content
-- **GIVEN** exactly one item is selected
+- **GIVEN** an item is selected
 - **WHEN** the detail pane renders
 - **THEN** all fields for that item type are displayed, along with creation date and last-modified date
 
@@ -27,11 +27,3 @@ The system SHALL display a `NavigationSplitView` with a sidebar (categories + co
 #### Scenario: Item list is sorted alphabetically
 - **WHEN** any category is selected
 - **THEN** the item list is sorted alphabetically by item name, case-insensitive
-
-#### Scenario: Multi-select items in the item list
-- **WHEN** the user ⌘-clicks or ⇧-clicks items in the item list
-- **THEN** multiple items SHALL be selected and available for drag-and-drop operations
-
-#### Scenario: Single-item actions disabled during multi-select
-- **GIVEN** multiple items are selected in the item list
-- **THEN** Edit (⌘E), Save (⌘S), Copy Username (⇧⌘C), Copy Password (⌥⌘C), Copy Website (⌥⇧⌘C), Favorite toggle, and Delete SHALL be disabled or no-op

--- a/openspec/changes/vault-folder-organization/specs/vault-browser-ui/spec.md
+++ b/openspec/changes/vault-folder-organization/specs/vault-browser-ui/spec.md
@@ -1,7 +1,7 @@
 ## MODIFIED Requirements
 
 ### Requirement: User can browse their vault in a three-pane layout
-The system SHALL display a `NavigationSplitView` with a sidebar (categories + counts), a middle item list, and a detail pane. The sidebar SHALL be organised into sections: *Menu Items* (All Items, Favorites), *Folders* (section header always visible; folder rows shown when folders exist), *Types* (Login, Card, Identity, Secure Note, SSH Key), and *Trash*, each with a live item count. Soft-deleted items (Trash) SHALL be excluded from all non-Trash views. The item list SHALL support both single selection (click) and multi-selection (⌘-click, ⇧-click) for drag-and-drop operations. When multiple items are selected, the detail pane SHALL show an empty state. When exactly one item is selected, the detail pane SHALL show that item's content.
+The system SHALL display a `NavigationSplitView` with a sidebar (categories + counts), a middle item list, and a detail pane. The sidebar SHALL be organised into sections: *Menu Items* (All Items, Favorites), *Folders* (section header always visible; folder rows shown when folders exist), *Types* (Login, Card, Identity, Secure Note, SSH Key), and *Trash*, each with a live item count. Soft-deleted items (Trash) SHALL be excluded from all non-Trash views. The item list SHALL support both single selection (click) and multi-selection (⌘-click, ⇧-click) for drag-and-drop operations. When multiple items are selected, the detail pane SHALL show an empty state and single-item actions (Edit, Copy, Favorite, Delete) SHALL be disabled. When exactly one item is selected, the detail pane SHALL show that item's content and all actions SHALL be available.
 
 #### Scenario: Sidebar shows all categories with counts
 - **WHEN** the vault browser opens
@@ -31,3 +31,7 @@ The system SHALL display a `NavigationSplitView` with a sidebar (categories + co
 #### Scenario: Multi-select items in the item list
 - **WHEN** the user ⌘-clicks or ⇧-clicks items in the item list
 - **THEN** multiple items SHALL be selected and available for drag-and-drop operations
+
+#### Scenario: Single-item actions disabled during multi-select
+- **GIVEN** multiple items are selected in the item list
+- **THEN** Edit (⌘E), Save (⌘S), Copy Username (⇧⌘C), Copy Password (⌥⌘C), Copy Website (⌥⇧⌘C), Favorite toggle, and Delete SHALL be disabled or no-op

--- a/openspec/changes/vault-folder-organization/specs/vault-browser-ui/spec.md
+++ b/openspec/changes/vault-folder-organization/specs/vault-browser-ui/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: User can browse their vault in a three-pane layout
+The system SHALL display a `NavigationSplitView` with a sidebar (categories + counts), a middle item list, and a detail pane. The sidebar SHALL be organised into sections: *Menu Items* (All Items, Favorites), *Folders* (section header always visible; folder rows shown when folders exist), *Types* (Login, Card, Identity, Secure Note, SSH Key), and *Trash*, each with a live item count. Soft-deleted items (Trash) SHALL be excluded from all non-Trash views. The item list SHALL support both single selection (click) and multi-selection (⌘-click, ⇧-click) for drag-and-drop operations. When multiple items are selected, the detail pane SHALL show an empty state. When exactly one item is selected, the detail pane SHALL show that item's content.
+
+#### Scenario: Sidebar shows all categories with counts
+- **WHEN** the vault browser opens
+- **THEN** the sidebar shows Menu Items, Folders (header always visible; rows when folders exist), Types, and Trash sections; each entry displays its item count; type entries are shown even when the count is zero
+
+#### Scenario: Selecting a sidebar category updates the item list
+- **WHEN** the user selects a sidebar entry (category, folder, or type)
+- **THEN** the middle pane shows only items belonging to that selection; the detail pane resets to its empty state
+
+#### Scenario: No item selected — empty detail state
+- **WHEN** no item is selected in the middle pane, or multiple items are selected
+- **THEN** the detail pane shows a "No item selected" empty state
+
+#### Scenario: Selecting an item shows its full content
+- **GIVEN** exactly one item is selected
+- **WHEN** the detail pane renders
+- **THEN** all fields for that item type are displayed, along with creation date and last-modified date
+
+#### Scenario: Item list shows type-specific subtitles and icons
+- **WHEN** the item list renders
+- **THEN** each row shows: favicon (or type-icon fallback), item name, type-specific subtitle (Login=username; Card=`*`+last 4 digits; Identity=first+last name; Secure Note=first 30 chars truncated; SSH Key=fingerprint), and a favorite star if marked as favorite
+
+#### Scenario: Item list is sorted alphabetically
+- **WHEN** any category is selected
+- **THEN** the item list is sorted alphabetically by item name, case-insensitive
+
+#### Scenario: Multi-select items in the item list
+- **WHEN** the user ⌘-clicks or ⇧-clicks items in the item list
+- **THEN** multiple items SHALL be selected and available for drag-and-drop operations

--- a/openspec/changes/vault-folder-organization/specs/vault-folder-organization/spec.md
+++ b/openspec/changes/vault-folder-organization/specs/vault-folder-organization/spec.md
@@ -120,18 +120,12 @@ The system SHALL allow folder deletion via right-click context menu → "Delete 
 ---
 
 ### Requirement: User can assign items to folders via drag-and-drop
-The system SHALL support dragging one or more items from the item list onto a folder row in the sidebar. Single-item drops SHALL use `PUT /ciphers/{id}/partial` with the target `folderId`. Multi-item drops SHALL use `PUT /ciphers/move` with the list of item IDs and the target `folderId`. The drop target folder row SHALL show SwiftUI's default `isTargeted` highlight during the drag. After a successful drop, item counts SHALL refresh for both the source and target folders. Drag-and-drop SHALL only be available from the active item list — trashed items SHALL NOT be draggable.
+The system SHALL support dragging a single item from the item list onto a folder row in the sidebar using `PUT /ciphers/{id}/partial` with the target `folderId`. The drop target folder row SHALL show SwiftUI's default `isTargeted` highlight during the drag. After a successful drop, item counts SHALL refresh for both the source and target folders. Drag-and-drop SHALL only be available from the active item list — trashed items SHALL NOT be draggable. Multi-select drag-and-drop is deferred to a follow-up change.
 
 #### Scenario: Drag single item to folder
 - **GIVEN** an item is displayed in the item list
 - **WHEN** the user drags the item onto a folder row in the sidebar
 - **THEN** the item SHALL be moved to that folder via `PUT /ciphers/{id}/partial`
-- **AND** sidebar folder counts SHALL refresh
-
-#### Scenario: Drag multiple items to folder
-- **GIVEN** multiple items are selected in the item list
-- **WHEN** the user drags the selection onto a folder row
-- **THEN** all selected items SHALL be moved to that folder via `PUT /ciphers/move`
 - **AND** sidebar folder counts SHALL refresh
 
 #### Scenario: Drop target highlights during drag
@@ -155,7 +149,7 @@ The system SHALL support dragging one or more items from the item list onto a fo
 ---
 
 ### Requirement: User can assign a folder via the item edit sheet
-The system SHALL display a folder picker in the item edit and create sheets. The picker SHALL list all folders sorted alphabetically, plus a "None" option to remove folder assignment. Selecting a folder SHALL set the `folderId` on the draft. The `folderId` SHALL be included in the cipher payload when saving via `PUT /ciphers/{id}` or `POST /api/ciphers`.
+The system SHALL display a folder picker in the item edit and create sheets when folders exist. The picker SHALL list all folders sorted alphabetically, plus a "None" option to remove folder assignment. Selecting a folder SHALL set the `folderId` on the draft. The `folderId` SHALL be included in the cipher payload when saving via `PUT /ciphers/{id}` or `POST /api/ciphers`. When no folders exist, the picker SHALL NOT be displayed.
 
 #### Scenario: Folder picker shown in edit sheet
 - **WHEN** the user opens the edit sheet for an item

--- a/openspec/changes/vault-folder-organization/specs/vault-folder-organization/spec.md
+++ b/openspec/changes/vault-folder-organization/specs/vault-folder-organization/spec.md
@@ -173,3 +173,114 @@ The system SHALL display a folder picker in the item edit and create sheets when
 #### Scenario: Assign folder on new item creation
 - **WHEN** the user creates a new item and selects a folder in the picker
 - **THEN** the new item SHALL be created with the selected `folderId`
+
+---
+
+### Requirement: Sidebar displays nested folders as a collapsible tree
+
+The system SHALL parse folder names using `/` as a hierarchy delimiter and render nested folders as a tree in the sidebar. A folder named `"Work/Projects"` SHALL appear as a child node under `"Work"`. If a parent path (e.g. `"Work"`) has no corresponding flat folder entry, it SHALL be rendered as a non-selectable virtual parent node — it cannot be selected or receive drag-and-drop. Real parent folders (where the flat entry exists) ARE selectable and receive drops. Parent nodes with at least one child SHALL display a disclosure arrow. Clicking the disclosure arrow collapses or expands child folder rows. Collapse state is per-session. Selecting a folder (real or virtual) shows only items whose `folderId` matches that exact folder — child folder items are NOT included.
+
+#### Scenario: Slash-delimited names render as nested tree
+- **GIVEN** the user has folders "Work" and "Work/Projects"
+- **WHEN** the sidebar renders
+- **THEN** "Work" SHALL appear as a parent row with a disclosure arrow
+- **AND** "Work/Projects" SHALL appear indented beneath "Work"
+
+#### Scenario: Virtual parent is non-selectable
+- **GIVEN** the user has a folder "Finance/Tax" but no "Finance" folder
+- **WHEN** the sidebar renders
+- **THEN** "Finance" SHALL appear as a non-selectable virtual parent with a disclosure arrow
+- **AND** "Finance/Tax" SHALL appear indented beneath "Finance"
+
+#### Scenario: Collapse hides child rows
+- **GIVEN** a parent folder "Work" is expanded and shows "Work/Projects" beneath it
+- **WHEN** the user clicks the disclosure arrow on "Work"
+- **THEN** "Work/Projects" SHALL be hidden from the sidebar
+
+#### Scenario: Expand restores child rows
+- **GIVEN** a parent folder "Work" is collapsed
+- **WHEN** the user clicks its disclosure arrow
+- **THEN** all child folders of "Work" SHALL reappear in the sidebar
+
+#### Scenario: Selecting a folder does not include child items
+- **GIVEN** folder "Work" has 2 items and folder "Work/Projects" has 3 items
+- **WHEN** the user selects "Work" in the sidebar
+- **THEN** the item list SHALL show only the 2 items directly assigned to "Work"
+
+#### Scenario: Badge count reflects direct assignments only
+- **GIVEN** folder "Work" has 2 directly assigned items and folder "Work/Projects" has 3 items
+- **WHEN** the sidebar renders
+- **THEN** the "Work" badge SHALL show 2 and the "Work/Projects" badge SHALL show 3
+
+#### Scenario: Nesting hint shown during folder creation
+- **WHEN** the inline folder creation text field is active
+- **THEN** the placeholder text SHALL read `"Name or Parent/Name"`
+- **AND** a help tooltip or accessible hint SHALL explain: `"Nest a folder by adding the parent folder's name followed by a /. Example: Social/Forums"`
+
+#### Scenario: Nesting hint shown during folder rename
+- **WHEN** the inline folder rename text field is active
+- **THEN** the same placeholder and help hint SHALL be present
+
+---
+
+### Requirement: Folder picker in item edit sheet matches field-row style
+
+The folder picker in the item edit and create sheets SHALL follow the same visual style as other field rows — a label above a value, with consistent horizontal padding, a separator, and no visible bordered button chrome. The picker SHALL use a menu presentation style so the label reads the selected folder name (or "None") inline in the field area. When no folders exist the picker row SHALL NOT be displayed (unchanged from existing behaviour).
+
+#### Scenario: Folder picker matches field row appearance
+- **WHEN** the user opens the edit sheet for an item that has folders available
+- **THEN** the "Folder" row SHALL visually match the other field rows in the sheet (label on top, value below, consistent padding)
+
+#### Scenario: Picker shows selected folder name inline
+- **GIVEN** an item is assigned to folder "Work"
+- **WHEN** the edit sheet opens
+- **THEN** the folder field SHALL display "Work" as the current value inline in the field row
+
+#### Scenario: Picker shows "None" when no folder assigned
+- **GIVEN** an item has no folder assigned
+- **WHEN** the edit sheet opens
+- **THEN** the folder field SHALL display "None" as the current value
+
+---
+
+### Requirement: Cmd+F search preserves active sidebar selection scope
+
+When the user activates the search field (via Cmd+F or clicking the search bar) while a sidebar item is selected, the search SHALL be scoped to that selection — including folder selections. The sidebar selection SHALL NOT be reset to All Items on search activation. Search results SHALL reflect the active `SidebarSelection` (folder, type, all items, etc.) exactly as defined in the existing folder-scoped search requirement.
+
+#### Scenario: Cmd+F preserves folder scope
+- **GIVEN** the user has selected folder "Work" in the sidebar
+- **WHEN** the user presses Cmd+F
+- **THEN** the search field SHALL become focused
+- **AND** search results SHALL be scoped to items in "Work"
+- **AND** the sidebar selection SHALL remain on "Work"
+
+#### Scenario: Search results update within folder scope
+- **GIVEN** the user has selected folder "Work" and typed a query in the search field
+- **WHEN** the query changes
+- **THEN** results SHALL be filtered within "Work" only, not across the full vault
+
+#### Scenario: Clearing search restores full folder item list
+- **GIVEN** the user is searching within folder "Work"
+- **WHEN** the user clears the search query
+- **THEN** all items in "Work" SHALL be shown (scope remains "Work")
+
+---
+
+### Requirement: Item detail view shows folder assignment
+
+The item detail pane SHALL display the assigned folder name in a read-only field row when the item has a `folderId`. The row SHALL appear after the last content section. The resolved folder name SHALL be looked up from the in-memory folder list by `folderId`. When `folderId` is nil the row SHALL be omitted entirely. The field row SHALL follow the same label-above-value visual style as other detail rows.
+
+#### Scenario: Detail view shows folder name for assigned item
+- **GIVEN** an item is assigned to folder "Work"
+- **WHEN** the user views the item in the detail pane
+- **THEN** a "Folder" row SHALL appear showing "Work"
+
+#### Scenario: Detail view omits folder row for unfoldered item
+- **GIVEN** an item has no folder assigned (`folderId` is nil)
+- **WHEN** the user views the item in the detail pane
+- **THEN** no "Folder" row SHALL appear
+
+#### Scenario: Folder name resolves from in-memory list
+- **GIVEN** an item has `folderId` matching folder "Finance"
+- **WHEN** the detail pane renders
+- **THEN** the folder row SHALL display "Finance" (resolved name, not the raw ID)

--- a/openspec/changes/vault-folder-organization/specs/vault-folder-organization/spec.md
+++ b/openspec/changes/vault-folder-organization/specs/vault-folder-organization/spec.md
@@ -64,16 +64,11 @@ The system SHALL provide a button (SF Symbol `folder.badge.plus`) on the "Folder
 ---
 
 ### Requirement: User can rename a folder
-The system SHALL support inline rename of a folder via SwiftUI's `.renameAction` modifier, which provides the standard macOS rename gesture: (1) click on an already-selected folder's name (single-click-to-rename, same as Finder), or (2) right-click a folder and choose "Rename" from the context menu. Both methods SHALL activate an inline editable text field on the folder row. Pressing Enter or clicking away SHALL commit the new name, encrypt it, and send `PUT /api/folders/{id}` to the server. Pressing Escape SHALL cancel the rename and restore the previous name. Empty or whitespace-only names SHALL be treated as a cancel.
-
-#### Scenario: Rename via click on selected folder name
-- **GIVEN** a folder is selected in the sidebar
-- **WHEN** the user clicks on the folder name text
-- **THEN** the folder name SHALL become an editable text field with the current name selected
+The system SHALL support inline rename of a folder via right-click context menu → "Rename". Selecting "Rename" SHALL activate an inline editable text field on the folder row. Pressing Enter or clicking away SHALL commit the new name, encrypt it, and send `PUT /api/folders/{id}` to the server. Pressing Escape SHALL cancel the rename and restore the previous name. Empty or whitespace-only names SHALL be treated as a cancel.
 
 #### Scenario: Rename via context menu
 - **WHEN** the user right-clicks a folder and selects "Rename"
-- **THEN** the folder name SHALL become an editable text field
+- **THEN** the folder name SHALL become an editable text field with the current name selected
 
 #### Scenario: Commit rename
 - **GIVEN** the user is editing a folder name with a non-empty value

--- a/openspec/changes/vault-folder-organization/specs/vault-folder-organization/spec.md
+++ b/openspec/changes/vault-folder-organization/specs/vault-folder-organization/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: User can browse vault items by folder
-The system SHALL display a "Folders" section in the sidebar between the Menu section and the Types section. Each folder row SHALL display the folder name and a badge with the count of items assigned to that folder. Folders SHALL be sorted alphabetically by decrypted name (case-insensitive). Selecting a folder SHALL display all items assigned to that folder in the item list, regardless of item type. The item list SHALL be sorted alphabetically by name, consistent with other sidebar selections. Items without a `folderId` SHALL NOT appear under any folder — they remain accessible via All Items, Favorites, and Type filters only.
+The system SHALL display a "Folders" section in the sidebar between the Menu section and the Types section. The "Folders" section header SHALL always be visible (even when no folders exist) to provide access to the create button. Each folder row SHALL display the folder name and a badge with the count of items assigned to that folder. Folders SHALL be sorted alphabetically by decrypted name (case-insensitive). Selecting a folder SHALL display all items assigned to that folder in the item list, regardless of item type. The item list SHALL be sorted alphabetically by name, consistent with other sidebar selections. Items without a `folderId` SHALL NOT appear under any folder — they remain accessible via All Items, Favorites, and Type filters only.
 
 #### Scenario: Folders section appears in sidebar with correct counts
 - **WHEN** the vault browser opens and the user has folders
@@ -33,7 +33,7 @@ The system SHALL display a "Folders" section in the sidebar between the Menu sec
 ---
 
 ### Requirement: User can create a folder
-The system SHALL provide a button (SF Symbol `folder.badge.plus`) on the "Folders" section header. Clicking the button SHALL create a new folder with a default name "New Folder" and immediately enter inline rename mode so the user can type the desired name. Pressing Enter SHALL commit the name, encrypt it as an EncString type-2, and send `POST /api/folders` to the server. Pressing Escape SHALL cancel creation and remove the uncommitted folder row. The folder name SHALL be encrypted client-side before being sent to the server.
+The system SHALL provide a button (SF Symbol `folder.badge.plus`) on the "Folders" section header. Clicking the button SHALL create a new folder with a default name "New Folder" and immediately enter inline rename mode so the user can type the desired name. Pressing Enter SHALL commit the name, encrypt it as an EncString type-2, and send `POST /api/folders` to the server. Pressing Escape SHALL cancel creation and remove the uncommitted folder row. The folder name SHALL be encrypted client-side before being sent to the server. Empty or whitespace-only names SHALL be treated as a cancel (the folder row is removed without an API call).
 
 #### Scenario: Create folder via header button
 - **WHEN** the user clicks the folder-plus button on the Folders section header
@@ -41,7 +41,7 @@ The system SHALL provide a button (SF Symbol `folder.badge.plus`) on the "Folder
 - **AND** the text field SHALL be focused for immediate editing
 
 #### Scenario: Commit folder name with Enter
-- **GIVEN** the user is editing a new folder name
+- **GIVEN** the user is editing a new folder name with a non-empty value
 - **WHEN** the user presses Enter
 - **THEN** the folder name SHALL be encrypted and sent to the server via `POST /api/folders`
 - **AND** the folder SHALL appear in the sidebar sorted alphabetically
@@ -51,15 +51,20 @@ The system SHALL provide a button (SF Symbol `folder.badge.plus`) on the "Folder
 - **WHEN** the user presses Escape
 - **THEN** the new folder row SHALL be removed without making any API call
 
-#### Scenario: Folders section always shows when create button is needed
-- **WHEN** the user has no folders
-- **THEN** the "Folders" section header SHALL still appear with the create button, but with no folder rows beneath it
-- **AND** clicking the create button SHALL add the first folder row in inline edit mode
+#### Scenario: Empty name treated as cancel
+- **GIVEN** the user is editing a new folder name
+- **WHEN** the user clears the name to empty or whitespace-only and presses Enter
+- **THEN** the new folder row SHALL be removed without making any API call
+
+#### Scenario: Server error during folder creation
+- **GIVEN** the user commits a valid folder name
+- **WHEN** the server returns an error
+- **THEN** the uncommitted folder row SHALL be removed and an error alert SHALL be shown
 
 ---
 
 ### Requirement: User can rename a folder
-The system SHALL support inline rename of a folder via SwiftUI's `.renameAction` modifier, which provides the standard macOS rename gesture: (1) click on an already-selected folder's name (single-click-to-rename, same as Finder), or (2) right-click a folder and choose "Rename" from the context menu. Both methods SHALL activate an inline editable text field on the folder row. Pressing Enter or clicking away SHALL commit the new name, encrypt it, and send `PUT /api/folders/{id}` to the server. Pressing Escape SHALL cancel the rename and restore the previous name.
+The system SHALL support inline rename of a folder via SwiftUI's `.renameAction` modifier, which provides the standard macOS rename gesture: (1) click on an already-selected folder's name (single-click-to-rename, same as Finder), or (2) right-click a folder and choose "Rename" from the context menu. Both methods SHALL activate an inline editable text field on the folder row. Pressing Enter or clicking away SHALL commit the new name, encrypt it, and send `PUT /api/folders/{id}` to the server. Pressing Escape SHALL cancel the rename and restore the previous name. Empty or whitespace-only names SHALL be treated as a cancel.
 
 #### Scenario: Rename via click on selected folder name
 - **GIVEN** a folder is selected in the sidebar
@@ -71,7 +76,7 @@ The system SHALL support inline rename of a folder via SwiftUI's `.renameAction`
 - **THEN** the folder name SHALL become an editable text field
 
 #### Scenario: Commit rename
-- **GIVEN** the user is editing a folder name
+- **GIVEN** the user is editing a folder name with a non-empty value
 - **WHEN** the user presses Enter
 - **THEN** the new name SHALL be encrypted and sent to the server via `PUT /api/folders/{id}`
 - **AND** the folder SHALL re-sort alphabetically in the sidebar
@@ -80,6 +85,16 @@ The system SHALL support inline rename of a folder via SwiftUI's `.renameAction`
 - **GIVEN** the user is editing a folder name
 - **WHEN** the user presses Escape
 - **THEN** the folder name SHALL revert to its previous value without making any API call
+
+#### Scenario: Empty name on rename treated as cancel
+- **GIVEN** the user is editing a folder name
+- **WHEN** the user clears the name to empty or whitespace-only and presses Enter
+- **THEN** the folder name SHALL revert to its previous value without making any API call
+
+#### Scenario: Server error during rename
+- **GIVEN** the user commits a valid new folder name
+- **WHEN** the server returns an error
+- **THEN** the folder name SHALL revert to its previous value and an error alert SHALL be shown
 
 ---
 
@@ -102,10 +117,15 @@ The system SHALL allow folder deletion via right-click context menu → "Delete 
 - **WHEN** the user cancels
 - **THEN** no API call SHALL be made and the folder SHALL remain unchanged
 
+#### Scenario: Server error during folder deletion
+- **GIVEN** the user confirms folder deletion
+- **WHEN** the server returns an error
+- **THEN** the folder SHALL remain in the sidebar unchanged and an error alert SHALL be shown
+
 ---
 
 ### Requirement: User can assign items to folders via drag-and-drop
-The system SHALL support dragging one or more items from the item list onto a folder row in the sidebar. Single-item drops SHALL use `PUT /ciphers/{id}/partial` with the target `folderId`. Multi-item drops SHALL use `PUT /ciphers/move` with the list of item IDs and the target `folderId`. The drop target folder row SHALL show SwiftUI's default `isTargeted` highlight during the drag. After a successful drop, item counts SHALL refresh for both the source and target folders.
+The system SHALL support dragging one or more items from the item list onto a folder row in the sidebar. Single-item drops SHALL use `PUT /ciphers/{id}/partial` with the target `folderId`. Multi-item drops SHALL use `PUT /ciphers/move` with the list of item IDs and the target `folderId`. The drop target folder row SHALL show SwiftUI's default `isTargeted` highlight during the drag. After a successful drop, item counts SHALL refresh for both the source and target folders. Drag-and-drop SHALL only be available from the active item list — trashed items SHALL NOT be draggable.
 
 #### Scenario: Drag single item to folder
 - **GIVEN** an item is displayed in the item list
@@ -127,6 +147,15 @@ The system SHALL support dragging one or more items from the item list onto a fo
 - **GIVEN** an item is in folder "Work"
 - **WHEN** the user drags it onto folder "Personal"
 - **THEN** the item's `folderId` SHALL change to "Personal" and counts for both folders SHALL update
+
+#### Scenario: Trashed items are not draggable
+- **GIVEN** the user is viewing the Trash
+- **THEN** items in the Trash SHALL NOT be draggable to folders
+
+#### Scenario: Server error during drag-and-drop move
+- **GIVEN** the user drops an item onto a folder
+- **WHEN** the server returns an error
+- **THEN** the local cache SHALL NOT be updated and an error alert SHALL be shown
 
 ---
 

--- a/openspec/changes/vault-folder-organization/specs/vault-folder-organization/spec.md
+++ b/openspec/changes/vault-folder-organization/specs/vault-folder-organization/spec.md
@@ -1,0 +1,157 @@
+## ADDED Requirements
+
+### Requirement: User can browse vault items by folder
+The system SHALL display a "Folders" section in the sidebar between the Menu section and the Types section. Each folder row SHALL display the folder name and a badge with the count of items assigned to that folder. Folders SHALL be sorted alphabetically by decrypted name (case-insensitive). Selecting a folder SHALL display all items assigned to that folder in the item list, regardless of item type. The item list SHALL be sorted alphabetically by name, consistent with other sidebar selections. Items without a `folderId` SHALL NOT appear under any folder — they remain accessible via All Items, Favorites, and Type filters only.
+
+#### Scenario: Folders section appears in sidebar with correct counts
+- **WHEN** the vault browser opens and the user has folders
+- **THEN** a "Folders" section SHALL appear between Menu and Types, with each folder showing its name and item count badge
+
+#### Scenario: Selecting a folder filters the item list
+- **WHEN** the user selects a folder in the sidebar
+- **THEN** the item list SHALL show only items assigned to that folder, sorted alphabetically by name
+
+#### Scenario: Folders are sorted alphabetically
+- **GIVEN** the user has folders named "Work", "Finance", "Personal"
+- **WHEN** the sidebar renders
+- **THEN** folders SHALL appear in order: Finance, Personal, Work
+
+#### Scenario: Empty folder shows zero count
+- **GIVEN** a folder exists with no items assigned
+- **WHEN** the sidebar renders
+- **THEN** the folder row SHALL display a count of 0
+
+#### Scenario: Folders section header always visible
+- **WHEN** the user has no folders
+- **THEN** the "Folders" section header with the create button SHALL still appear, but with no folder rows beneath it
+
+#### Scenario: Search scopes to selected folder
+- **GIVEN** the user has selected a folder in the sidebar
+- **WHEN** the user types a search query
+- **THEN** search results SHALL be scoped to items within that folder
+
+---
+
+### Requirement: User can create a folder
+The system SHALL provide a button (SF Symbol `folder.badge.plus`) on the "Folders" section header. Clicking the button SHALL create a new folder with a default name "New Folder" and immediately enter inline rename mode so the user can type the desired name. Pressing Enter SHALL commit the name, encrypt it as an EncString type-2, and send `POST /api/folders` to the server. Pressing Escape SHALL cancel creation and remove the uncommitted folder row. The folder name SHALL be encrypted client-side before being sent to the server.
+
+#### Scenario: Create folder via header button
+- **WHEN** the user clicks the folder-plus button on the Folders section header
+- **THEN** a new folder row SHALL appear with an editable text field containing "New Folder"
+- **AND** the text field SHALL be focused for immediate editing
+
+#### Scenario: Commit folder name with Enter
+- **GIVEN** the user is editing a new folder name
+- **WHEN** the user presses Enter
+- **THEN** the folder name SHALL be encrypted and sent to the server via `POST /api/folders`
+- **AND** the folder SHALL appear in the sidebar sorted alphabetically
+
+#### Scenario: Cancel folder creation with Escape
+- **GIVEN** the user is editing a new folder name
+- **WHEN** the user presses Escape
+- **THEN** the new folder row SHALL be removed without making any API call
+
+#### Scenario: Folders section always shows when create button is needed
+- **WHEN** the user has no folders
+- **THEN** the "Folders" section header SHALL still appear with the create button, but with no folder rows beneath it
+- **AND** clicking the create button SHALL add the first folder row in inline edit mode
+
+---
+
+### Requirement: User can rename a folder
+The system SHALL support inline rename of a folder via two methods: (1) select a folder and press Enter, or (2) right-click a folder and choose "Rename" from the context menu. Both methods SHALL activate an inline editable text field on the folder row. Pressing Enter SHALL commit the new name, encrypt it, and send `PUT /api/folders/{id}` to the server. Pressing Escape SHALL cancel the rename and restore the previous name.
+
+#### Scenario: Rename via Enter key
+- **GIVEN** a folder is selected in the sidebar
+- **WHEN** the user presses Enter
+- **THEN** the folder name SHALL become an editable text field with the current name selected
+
+#### Scenario: Rename via context menu
+- **WHEN** the user right-clicks a folder and selects "Rename"
+- **THEN** the folder name SHALL become an editable text field
+
+#### Scenario: Commit rename
+- **GIVEN** the user is editing a folder name
+- **WHEN** the user presses Enter
+- **THEN** the new name SHALL be encrypted and sent to the server via `PUT /api/folders/{id}`
+- **AND** the folder SHALL re-sort alphabetically in the sidebar
+
+#### Scenario: Cancel rename
+- **GIVEN** the user is editing a folder name
+- **WHEN** the user presses Escape
+- **THEN** the folder name SHALL revert to its previous value without making any API call
+
+---
+
+### Requirement: User can delete a folder
+The system SHALL allow folder deletion via right-click context menu → "Delete Folder". Deleting a folder SHALL show a confirmation alert explaining that items in the folder will not be deleted but will become unfoldered. Confirming SHALL send `DELETE /api/folders/{id}` to the server. Items previously in the deleted folder SHALL have their `folderId` cleared in the local cache and remain accessible via All Items and Type filters.
+
+#### Scenario: Delete folder via context menu
+- **WHEN** the user right-clicks a folder and selects "Delete Folder"
+- **THEN** a confirmation alert SHALL appear stating the folder will be deleted and items will be unfoldered
+
+#### Scenario: Confirm folder deletion
+- **GIVEN** the delete confirmation alert is shown
+- **WHEN** the user confirms
+- **THEN** the folder SHALL be removed from the server via `DELETE /api/folders/{id}`
+- **AND** the folder SHALL be removed from the sidebar
+- **AND** items that were in the folder SHALL have their `folderId` cleared in the local cache
+
+#### Scenario: Cancel folder deletion
+- **GIVEN** the delete confirmation alert is shown
+- **WHEN** the user cancels
+- **THEN** no API call SHALL be made and the folder SHALL remain unchanged
+
+---
+
+### Requirement: User can assign items to folders via drag-and-drop
+The system SHALL support dragging one or more items from the item list onto a folder row in the sidebar. Single-item drops SHALL use `PUT /ciphers/{id}/partial` with the target `folderId`. Multi-item drops SHALL use `PUT /ciphers/move` with the list of item IDs and the target `folderId`. The drop target folder row SHALL show SwiftUI's default `isTargeted` highlight during the drag. After a successful drop, item counts SHALL refresh for both the source and target folders.
+
+#### Scenario: Drag single item to folder
+- **GIVEN** an item is displayed in the item list
+- **WHEN** the user drags the item onto a folder row in the sidebar
+- **THEN** the item SHALL be moved to that folder via `PUT /ciphers/{id}/partial`
+- **AND** sidebar folder counts SHALL refresh
+
+#### Scenario: Drag multiple items to folder
+- **GIVEN** multiple items are selected in the item list
+- **WHEN** the user drags the selection onto a folder row
+- **THEN** all selected items SHALL be moved to that folder via `PUT /ciphers/move`
+- **AND** sidebar folder counts SHALL refresh
+
+#### Scenario: Drop target highlights during drag
+- **WHEN** the user drags an item over a folder row
+- **THEN** the folder row SHALL show the default SwiftUI drop target highlight
+
+#### Scenario: Drag to move between folders
+- **GIVEN** an item is in folder "Work"
+- **WHEN** the user drags it onto folder "Personal"
+- **THEN** the item's `folderId` SHALL change to "Personal" and counts for both folders SHALL update
+
+---
+
+### Requirement: User can assign a folder via the item edit sheet
+The system SHALL display a folder picker in the item edit and create sheets. The picker SHALL list all folders sorted alphabetically, plus a "None" option to remove folder assignment. Selecting a folder SHALL set the `folderId` on the draft. The `folderId` SHALL be included in the cipher payload when saving via `PUT /ciphers/{id}` or `POST /api/ciphers`.
+
+#### Scenario: Folder picker shown in edit sheet
+- **WHEN** the user opens the edit sheet for an item
+- **THEN** a "Folder" picker SHALL be displayed with all folders and a "None" option
+
+#### Scenario: Current folder is pre-selected
+- **GIVEN** an item is assigned to folder "Work"
+- **WHEN** the edit sheet opens
+- **THEN** "Work" SHALL be pre-selected in the folder picker
+
+#### Scenario: Change folder via picker
+- **GIVEN** the edit sheet is open
+- **WHEN** the user selects a different folder and saves
+- **THEN** the item's `folderId` SHALL be updated on the server
+
+#### Scenario: Remove folder assignment
+- **GIVEN** an item is assigned to a folder
+- **WHEN** the user selects "None" in the folder picker and saves
+- **THEN** the item's `folderId` SHALL be set to nil on the server
+
+#### Scenario: Assign folder on new item creation
+- **WHEN** the user creates a new item and selects a folder in the picker
+- **THEN** the new item SHALL be created with the selected `folderId`

--- a/openspec/changes/vault-folder-organization/specs/vault-folder-organization/spec.md
+++ b/openspec/changes/vault-folder-organization/specs/vault-folder-organization/spec.md
@@ -59,11 +59,11 @@ The system SHALL provide a button (SF Symbol `folder.badge.plus`) on the "Folder
 ---
 
 ### Requirement: User can rename a folder
-The system SHALL support inline rename of a folder via two methods: (1) select a folder and press Enter, or (2) right-click a folder and choose "Rename" from the context menu. Both methods SHALL activate an inline editable text field on the folder row. Pressing Enter SHALL commit the new name, encrypt it, and send `PUT /api/folders/{id}` to the server. Pressing Escape SHALL cancel the rename and restore the previous name.
+The system SHALL support inline rename of a folder via SwiftUI's `.renameAction` modifier, which provides the standard macOS rename gesture: (1) click on an already-selected folder's name (single-click-to-rename, same as Finder), or (2) right-click a folder and choose "Rename" from the context menu. Both methods SHALL activate an inline editable text field on the folder row. Pressing Enter or clicking away SHALL commit the new name, encrypt it, and send `PUT /api/folders/{id}` to the server. Pressing Escape SHALL cancel the rename and restore the previous name.
 
-#### Scenario: Rename via Enter key
+#### Scenario: Rename via click on selected folder name
 - **GIVEN** a folder is selected in the sidebar
-- **WHEN** the user presses Enter
+- **WHEN** the user clicks on the folder name text
 - **THEN** the folder name SHALL become an editable text field with the current name selected
 
 #### Scenario: Rename via context menu

--- a/openspec/changes/vault-folder-organization/specs/vault-item-create/spec.md
+++ b/openspec/changes/vault-folder-organization/specs/vault-item-create/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Edit and create sheets include a folder picker
+The system SHALL display a "Folder" picker in both the item edit sheet and the item create sheet. The picker SHALL list all folders sorted alphabetically by name, plus a "None" option at the top. For existing items, the picker SHALL pre-select the item's current folder (or "None" if unfoldered). For new items, the picker SHALL default to "None". The selected folder SHALL be included as `folderId` in the cipher payload when saving.
+
+#### Scenario: Folder picker shown in edit sheet
+- **WHEN** the user opens the edit sheet for an existing item
+- **THEN** a "Folder" picker SHALL be displayed listing "None" followed by all folders alphabetically
+
+#### Scenario: Folder picker shown in create sheet
+- **WHEN** the user opens the create sheet for a new item
+- **THEN** a "Folder" picker SHALL be displayed with "None" pre-selected
+
+#### Scenario: Current folder pre-selected on edit
+- **GIVEN** an item is assigned to folder "Work"
+- **WHEN** the edit sheet opens
+- **THEN** "Work" SHALL be pre-selected in the folder picker
+
+#### Scenario: Folder selection included in save payload
+- **GIVEN** the user selects folder "Personal" in the picker
+- **WHEN** the user saves the item
+- **THEN** the cipher payload SHALL include `folderId` set to the "Personal" folder's ID

--- a/openspec/changes/vault-folder-organization/specs/vault-item-create/spec.md
+++ b/openspec/changes/vault-folder-organization/specs/vault-item-create/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Edit and create sheets include a folder picker
-The system SHALL display a "Folder" picker in both the item edit sheet and the item create sheet. The picker SHALL list all folders sorted alphabetically by name, plus a "None" option at the top. For existing items, the picker SHALL pre-select the item's current folder (or "None" if unfoldered). For new items, the picker SHALL default to "None". The selected folder SHALL be included as `folderId` in the cipher payload when saving.
+The system SHALL display a "Folder" picker in both the item edit sheet and the item create sheet when folders exist. The picker SHALL list all folders sorted alphabetically by name, plus a "None" option at the top. For existing items, the picker SHALL pre-select the item's current folder (or "None" if unfoldered). For new items, the picker SHALL default to "None". The selected folder SHALL be included as `folderId` in the cipher payload when saving. When no folders exist, the picker SHALL NOT be displayed.
 
 #### Scenario: Folder picker shown in edit sheet
 - **WHEN** the user opens the edit sheet for an existing item

--- a/openspec/changes/vault-folder-organization/tasks.md
+++ b/openspec/changes/vault-folder-organization/tasks.md
@@ -22,12 +22,12 @@
 
 ## 4. API Client
 
-- [ ] 4.1 Add `createFolder(encryptedName: String) async throws -> RawFolder` to `PrizmAPIClientProtocol` and impl (`POST /api/folders`)
-- [ ] 4.2 Add `updateFolder(id: String, encryptedName: String) async throws -> RawFolder` (`PUT /api/folders/{id}`)
-- [ ] 4.3 Add `deleteFolder(id: String) async throws` (`DELETE /api/folders/{id}`)
-- [ ] 4.4 Add `updateCipherPartial(id: String, folderId: String?, favorite: Bool) async throws` (`PUT /ciphers/{id}/partial`)
-- [ ] 4.5 Add `moveCiphersToFolder(ids: [String], folderId: String?) async throws` (`PUT /ciphers/move`)
-- [ ] 4.6 Update `MockPrizmAPIClient` with folder endpoint stubs
+- [x] 4.1 Add `createFolder(encryptedName: String) async throws -> RawFolder` to `PrizmAPIClientProtocol` and impl (`POST /api/folders`)
+- [x] 4.2 Add `updateFolder(id: String, encryptedName: String) async throws -> RawFolder` (`PUT /api/folders/{id}`)
+- [x] 4.3 Add `deleteFolder(id: String) async throws` (`DELETE /api/folders/{id}`)
+- [x] 4.4 Add `updateCipherPartial(id: String, folderId: String?, favorite: Bool) async throws` (`PUT /ciphers/{id}/partial`)
+- [x] 4.5 Add `moveCiphersToFolder(ids: [String], folderId: String?) async throws` (`PUT /ciphers/move`)
+- [x] 4.6 Update `MockPrizmAPIClient` with folder endpoint stubs
 
 ## 5. Repository Layer
 

--- a/openspec/changes/vault-folder-organization/tasks.md
+++ b/openspec/changes/vault-folder-organization/tasks.md
@@ -46,12 +46,12 @@
 
 ## 6. Domain Use Cases
 
-- [ ] 6.1 Create `CreateFolderUseCase` protocol in Domain and `CreateFolderUseCaseImpl` in Data (delegates to `VaultRepository.createFolder`)
-- [ ] 6.2 Create `RenameFolderUseCase` protocol in Domain and `RenameFolderUseCaseImpl` in Data (delegates to `VaultRepository.renameFolder`)
-- [ ] 6.3 Create `DeleteFolderUseCase` protocol in Domain and `DeleteFolderUseCaseImpl` in Data (delegates to `VaultRepository.deleteFolder`)
-- [ ] 6.4 Create `MoveItemToFolderUseCase` protocol in Domain and `MoveItemToFolderUseCaseImpl` in Data (delegates to `VaultRepository.moveItemToFolder` / `moveItemsToFolder`)
-- [ ] 6.5 Add use case tests for folder create, rename, delete, and move-to-folder
-- [ ] 6.6 Wire all folder use cases in `AppContainer`
+- [x] 6.1 Create `CreateFolderUseCase` protocol in Domain and `CreateFolderUseCaseImpl` in Data (delegates to `VaultRepository.createFolder`)
+- [x] 6.2 Create `RenameFolderUseCase` protocol in Domain and `RenameFolderUseCaseImpl` in Data (delegates to `VaultRepository.renameFolder`)
+- [x] 6.3 Create `DeleteFolderUseCase` protocol in Domain and `DeleteFolderUseCaseImpl` in Data (delegates to `VaultRepository.deleteFolder`)
+- [x] 6.4 Create `MoveItemToFolderUseCase` protocol in Domain and `MoveItemToFolderUseCaseImpl` in Data (delegates to `VaultRepository.moveItemToFolder` / `moveItemsToFolder`)
+- [x] 6.5 Add use case tests for folder create, rename, delete, and move-to-folder
+- [x] 6.6 Wire all folder use cases in `AppContainer`
 
 ## 7. Sidebar UI
 

--- a/openspec/changes/vault-folder-organization/tasks.md
+++ b/openspec/changes/vault-folder-organization/tasks.md
@@ -31,14 +31,14 @@
 
 ## 5. Repository Layer
 
-- [ ] 5.1 Add `folders: [Folder]` storage to `VaultRepositoryImpl` with populate/clear
+- [ ] 5.1 Add `folders: [Folder]` storage to `VaultRepositoryImpl`; update `populate` and `clearVault` to include folders
 - [ ] 5.2 Add `folders() throws -> [Folder]` to `VaultRepository` protocol and impl (sorted alphabetically)
 - [ ] 5.3 Update `VaultRepository.populate` to accept folders alongside items; update `MockVaultRepository` and all existing tests that call `populate`
 - [ ] 5.4 Update `SyncRepositoryImpl.sync` to call `crypto.decryptFolders` and pass results to `vaultRepository.populate`
 - [ ] 5.5 Update `VaultRepositoryImpl.items(for:)` to handle `.folder(id)` selection (filter by `folderId`)
 - [ ] 5.6 Update `VaultRepositoryImpl.itemCounts()` to include per-folder counts
 - [ ] 5.7 Update `VaultRepositoryImpl.searchItems(query:in:)` to support folder-scoped search
-- [ ] 5.8 Add folder CRUD methods to `VaultRepository` protocol: `createFolder(name:)`, `renameFolder(id:name:)`, `deleteFolder(id:)` — `VaultRepositoryImpl` encrypts name internally, calls API, updates local cache
+- [ ] 5.8 Add folder CRUD methods to `VaultRepository` protocol: `createFolder(name:)`, `renameFolder(id:name:)`, `deleteFolder(id:)` — `VaultRepositoryImpl` encrypts name internally, calls API, updates local cache; reject empty/whitespace-only names before API call
 - [ ] 5.9 Add `moveItemToFolder(itemId:folderId:)` and `moveItemsToFolder(itemIds:folderId:)` to `VaultRepository` — `VaultRepositoryImpl` calls partial/move API, updates local folderId
 - [ ] 5.10 Update `MockVaultRepository` with all new folder methods
 - [ ] 5.11 Add `VaultRepositoryImplTests` for folder-scoped filtering, counts, and folder CRUD
@@ -65,7 +65,7 @@
 ## 8. Item List & Drag
 
 - [ ] 8.1 Change `ItemListView` selection from `VaultItem?` to `Set<String>` for multi-select support
-- [ ] 8.2 Update `VaultBrowserViewModel` to handle `Set<String>` selection and derive detail pane item (single selected → show detail; zero or multiple → empty state)
+- [ ] 8.2 Update `VaultBrowserViewModel` to handle `Set<String>` selection and derive detail pane item (single selected → show detail; zero or multiple → empty state); disable Edit, Copy, Favorite, Delete actions when multiple items are selected
 - [ ] 8.3 Add `.draggable` on item rows with item ID as `Transferable` payload
 - [ ] 8.4 Wire drop handler on folder rows to call `MoveItemToFolderUseCase` and refresh counts
 
@@ -78,8 +78,8 @@
 ## 10. ViewModel Integration
 
 - [ ] 10.1 Expose `folders` from `VaultBrowserViewModel` (calls `vault.folders()`) for sidebar rendering
-- [ ] 10.2 Add folder CRUD actions to `VaultBrowserViewModel` calling use cases (create, rename, delete)
-- [ ] 10.3 Add move-to-folder action to `VaultBrowserViewModel` calling `MoveItemToFolderUseCase` (single and bulk)
+- [ ] 10.2 Add folder CRUD actions to `VaultBrowserViewModel` calling use cases (create, rename, delete); surface errors via `actionError` alert; validate empty/whitespace names client-side before calling use case
+- [ ] 10.3 Add move-to-folder action to `VaultBrowserViewModel` calling `MoveItemToFolderUseCase` (single and bulk); surface errors via `actionError`; do not update local cache on failure
 - [ ] 10.4 Update `refreshCounts` and `refreshItems` to include folder data
 - [ ] 10.5 Handle folder deletion: if the deleted folder was selected, switch to All Items
 - [ ] 10.6 Add delete folder confirmation alert to `VaultBrowserView`

--- a/openspec/changes/vault-folder-organization/tasks.md
+++ b/openspec/changes/vault-folder-organization/tasks.md
@@ -64,22 +64,22 @@
 
 ## 8. Item List & Drag
 
-- [ ] 8.1 Change `ItemListView` selection from `VaultItem?` to `Set<String>` for multi-select support
-- [ ] 8.2 Update `VaultBrowserViewModel` to handle `Set<String>` selection and derive detail pane item (single selected → show detail; zero or multiple → empty state); disable Edit, Copy, Favorite, Delete actions when multiple items are selected
-- [ ] 8.3 Add `.draggable` on item rows with item ID as `Transferable` payload
-- [ ] 8.4 Wire drop handler on folder rows to call `MoveItemToFolderUseCase` and refresh counts
+- [x] 8.1 Change `ItemListView` selection from `VaultItem?` to `Set<String>` for multi-select support
+- [x] 8.2 Update `VaultBrowserViewModel` to handle `Set<String>` selection and derive detail pane item (single selected → show detail; zero or multiple → empty state); disable Edit, Copy, Favorite, Delete actions when multiple items are selected
+- [x] 8.3 Add `.draggable` on item rows with item ID as `Transferable` payload
+- [x] 8.4 Wire drop handler on folder rows to call `MoveItemToFolderUseCase` and refresh counts
 
 ## 9. Edit Sheet — Folder Picker
 
-- [ ] 9.1 Add folder `Picker` to `ItemEditView` (all folders + "None", sorted alphabetically)
-- [ ] 9.2 Bind picker selection to `DraftVaultItem.folderId`
-- [ ] 9.3 Pass `[Folder]` to `ItemEditViewModel` at construction time via `AppContainer` factory methods (call `vaultStore.folders()`)
+- [x] 9.1 Add folder `Picker` to `ItemEditView` (all folders + "None", sorted alphabetically)
+- [x] 9.2 Bind picker selection to `DraftVaultItem.folderId`
+- [x] 9.3 Pass `[Folder]` to `ItemEditViewModel` at construction time via `AppContainer` factory methods (call `vaultStore.folders()`)
 
 ## 10. ViewModel Integration
 
-- [ ] 10.1 Expose `folders` from `VaultBrowserViewModel` (calls `vault.folders()`) for sidebar rendering
-- [ ] 10.2 Add folder CRUD actions to `VaultBrowserViewModel` calling use cases (create, rename, delete); surface errors via `actionError` alert; validate empty/whitespace names client-side before calling use case
-- [ ] 10.3 Add move-to-folder action to `VaultBrowserViewModel` calling `MoveItemToFolderUseCase` (single and bulk); surface errors via `actionError`; do not update local cache on failure
-- [ ] 10.4 Update `refreshCounts` and `refreshItems` to include folder data
-- [ ] 10.5 Handle folder deletion: if the deleted folder was selected, switch to All Items
-- [ ] 10.6 Add delete folder confirmation alert to `VaultBrowserView`
+- [x] 10.1 Expose `folders` from `VaultBrowserViewModel` (calls `vault.folders()`) for sidebar rendering
+- [x] 10.2 Add folder CRUD actions to `VaultBrowserViewModel` calling use cases (create, rename, delete); surface errors via `actionError` alert; validate empty/whitespace names client-side before calling use case
+- [x] 10.3 Add move-to-folder action to `VaultBrowserViewModel` calling `MoveItemToFolderUseCase` (single and bulk); surface errors via `actionError`; do not update local cache on failure
+- [x] 10.4 Update `refreshCounts` and `refreshItems` to include folder data
+- [x] 10.5 Handle folder deletion: if the deleted folder was selected, switch to All Items
+- [x] 10.6 Add delete folder confirmation alert to `VaultBrowserView`

--- a/openspec/changes/vault-folder-organization/tasks.md
+++ b/openspec/changes/vault-folder-organization/tasks.md
@@ -1,0 +1,85 @@
+## 1. Wire Models & Sync
+
+- [ ] 1.1 Add `RawFolder` model (`id: String`, `name: String`, `revisionDate: String?`) to `Data/Network/Models/`
+- [ ] 1.2 Add `folders: [RawFolder]` to `SyncResponse`
+- [ ] 1.3 Add `folderId: String?` to `RawCipher`
+
+## 2. Domain Entities
+
+- [ ] 2.1 Create `Folder` entity (`id: String`, `name: String`) in `Domain/Entities/`
+- [ ] 2.2 Add `folderId: String?` to `VaultItem` (with default `nil` in init)
+- [ ] 2.3 Add `var folderId: String?` to `DraftVaultItem` and `DraftVaultItem.blank(type:)`
+- [ ] 2.4 Add `.folder(String)` case to `SidebarSelection` (update `Equatable`, `Hashable`, `displayName`)
+- [ ] 2.5 Add `.folders` case to `SidebarSection`
+
+## 3. Mapper & Crypto
+
+- [ ] 3.1 Pass through `folderId` in `CipherMapper.map(raw:keys:)` → `VaultItem`
+- [ ] 3.2 Include `folderId` in `CipherMapper.toRawCipher(_:encryptedWith:)` output
+- [ ] 3.3 Update `CipherMapperTests` to verify `folderId` pass-through (forward and reverse)
+- [ ] 3.4 Add folder name decrypt in `SyncRepositoryImpl` using existing `EncString.decrypt(keys:)` path
+- [ ] 3.5 Add folder name encrypt in use case impls using existing `EncString.encrypt(data:keys:)` path
+
+## 4. API Client
+
+- [ ] 4.1 Add `createFolder(encryptedName: String) async throws -> RawFolder` to `PrizmAPIClientProtocol` and impl (`POST /api/folders`)
+- [ ] 4.2 Add `updateFolder(id: String, encryptedName: String) async throws -> RawFolder` (`PUT /api/folders/{id}`)
+- [ ] 4.3 Add `deleteFolder(id: String) async throws` (`DELETE /api/folders/{id}`)
+- [ ] 4.4 Add `updateCipherPartial(id: String, folderId: String?, favorite: Bool) async throws` (`PUT /ciphers/{id}/partial`)
+- [ ] 4.5 Add `moveCiphersToFolder(ids: [String], folderId: String?) async throws` (`PUT /ciphers/move`)
+- [ ] 4.6 Update `MockPrizmAPIClient` with folder endpoint stubs
+
+## 5. Repository Layer
+
+- [ ] 5.1 Add `folders: [Folder]` storage to `VaultRepositoryImpl` with populate/clear
+- [ ] 5.2 Add `folders() throws -> [Folder]` to `VaultRepository` protocol and impl (sorted alphabetically)
+- [ ] 5.3 Update `VaultRepository.populate` to accept folders alongside items
+- [ ] 5.4 Update `SyncRepositoryImpl.sync` to decrypt folder names from `syncResponse.folders` and pass to `vaultRepository.populate`
+- [ ] 5.5 Update `VaultRepositoryImpl.items(for:)` to handle `.folder(id)` selection (filter by `folderId`)
+- [ ] 5.6 Update `VaultRepositoryImpl.itemCounts()` to include per-folder counts
+- [ ] 5.7 Update `VaultRepositoryImpl.searchItems(query:in:)` to support folder-scoped search
+- [ ] 5.8 Add folder CRUD methods to `VaultRepository`: `createFolder`, `renameFolder`, `deleteFolder` (encrypt name, call API, update local cache)
+- [ ] 5.9 Add `moveItemToFolder(itemId:folderId:)` and `moveItemsToFolder(itemIds:folderId:)` to `VaultRepository` (call partial/move API, update local folderId)
+- [ ] 5.10 Update `MockVaultRepository` with folder methods and `folderId` support
+- [ ] 5.11 Add `VaultRepositoryImplTests` for folder-scoped filtering, counts, and folder CRUD
+- [ ] 5.12 Add tests for move-to-folder (single and bulk, local cache update)
+
+## 6. Domain Use Cases
+
+- [ ] 6.1 Create `CreateFolderUseCase` protocol in Domain and `CreateFolderUseCaseImpl` in Data
+- [ ] 6.2 Create `RenameFolderUseCase` protocol in Domain and `RenameFolderUseCaseImpl` in Data
+- [ ] 6.3 Create `DeleteFolderUseCase` protocol in Domain and `DeleteFolderUseCaseImpl` in Data
+- [ ] 6.4 Create `MoveItemToFolderUseCase` protocol in Domain and `MoveItemToFolderUseCaseImpl` in Data (handles single and bulk)
+- [ ] 6.5 Add use case tests for folder create, rename, delete, and move-to-folder
+- [ ] 6.6 Wire use cases in `AppContainer`
+
+## 7. Sidebar UI
+
+- [ ] 7.1 Add `.folders` section to `SidebarView` with dynamic folder rows sorted alphabetically
+- [ ] 7.2 Add `folder.badge.plus` button on the Folders section header for folder creation
+- [ ] 7.3 Add `.contextMenu` on folder rows with "Rename" and "Delete Folder" actions
+- [ ] 7.4 Implement inline rename using SwiftUI `.renameAction` on folder rows
+- [ ] 7.5 Add `.dropDestination` on folder rows to accept dragged item IDs
+- [ ] 7.6 Always show the Folders section header (with create button); show folder rows only when folders exist
+
+## 8. Item List & Drag
+
+- [ ] 8.1 Change `ItemListView` selection from `VaultItem?` to `Set<String>` for multi-select support
+- [ ] 8.2 Update `VaultBrowserViewModel` to handle `Set<String>` selection and derive detail pane item
+- [ ] 8.3 Add `.draggable` on item rows with item ID as `Transferable` payload
+- [ ] 8.4 Wire drop handler on folder rows to call `MoveItemToFolderUseCase` and refresh counts
+
+## 9. Edit Sheet — Folder Picker
+
+- [ ] 9.1 Add folder `Picker` to `ItemEditView` (all folders + "None", sorted alphabetically)
+- [ ] 9.2 Bind picker selection to `DraftVaultItem.folderId`
+- [ ] 9.3 Pass folders from `VaultRepository` through to the edit view model
+
+## 10. ViewModel Integration
+
+- [ ] 10.1 Expose `folders` from `VaultBrowserViewModel` for sidebar rendering
+- [ ] 10.2 Add folder CRUD actions to `VaultBrowserViewModel` calling use cases (create, rename, delete)
+- [ ] 10.3 Add move-to-folder action to `VaultBrowserViewModel` calling `MoveItemToFolderUseCase` (single and bulk)
+- [ ] 10.4 Update `refreshCounts` and `refreshItems` to include folder data
+- [ ] 10.5 Handle folder deletion: if the deleted folder was selected, switch to All Items
+- [ ] 10.6 Add delete folder confirmation alert to `VaultBrowserView`

--- a/openspec/changes/vault-folder-organization/tasks.md
+++ b/openspec/changes/vault-folder-organization/tasks.md
@@ -14,11 +14,11 @@
 
 ## 3. Mapper & Crypto
 
-- [ ] 3.1 Pass through `folderId` in `CipherMapper.map(raw:keys:)` → `VaultItem`
-- [ ] 3.2 Include `folderId` in `CipherMapper.toRawCipher(_:encryptedWith:)` output
-- [ ] 3.3 Update `CipherMapperTests` to verify `folderId` pass-through (forward and reverse)
-- [ ] 3.4 Add `decryptFolders(folders: [RawFolder]) async throws -> [Folder]` to `PrizmCryptoService` protocol and impl (mirrors `decryptList` pattern)
-- [ ] 3.5 Add folder name encrypt helper in `VaultRepositoryImpl` using existing `EncString.encrypt(data:keys:)` path (called before API client methods)
+- [x] 3.1 Pass through `folderId` in `CipherMapper.map(raw:keys:)` → `VaultItem`
+- [x] 3.2 Include `folderId` in `CipherMapper.toRawCipher(_:encryptedWith:)` output
+- [x] 3.3 Update `CipherMapperTests` to verify `folderId` pass-through (forward and reverse)
+- [x] 3.4 Add `decryptFolders(folders: [RawFolder]) async throws -> [Folder]` to `PrizmCryptoService` protocol and impl (mirrors `decryptList` pattern)
+- [x] 3.5 Add folder name encrypt helper in `VaultRepositoryImpl` using existing `EncString.encrypt(data:keys:)` path (called before API client methods)
 
 ## 4. API Client
 

--- a/openspec/changes/vault-folder-organization/tasks.md
+++ b/openspec/changes/vault-folder-organization/tasks.md
@@ -31,18 +31,18 @@
 
 ## 5. Repository Layer
 
-- [ ] 5.1 Add `folders: [Folder]` storage to `VaultRepositoryImpl`; update `populate` and `clearVault` to include folders
-- [ ] 5.2 Add `folders() throws -> [Folder]` to `VaultRepository` protocol and impl (sorted alphabetically)
-- [ ] 5.3 Update `VaultRepository.populate` to accept folders alongside items; update `MockVaultRepository` and all existing tests that call `populate`
-- [ ] 5.4 Update `SyncRepositoryImpl.sync` to call `crypto.decryptFolders` and pass results to `vaultRepository.populate`
-- [ ] 5.5 Update `VaultRepositoryImpl.items(for:)` to handle `.folder(id)` selection (filter by `folderId`)
-- [ ] 5.6 Update `VaultRepositoryImpl.itemCounts()` to include per-folder counts
-- [ ] 5.7 Update `VaultRepositoryImpl.searchItems(query:in:)` to support folder-scoped search
-- [ ] 5.8 Add folder CRUD methods to `VaultRepository` protocol: `createFolder(name:)`, `renameFolder(id:name:)`, `deleteFolder(id:)` — `VaultRepositoryImpl` encrypts name internally, calls API, updates local cache; reject empty/whitespace-only names before API call
-- [ ] 5.9 Add `moveItemToFolder(itemId:folderId:)` and `moveItemsToFolder(itemIds:folderId:)` to `VaultRepository` — `VaultRepositoryImpl` calls partial/move API, updates local folderId
-- [ ] 5.10 Update `MockVaultRepository` with all new folder methods
-- [ ] 5.11 Add `VaultRepositoryImplTests` for folder-scoped filtering, counts, and folder CRUD
-- [ ] 5.12 Add tests for move-to-folder (single and bulk, local cache update)
+- [x] 5.1 Add `folders: [Folder]` storage to `VaultRepositoryImpl`; update `populate` and `clearVault` to include folders
+- [x] 5.2 Add `folders() throws -> [Folder]` to `VaultRepository` protocol and impl (sorted alphabetically)
+- [x] 5.3 Update `VaultRepository.populate` to accept folders alongside items; update `MockVaultRepository` and all existing tests that call `populate`
+- [x] 5.4 Update `SyncRepositoryImpl.sync` to call `crypto.decryptFolders` and pass results to `vaultRepository.populate`
+- [x] 5.5 Update `VaultRepositoryImpl.items(for:)` to handle `.folder(id)` selection (filter by `folderId`)
+- [x] 5.6 Update `VaultRepositoryImpl.itemCounts()` to include per-folder counts
+- [x] 5.7 Update `VaultRepositoryImpl.searchItems(query:in:)` to support folder-scoped search
+- [x] 5.8 Add folder CRUD methods to `VaultRepository` protocol: `createFolder(name:)`, `renameFolder(id:name:)`, `deleteFolder(id:)` — `VaultRepositoryImpl` encrypts name internally, calls API, updates local cache; reject empty/whitespace-only names before API call
+- [x] 5.9 Add `moveItemToFolder(itemId:folderId:)` and `moveItemsToFolder(itemIds:folderId:)` to `VaultRepository` — `VaultRepositoryImpl` calls partial/move API, updates local folderId
+- [x] 5.10 Update `MockVaultRepository` with all new folder methods
+- [x] 5.11 Add `VaultRepositoryImplTests` for folder-scoped filtering, counts, and folder CRUD
+- [x] 5.12 Add tests for move-to-folder (single and bulk, local cache update)
 
 ## 6. Domain Use Cases
 

--- a/openspec/changes/vault-folder-organization/tasks.md
+++ b/openspec/changes/vault-folder-organization/tasks.md
@@ -64,8 +64,8 @@
 
 ## 8. Item List & Drag
 
-- [x] 8.1 Change `ItemListView` selection from `VaultItem?` to `Set<String>` for multi-select support
-- [x] 8.2 Update `VaultBrowserViewModel` to handle `Set<String>` selection and derive detail pane item (single selected → show detail; zero or multiple → empty state); disable Edit, Copy, Favorite, Delete actions when multiple items are selected
+- [x] 8.1 Add `.draggable` support to item list rows (multi-select deferred to follow-up)
+- [x] 8.2 Wire single-item drag-and-drop from item list to folder sidebar rows
 - [x] 8.3 Add `.draggable` on item rows with item ID as `Transferable` payload
 - [x] 8.4 Wire drop handler on folder rows to call `MoveItemToFolderUseCase` and refresh counts
 

--- a/openspec/changes/vault-folder-organization/tasks.md
+++ b/openspec/changes/vault-folder-organization/tasks.md
@@ -1,16 +1,16 @@
 ## 1. Wire Models & Sync
 
-- [ ] 1.1 Add `RawFolder` model (`id: String`, `name: String`, `revisionDate: String?`) to `Data/Network/Models/`
-- [ ] 1.2 Add `folders: [RawFolder]` to `SyncResponse`
-- [ ] 1.3 Add `folderId: String?` to `RawCipher`
+- [x] 1.1 Add `RawFolder` model (`id: String`, `name: String`, `revisionDate: String?`) to `Data/Network/Models/`
+- [x] 1.2 Add `folders: [RawFolder]` to `SyncResponse`
+- [x] 1.3 Add `folderId: String?` to `RawCipher`
 
 ## 2. Domain Entities
 
-- [ ] 2.1 Create `Folder` entity (`id: String`, `name: String`) in `Domain/Entities/`
-- [ ] 2.2 Add `folderId: String?` to `VaultItem` (with default `nil` in init)
-- [ ] 2.3 Add `var folderId: String?` to `DraftVaultItem` and `DraftVaultItem.blank(type:)`
-- [ ] 2.4 Add `.folder(String)` case to `SidebarSelection` (update `Equatable`, `Hashable`, `displayName`)
-- [ ] 2.5 Add `.folders` case to `SidebarSection`
+- [x] 2.1 Create `Folder` entity (`id: String`, `name: String`) in `Domain/Entities/`
+- [x] 2.2 Add `folderId: String?` to `VaultItem` (with default `nil` in init)
+- [x] 2.3 Add `var folderId: String?` to `DraftVaultItem` and `DraftVaultItem.blank(type:)`
+- [x] 2.4 Add `.folder(String)` case to `SidebarSelection` (update `Equatable`, `Hashable`, `displayName`)
+- [x] 2.5 Add `.folders` case to `SidebarSection`
 
 ## 3. Mapper & Crypto
 

--- a/openspec/changes/vault-folder-organization/tasks.md
+++ b/openspec/changes/vault-folder-organization/tasks.md
@@ -55,12 +55,12 @@
 
 ## 7. Sidebar UI
 
-- [ ] 7.1 Add `.folders` section to `SidebarView` with dynamic folder rows sorted alphabetically
-- [ ] 7.2 Add `folder.badge.plus` button on the Folders section header for folder creation
-- [ ] 7.3 Add `.contextMenu` on folder rows with "Rename" and "Delete Folder" actions
-- [ ] 7.4 Implement inline rename using SwiftUI `.renameAction` on folder rows
-- [ ] 7.5 Add `.dropDestination` on folder rows to accept dragged item IDs
-- [ ] 7.6 Always show the Folders section header (with create button); show folder rows only when folders exist
+- [x] 7.1 Add `.folders` section to `SidebarView` with dynamic folder rows sorted alphabetically
+- [x] 7.2 Add `folder.badge.plus` button on the Folders section header for folder creation
+- [x] 7.3 Add `.contextMenu` on folder rows with "Rename" and "Delete Folder" actions
+- [x] 7.4 Implement inline rename using SwiftUI `.renameAction` on folder rows
+- [x] 7.5 Add `.dropDestination` on folder rows to accept dragged item IDs
+- [x] 7.6 Always show the Folders section header (with create button); show folder rows only when folders exist
 
 ## 8. Item List & Drag
 

--- a/openspec/changes/vault-folder-organization/tasks.md
+++ b/openspec/changes/vault-folder-organization/tasks.md
@@ -17,8 +17,8 @@
 - [ ] 3.1 Pass through `folderId` in `CipherMapper.map(raw:keys:)` → `VaultItem`
 - [ ] 3.2 Include `folderId` in `CipherMapper.toRawCipher(_:encryptedWith:)` output
 - [ ] 3.3 Update `CipherMapperTests` to verify `folderId` pass-through (forward and reverse)
-- [ ] 3.4 Add folder name decrypt in `SyncRepositoryImpl` using existing `EncString.decrypt(keys:)` path
-- [ ] 3.5 Add folder name encrypt in use case impls using existing `EncString.encrypt(data:keys:)` path
+- [ ] 3.4 Add `decryptFolders(folders: [RawFolder]) async throws -> [Folder]` to `PrizmCryptoService` protocol and impl (mirrors `decryptList` pattern)
+- [ ] 3.5 Add folder name encrypt helper in `VaultRepositoryImpl` using existing `EncString.encrypt(data:keys:)` path (called before API client methods)
 
 ## 4. API Client
 
@@ -33,25 +33,25 @@
 
 - [ ] 5.1 Add `folders: [Folder]` storage to `VaultRepositoryImpl` with populate/clear
 - [ ] 5.2 Add `folders() throws -> [Folder]` to `VaultRepository` protocol and impl (sorted alphabetically)
-- [ ] 5.3 Update `VaultRepository.populate` to accept folders alongside items
-- [ ] 5.4 Update `SyncRepositoryImpl.sync` to decrypt folder names from `syncResponse.folders` and pass to `vaultRepository.populate`
+- [ ] 5.3 Update `VaultRepository.populate` to accept folders alongside items; update `MockVaultRepository` and all existing tests that call `populate`
+- [ ] 5.4 Update `SyncRepositoryImpl.sync` to call `crypto.decryptFolders` and pass results to `vaultRepository.populate`
 - [ ] 5.5 Update `VaultRepositoryImpl.items(for:)` to handle `.folder(id)` selection (filter by `folderId`)
 - [ ] 5.6 Update `VaultRepositoryImpl.itemCounts()` to include per-folder counts
 - [ ] 5.7 Update `VaultRepositoryImpl.searchItems(query:in:)` to support folder-scoped search
-- [ ] 5.8 Add folder CRUD methods to `VaultRepository`: `createFolder`, `renameFolder`, `deleteFolder` (encrypt name, call API, update local cache)
-- [ ] 5.9 Add `moveItemToFolder(itemId:folderId:)` and `moveItemsToFolder(itemIds:folderId:)` to `VaultRepository` (call partial/move API, update local folderId)
-- [ ] 5.10 Update `MockVaultRepository` with folder methods and `folderId` support
+- [ ] 5.8 Add folder CRUD methods to `VaultRepository` protocol: `createFolder(name:)`, `renameFolder(id:name:)`, `deleteFolder(id:)` — `VaultRepositoryImpl` encrypts name internally, calls API, updates local cache
+- [ ] 5.9 Add `moveItemToFolder(itemId:folderId:)` and `moveItemsToFolder(itemIds:folderId:)` to `VaultRepository` — `VaultRepositoryImpl` calls partial/move API, updates local folderId
+- [ ] 5.10 Update `MockVaultRepository` with all new folder methods
 - [ ] 5.11 Add `VaultRepositoryImplTests` for folder-scoped filtering, counts, and folder CRUD
 - [ ] 5.12 Add tests for move-to-folder (single and bulk, local cache update)
 
 ## 6. Domain Use Cases
 
-- [ ] 6.1 Create `CreateFolderUseCase` protocol in Domain and `CreateFolderUseCaseImpl` in Data
-- [ ] 6.2 Create `RenameFolderUseCase` protocol in Domain and `RenameFolderUseCaseImpl` in Data
-- [ ] 6.3 Create `DeleteFolderUseCase` protocol in Domain and `DeleteFolderUseCaseImpl` in Data
-- [ ] 6.4 Create `MoveItemToFolderUseCase` protocol in Domain and `MoveItemToFolderUseCaseImpl` in Data (handles single and bulk)
+- [ ] 6.1 Create `CreateFolderUseCase` protocol in Domain and `CreateFolderUseCaseImpl` in Data (delegates to `VaultRepository.createFolder`)
+- [ ] 6.2 Create `RenameFolderUseCase` protocol in Domain and `RenameFolderUseCaseImpl` in Data (delegates to `VaultRepository.renameFolder`)
+- [ ] 6.3 Create `DeleteFolderUseCase` protocol in Domain and `DeleteFolderUseCaseImpl` in Data (delegates to `VaultRepository.deleteFolder`)
+- [ ] 6.4 Create `MoveItemToFolderUseCase` protocol in Domain and `MoveItemToFolderUseCaseImpl` in Data (delegates to `VaultRepository.moveItemToFolder` / `moveItemsToFolder`)
 - [ ] 6.5 Add use case tests for folder create, rename, delete, and move-to-folder
-- [ ] 6.6 Wire use cases in `AppContainer`
+- [ ] 6.6 Wire all folder use cases in `AppContainer`
 
 ## 7. Sidebar UI
 
@@ -65,7 +65,7 @@
 ## 8. Item List & Drag
 
 - [ ] 8.1 Change `ItemListView` selection from `VaultItem?` to `Set<String>` for multi-select support
-- [ ] 8.2 Update `VaultBrowserViewModel` to handle `Set<String>` selection and derive detail pane item
+- [ ] 8.2 Update `VaultBrowserViewModel` to handle `Set<String>` selection and derive detail pane item (single selected → show detail; zero or multiple → empty state)
 - [ ] 8.3 Add `.draggable` on item rows with item ID as `Transferable` payload
 - [ ] 8.4 Wire drop handler on folder rows to call `MoveItemToFolderUseCase` and refresh counts
 
@@ -73,11 +73,11 @@
 
 - [ ] 9.1 Add folder `Picker` to `ItemEditView` (all folders + "None", sorted alphabetically)
 - [ ] 9.2 Bind picker selection to `DraftVaultItem.folderId`
-- [ ] 9.3 Pass folders from `VaultRepository` through to the edit view model
+- [ ] 9.3 Pass `[Folder]` to `ItemEditViewModel` at construction time via `AppContainer` factory methods (call `vaultStore.folders()`)
 
 ## 10. ViewModel Integration
 
-- [ ] 10.1 Expose `folders` from `VaultBrowserViewModel` for sidebar rendering
+- [ ] 10.1 Expose `folders` from `VaultBrowserViewModel` (calls `vault.folders()`) for sidebar rendering
 - [ ] 10.2 Add folder CRUD actions to `VaultBrowserViewModel` calling use cases (create, rename, delete)
 - [ ] 10.3 Add move-to-folder action to `VaultBrowserViewModel` calling `MoveItemToFolderUseCase` (single and bulk)
 - [ ] 10.4 Update `refreshCounts` and `refreshItems` to include folder data


### PR DESCRIPTION
## What

Increase sidebar row font sizes to match Apple Mail's visual weight, using a two-tier hierarchy:

- **Top-level rows** (All Items, Favorites, item types, Trash): `.title3` (15pt)
- **Folder rows**: `.body` (13pt) — slightly smaller, matching Mail's child-item styling

## Changes

- `DesignSystem.swift`: added `Typography.sidebarRow` and `Typography.sidebarChildRow` tokens
- `SidebarView.swift`: applied font modifiers to `SidebarRowView` and `FolderRowLabel`

## Constitution Check

✅ All principles pass. Presentation-only change, no security/architecture impact.