### PR TITLE
Add Homebrew cask tap and auto-update in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,3 +59,21 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ env.DMG_PATH }}
+
+      - name: Update Homebrew cask
+        env:
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+        run: |
+          SHA=$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')
+          VERSION="${GITHUB_REF_NAME#v}"
+
+          git clone "https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/b0x42/homebrew-prizm.git" tap
+          cd tap
+
+          sed -i '' "s/version \".*\"/version \"${VERSION}\"/" Casks/prizm.rb
+          sed -i '' "s/sha256 \".*\"/sha256 \"${SHA}\"/" Casks/prizm.rb
+
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+          git commit -am "Update prizm to ${VERSION}"
+          git push

--- a/Casks/prizm.rb
+++ b/Casks/prizm.rb
@@ -1,0 +1,13 @@
+cask "prizm" do
+  version "1.1.0"
+  sha256 "600d35c4c26699086866642f16a04e64279c5cb4cae7cdc652480e88ddd14380"
+
+  url "https://github.com/b0x42/prizm/releases/download/v#{version}/Prizm-v#{version}.dmg"
+  name "Prizm"
+  desc "Native macOS client for Vaultwarden and self-hosted Bitwarden"
+  homepage "https://github.com/b0x42/prizm"
+
+  depends_on macos: ">= :tahoe"
+
+  app "Prizm.app"
+end

--- a/README.md
+++ b/README.md
@@ -57,7 +57,14 @@ Prizm exists to give macOS users a native, auditable, trustworthy interface to t
 
 Tested against Vaultwarden 1.35.4. Older versions may work but are not validated.
 
-### Unsigned DMG (simplest)
+### Homebrew (recommended)
+
+```bash
+brew tap b0x42/prizm
+brew install --cask prizm
+```
+
+### Unsigned DMG
 
 A signed, notarized DMG requires an Apple Developer ID certificate ($99/year). This project is a solo open-source effort — that cost is not justified for early releases. Until that changes, the DMG is unsigned.
 
@@ -72,13 +79,6 @@ xattr -dr com.apple.quarantine /Applications/Prizm.app
 ```
 
 **[Download Prizm](https://github.com/b0x42/prizm/releases/latest)**
-
-### Homebrew
-
-```bash
-brew tap b0x42/prizm
-brew install --cask prizm
-```
 
 ### Build from source
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ xattr -dr com.apple.quarantine /Applications/Prizm.app
 
 **[Download Prizm](https://github.com/b0x42/prizm/releases/latest)**
 
+### Homebrew
+
+```bash
+brew tap b0x42/prizm
+brew install --cask prizm
+```
+
 ### Build from source
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -64,21 +64,17 @@ brew tap b0x42/prizm
 brew install --cask prizm
 ```
 
-### Unsigned DMG
+### Direct Download
 
-A signed, notarized DMG requires an Apple Developer ID certificate ($99/year). This project is a solo open-source effort — that cost is not justified for early releases. Until that changes, the DMG is unsigned.
+**[Download Prizm](https://github.com/b0x42/prizm/releases/latest)**
 
-**How to open an unsigned app on macOS:**
-
-After downloading, right-click (Control-click) the `.app` and choose **Open**, then confirm. You only need to do this once. After that, you can open it normally.
+The app is not notarized. After downloading, right-click (Control-click) the `.app` and choose **Open**, then confirm. You only need to do this once. After that, you can open it normally.
 
 Alternatively, from Terminal:
 
 ```bash
 xattr -dr com.apple.quarantine /Applications/Prizm.app
 ```
-
-**[Download Prizm](https://github.com/b0x42/prizm/releases/latest)**
 
 ### Build from source
 
@@ -135,6 +131,7 @@ Want to shift something up the list? [Open an issue](https://github.com/b0x42/pr
 
 ## Known Limitations
 
+- **Not notarized** — The app is not signed with an Apple Developer ID. On first launch, right-click and choose Open to bypass Gatekeeper.
 - **Personal vault only** — Organisation ciphers are skipped during sync.
 - **No browser auto-fill** — There is no browser extension. Copy-paste is the current workflow.
 - **No biometric unlock** — Touch ID / Face ID unlock is not yet implemented.

--- a/openspec/changes/homebrew-cask/.openspec.yaml
+++ b/openspec/changes/homebrew-cask/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/homebrew-cask/design.md
+++ b/openspec/changes/homebrew-cask/design.md
@@ -1,0 +1,37 @@
+## Context
+
+Prizm distributes an unsigned DMG via GitHub Releases. Users who download through a browser must manually run `xattr -dr com.apple.quarantine` before macOS allows the app to launch. Homebrew casks automate this entire flow and are the de facto install method for macOS power users.
+
+The release workflow already produces versioned DMGs (`Prizm-v{version}.dmg`) attached to GitHub Releases. No pipeline changes are needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a `brew install --cask prizm` install path via a custom tap
+- Keep the cask formula in a separate `homebrew-prizm` repository so it can be versioned independently of the app
+- Document the Homebrew install method in the README
+
+**Non-Goals:**
+- Submitting to the official `homebrew-cask` tap (requires popularity thresholds and code signing)
+- Automating cask version bumps in CI (manual updates are fine for now)
+- Changing the release workflow or DMG naming
+
+## Decisions
+
+1. **Separate tap repository (`b0x42/homebrew-prizm`)** over embedding casks in the main repo.
+   - Homebrew convention: `brew tap <user>/<name>` maps to `github.com/<user>/homebrew-<name>`. A dedicated repo follows this convention cleanly.
+   - Keeps the main repo focused on app source code.
+   - Alternative: self-tap via `Casks/` in this repo — works but is non-standard and clutters the project root.
+
+2. **Versioned DMG URL with `#{version}` interpolation** over a fixed `Prizm.dmg` filename.
+   - The release workflow already produces `Prizm-v{version}.dmg`. The cask interpolates this naturally.
+   - Users who download manually retain version info in the filename.
+
+3. **`depends_on macos: ">= :tahoe"`** to enforce the macOS 26 requirement at install time.
+   - Prevents confusing launch failures on older macOS versions.
+
+## Risks / Trade-offs
+
+- **Manual cask updates**: Each release requires manually updating `version` and `sha256` in the cask formula. → Acceptable for current release cadence; CI automation can be added later.
+- **Unsigned app warning**: Even via Homebrew, macOS may still show a warning on first launch since the app is unsigned. → Homebrew handles quarantine removal, but Gatekeeper may still intervene. Users can right-click → Open to bypass.
+- **Tap discoverability**: Custom taps require users to know the tap name. → Document prominently in README.

--- a/openspec/changes/homebrew-cask/proposal.md
+++ b/openspec/changes/homebrew-cask/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Users currently download an unsigned DMG from GitHub Releases and must manually strip the quarantine attribute. A Homebrew cask eliminates this friction — `brew install --cask prizm` handles download, quarantine removal, DMG mounting, and app placement in one command. This is the standard install path macOS power users expect.
+
+## What Changes
+
+- Add a `homebrew-prizm` tap repository structure with a `Casks/prizm.rb` cask formula
+- The cask references versioned DMG assets (`Prizm-v{version}.dmg`) from GitHub Releases
+- Document the Homebrew install method in the project README
+
+## Capabilities
+
+### New Capabilities
+- `homebrew-cask`: Homebrew cask formula and tap repository structure enabling `brew tap b0x42/prizm && brew install --cask prizm`
+
+### Modified Capabilities
+- `release-infrastructure`: Release workflow needs no changes — it already produces correctly-named versioned DMGs. README install section needs updating to include Homebrew instructions.
+
+## Impact
+
+- New repository `homebrew-prizm` under `b0x42` GitHub org (or a `Casks/` directory in this repo as a self-tap)
+- README.md install section updated with Homebrew instructions
+- No code changes to the app itself
+- No changes to the existing release workflow

--- a/openspec/changes/homebrew-cask/specs/homebrew-cask/spec.md
+++ b/openspec/changes/homebrew-cask/specs/homebrew-cask/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Homebrew tap repository exists with a valid cask formula
+The `b0x42/homebrew-prizm` repository SHALL contain a cask formula at `Casks/prizm.rb` that installs Prizm from the GitHub Releases DMG.
+
+#### Scenario: User taps and installs Prizm
+- **WHEN** a user runs `brew tap b0x42/prizm && brew install --cask prizm`
+- **THEN** Homebrew downloads the versioned DMG, extracts `Prizm.app`, and places it in `/Applications`
+
+#### Scenario: Cask formula references correct DMG URL
+- **WHEN** the cask formula is evaluated
+- **THEN** the `url` field resolves to `https://github.com/b0x42/prizm/releases/download/v{version}/Prizm-v{version}.dmg`
+
+### Requirement: Cask formula includes correct metadata
+The cask formula SHALL include `name`, `desc`, `homepage`, and `sha256` fields matching the Prizm project.
+
+#### Scenario: Brew info displays correct metadata
+- **WHEN** a user runs `brew info --cask prizm`
+- **THEN** the output shows the app name as "Prizm", description as "Native macOS client for Vaultwarden and self-hosted Bitwarden", and homepage as the GitHub repository URL
+
+### Requirement: Cask enforces minimum macOS version
+The cask formula SHALL declare `depends_on macos: ">= :tahoe"` to prevent installation on unsupported macOS versions.
+
+#### Scenario: Install attempted on macOS 15
+- **WHEN** a user runs `brew install --cask prizm` on macOS 15 (Sequoia)
+- **THEN** Homebrew refuses to install with a message indicating the macOS version requirement is not met
+
+### Requirement: Cask declares the app artifact
+The cask formula SHALL declare `app "Prizm.app"` so Homebrew moves the app to `/Applications` and manages uninstall.
+
+#### Scenario: User uninstalls Prizm via Homebrew
+- **WHEN** a user runs `brew uninstall --cask prizm`
+- **THEN** Homebrew removes `Prizm.app` from `/Applications`

--- a/openspec/changes/homebrew-cask/specs/release-infrastructure/spec.md
+++ b/openspec/changes/homebrew-cask/specs/release-infrastructure/spec.md
@@ -1,0 +1,8 @@
+## ADDED Requirements
+
+### Requirement: README documents Homebrew cask installation
+The README SHALL include a Homebrew install section under the Install heading that shows the `brew tap` and `brew install --cask` commands.
+
+#### Scenario: User reads install instructions
+- **WHEN** a user views the README Install section
+- **THEN** they see Homebrew listed as an install method with the exact commands `brew tap b0x42/prizm` and `brew install --cask prizm`

--- a/openspec/changes/homebrew-cask/tasks.md
+++ b/openspec/changes/homebrew-cask/tasks.md
@@ -1,0 +1,7 @@
+## 1. Cask Formula
+
+- [x] 1.1 Create `Casks/prizm.rb` with version, sha256, url (using `#{version}` interpolation for `Prizm-v{version}.dmg`), name, desc, homepage, `depends_on macos: ">= :tahoe"`, and `app "Prizm.app"`
+
+## 2. README Update
+
+- [x] 2.1 Add a "Homebrew" subsection under Install in `README.md` with `brew tap b0x42/prizm` and `brew install --cask prizm` commands


### PR DESCRIPTION
- Add `Casks/prizm.rb` cask formula (version 1.1.0, versioned DMG URL, macOS Tahoe dependency)
- Create `b0x42/homebrew-prizm` tap repository
- Add auto-update step to release workflow (updates tap on every `v*` tag)
- Update README: Homebrew as recommended install method, rename Direct Download, add not-notarized to Known Limitations