### PR TITLE
fix(keychain): fall back to login keychain on unsigned builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Build (no signing)
         run: |
+          set -o pipefail
           xcodebuild \
             -project "Prizm/Prizm.xcodeproj" \
             -scheme "Prizm" \
@@ -36,10 +37,11 @@ jobs:
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
-            build | xcpretty || exit ${PIPESTATUS[0]}
+            build | xcpretty
 
       - name: Test (no signing)
         run: |
+          set -o pipefail
           xcodebuild test \
             -project "Prizm/Prizm.xcodeproj" \
             -scheme "Prizm" \
@@ -47,4 +49,4 @@ jobs:
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
-            | xcpretty || exit ${PIPESTATUS[0]}
+            | xcpretty

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ fastlane/test_output
 
 # Per-developer Xcode signing config (contains Team ID — never commit)
 Prizm/LocalConfig.xcconfig
+# Per-developer secrets (contains client identifier — never commit)
+Prizm/LocalSecrets.xcconfig
 
 # Local dev Vaultwarden
 dev-vault/

--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -73,6 +73,32 @@ Prizm is a native macOS SwiftUI application. It inherits platform accessibility 
 
 ---
 
+## Login Screen — Server Picker
+
+The server-type picker (`Picker` with `.segmented` style) is annotated with:
+- `accessibilityIdentifier`: `login.serverTypePicker`
+- `accessibilityLabel`: `"Server"` (replaces the default empty label from the segmented style)
+- `accessibilityValue`: the current selection label ("Bitwarden US", "Bitwarden EU", or "Self-hosted")
+
+VoiceOver announces the control as *"Server, Bitwarden US, segmented control, 1 of 3"* on first focus
+and reads the new value when the selection changes.
+
+## New-Device OTP Screen (`NewDeviceOTPView`)
+
+| Element | Identifier | Label |
+|---|---|---|
+| OTP text field | `login.newDeviceOtpField` | "Verification code" |
+| Sign In button | *(inherited from `login.signIn` pattern)* | "Sign In" |
+| Resend button | `login.resendOtpButton` | "Resend code" |
+| Cancel button | `login.cancelOtpButton` | "Cancel" |
+| Error label | `login.otpErrorMessage` | *(dynamic error text)* |
+
+The header "Check your email" has the `.isHeader` accessibility trait so VoiceOver reads it with
+heading emphasis on first appearance.
+
+All error messages (OTP invalid, resend failure) are posted as `AccessibilityNotification.Announcement`
+so VoiceOver announces them immediately without requiring focus to move to the error label.
+
 ## Known Gaps
 
 1. **Drag-and-drop lacks keyboard alternative** (2.1.1) — Folder drag-and-drop operations cannot be performed via keyboard alone. Items can be moved to folders via the edit form as a workaround.

--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -87,6 +87,7 @@ and reads the new value when the selection changes.
 
 | Element | Identifier | Label |
 |---|---|---|
+| "Check your email" header | `login.newDeviceOtpHeader` | "Check your email" |
 | OTP text field | `login.newDeviceOtpField` | "Verification code" |
 | Sign In button | *(inherited from `login.signIn` pattern)* | "Sign In" |
 | Resend button | `login.resendOtpButton` | "Resend code" |

--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -78,9 +78,9 @@ Prizm is a native macOS SwiftUI application. It inherits platform accessibility 
 The server-type picker (`Picker` with `.segmented` style) is annotated with:
 - `accessibilityIdentifier`: `login.serverTypePicker`
 - `accessibilityLabel`: `"Server"` (replaces the default empty label from the segmented style)
-- `accessibilityValue`: the current selection label ("Bitwarden US", "Bitwarden EU", or "Self-hosted")
+- `accessibilityValue`: the current selection label ("Bitwarden Cloud (US)", "Bitwarden Cloud (EU)", or "Self-hosted")
 
-VoiceOver announces the control as *"Server, Bitwarden US, segmented control, 1 of 3"* on first focus
+VoiceOver announces the control as *"Server, Bitwarden Cloud (US), segmented control, 1 of 3"* on first focus
 and reads the new value when the selection changes.
 
 ## New-Device OTP Screen (`NewDeviceOTPView`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ xcodebuild test \
 |---|---|
 | vault-document-storage | `openspec/changes/vault-document-storage/` |
 | vault-sync-status | `openspec/changes/vault-sync-status/` |
+| hosted-cloud-support | `openspec/changes/hosted-cloud-support/` |
 
 ## Change Workflow (openspec)
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -221,8 +221,9 @@ Reference: https://contributing.bitwarden.com/architecture/security/requirements
   MUST be used for all requests to Bitwarden Cloud endpoints (`cloudUS`, `cloudEU`).
   It MUST be injected at build time via a gitignored `.xcconfig` file and MUST NOT
   appear in source control. See: https://contributing.bitwarden.com/architecture/adr/integration-identifiers/
-- **Required headers**: All API requests MUST include the minimum required headers
-  (`Bitwarden-Client-Name`, `Bitwarden-Client-Version`, `Device-Type`).
+- **Required headers**: All API requests MUST include `Bitwarden-Client-Name` and
+  `Bitwarden-Client-Version`. The `Device-Type` parameter is required only on identity
+  token requests (`/connect/token`), where it is sent as a form body field, not a header.
 - **Client version string**: SHOULD reflect the Bitwarden server API version the client
   has been tested against; document the tested version in `Config.swift`.
 - **ATS / HTTPS**: All cloud and self-hosted endpoints MUST use HTTPS. `NSAllowsArbitraryLoads`
@@ -313,4 +314,4 @@ Standards governing how features are built and shipped:
 
 ---
 
-**Version**: 1.6.0 | **Ratified**: 2026-03-12 | **Last Amended**: 2026-04-19
+**Version**: 1.6.1 | **Ratified**: 2026-03-12 | **Last Amended**: 2026-04-25

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -1,14 +1,14 @@
 <!--
 SYNC IMPACT REPORT
 ==================
-Version change: 1.4.3 → 1.5.0
-Bump type: MINOR — New principle added (§VIII Accessibility).
-Modified sections: N/A
-Added sections:
-  - §VIII. Accessibility (NON-NEGOTIABLE): All interactive controls must be VoiceOver-
-    usable with accessibilityLabel. Decorative images hidden. Stateful controls expose
-    value. Section headers carry .isHeader trait. Transient errors announced. Project
-    must maintain ACCESSIBILITY.md conformance statement. PRs without labels are blocking.
+Version change: 1.5.0 → 1.6.0
+Bump type: MINOR — Bitwarden API Integration Requirements expanded to v2 (cloud support).
+Modified sections:
+  - Bitwarden API Integration Requirements: removed v1 self-hosted-only restriction;
+    added v2 cloud support requirements including registered client identifier
+    injection, EU region endpoints, ATS/HTTPS enforcement for all cloud domains,
+    and explicit prohibition on silently falling back between regions.
+Added sections: N/A
 Removed sections: N/A
 Templates requiring updates: N/A
 Follow-up TODOs: N/A
@@ -206,19 +206,28 @@ Reference: https://contributing.bitwarden.com/architecture/security/requirements
 
 ### Bitwarden API Integration Requirements
 
-**v1 scope: self-hosted servers only** (Vaultwarden or Bitwarden self-hosted).
-Client identifier registration with Bitwarden, Inc. is not required and does not apply.
+**v2 scope: Bitwarden Cloud (US + EU) and self-hosted** (Vaultwarden or Bitwarden self-hosted).
 
-- **Server URL**: Users supply their own server base URL; no hardcoded `bitwarden.com`
-  endpoint is permitted in v1. The app MUST NOT silently fall back to bitwarden.com.
+- **Server selection**: Users MUST explicitly select their server environment (Cloud US,
+  Cloud EU, or Self-hosted) at login. The app MUST NOT auto-detect or silently fall back
+  between environments. Switching regions requires a new login.
+- **Hardcoded cloud endpoints**: The following canonical Bitwarden Cloud endpoints are
+  approved for use and MUST NOT be changed without a Constitution amendment:
+  - US: `api.bitwarden.com`, `identity.bitwarden.com`, `icons.bitwarden.net`
+  - EU: `api.bitwarden.eu`, `identity.bitwarden.eu`, `icons.bitwarden.net`
+- **Self-hosted**: Users supply their own server base URL. The app MUST NOT silently
+  route self-hosted requests to Bitwarden Cloud endpoints.
+- **Registered client identifier**: A client identifier registered with Bitwarden, Inc.
+  MUST be used for all requests to Bitwarden Cloud endpoints (`cloudUS`, `cloudEU`).
+  It MUST be injected at build time via a gitignored `.xcconfig` file and MUST NOT
+  appear in source control. See: https://contributing.bitwarden.com/architecture/adr/integration-identifiers/
 - **Required headers**: All API requests MUST include the minimum required headers
-  (e.g. `Bitwarden-Client-Name`, `Bitwarden-Client-Version`, `Device-Type`).
-  Self-hosted servers are generally permissive, but correct headers ensure compatibility.
+  (`Bitwarden-Client-Name`, `Bitwarden-Client-Version`, `Device-Type`).
 - **Client version string**: SHOULD reflect the Bitwarden server API version the client
   has been tested against; document the tested version in `Config.swift`.
-- **Future — bitwarden.com support**: If v2 adds support for bitwarden.com (the hosted
-  service), a registered client identifier MUST be obtained before that release.
-  See: https://contributing.bitwarden.com/architecture/adr/integration-identifiers/
+- **ATS / HTTPS**: All cloud and self-hosted endpoints MUST use HTTPS. `NSAllowsArbitraryLoads`
+  MUST remain disabled. Self-hosted URLs entered by users MUST be validated for HTTPS
+  scheme before any network request is attempted.
 
 ---
 
@@ -304,4 +313,4 @@ Standards governing how features are built and shipped:
 
 ---
 
-**Version**: 1.5.0 | **Ratified**: 2026-03-12 | **Last Amended**: 2026-04-10
+**Version**: 1.6.0 | **Ratified**: 2026-03-12 | **Last Amended**: 2026-04-19

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,6 +38,29 @@ A free Apple ID ("Personal Team") works for local builds. You do not need a paid
 
 > **The build will fail without this file.** `LocalConfig.xcconfig` is git-ignored so your Team ID never appears in the repository.
 
+### LocalSecrets.xcconfig (required for Bitwarden Cloud login)
+
+Bitwarden Cloud requires a registered client identifier. For self-hosted Vaultwarden, this file is optional — self-hosted login works without it.
+
+```bash
+cp Prizm/LocalSecrets.xcconfig.template Prizm/LocalSecrets.xcconfig
+```
+
+Set your registered Bitwarden client identifier (obtained from the Bitwarden developer portal):
+
+```
+BW_CLIENT_IDENTIFIER = com.example.prizm
+```
+
+**How the secret flows:**
+
+1. `BW_CLIENT_IDENTIFIER` in `LocalSecrets.xcconfig` (gitignored)
+2. → `BWClientIdentifier` in `Prizm/Prizm/Info.plist` via `$(BW_CLIENT_IDENTIFIER)`
+3. → `Config.bitwardenClientIdentifier` in `App/Config.swift` via `Bundle.main`
+4. → `client_id` form parameter in identity token requests to Bitwarden Cloud
+
+Without this value, cloud login will fail with `AuthError.clientIdentifierNotConfigured`. Self-hosted Vaultwarden login is unaffected — it always uses `"desktop"` as the `client_id`.
+
 ## Building
 
 Open the project in Xcode:

--- a/Prizm/App/Config.swift
+++ b/Prizm/App/Config.swift
@@ -19,13 +19,17 @@ extension Notification.Name {
 // MARK: - App config
 
 enum Config {
-    static let clientName = "desktop"
+    // nonisolated(unsafe): both values are immutable after process start and safe to read from
+    // any isolation domain. `bitwardenClientIdentifier` reads from Info.plist (set once at
+    // launch); `clientName` is a string literal. Using nonisolated(unsafe) avoids propagating
+    // @MainActor isolation (inferred from Bundle.main) to every actor that reads Config.
+    nonisolated(unsafe) static let clientName = "desktop"
     static let deviceType = 7
 
     /// Registered Bitwarden client identifier, injected at build time via LocalSecrets.xcconfig.
     /// Empty string when LocalSecrets.xcconfig is absent — cloud login fails fast with
     /// AuthError.clientIdentifierNotConfigured before any network request is attempted.
-    static let bitwardenClientIdentifier: String =
+    nonisolated(unsafe) static let bitwardenClientIdentifier: String =
         Bundle.main.object(forInfoDictionaryKey: "BWClientIdentifier") as? String ?? ""
 
     /// Bitwarden server API version Prizm was last tested against.

--- a/Prizm/App/Config.swift
+++ b/Prizm/App/Config.swift
@@ -19,7 +19,9 @@ extension Notification.Name {
 // MARK: - App config
 
 enum Config {
-    static nonisolated let clientName = "desktop"
+    // "desktop" is rejected by bitwarden.eu — the EU server blocks impersonation of
+    // Bitwarden's own client names. Use "prizm" (Prizm's registered client name).
+    static nonisolated let clientName = "prizm"
     static let deviceType = 7
 
     /// Registered Bitwarden client identifier, injected at build time via LocalSecrets.xcconfig.

--- a/Prizm/App/Config.swift
+++ b/Prizm/App/Config.swift
@@ -19,17 +19,17 @@ extension Notification.Name {
 // MARK: - App config
 
 enum Config {
-    // nonisolated(unsafe): both values are immutable after process start and safe to read from
-    // any isolation domain. `bitwardenClientIdentifier` reads from Info.plist (set once at
-    // launch); `clientName` is a string literal. Using nonisolated(unsafe) avoids propagating
-    // @MainActor isolation (inferred from Bundle.main) to every actor that reads Config.
-    nonisolated(unsafe) static let clientName = "desktop"
+    static nonisolated let clientName = "desktop"
     static let deviceType = 7
 
     /// Registered Bitwarden client identifier, injected at build time via LocalSecrets.xcconfig.
     /// Empty string when LocalSecrets.xcconfig is absent — cloud login fails fast with
     /// AuthError.clientIdentifierNotConfigured before any network request is attempted.
-    nonisolated(unsafe) static let bitwardenClientIdentifier: String =
+    ///
+    /// `nonisolated` prevents @MainActor isolation (inferred from Bundle.main) from
+    /// propagating to every actor that reads this constant. String is Sendable so the
+    /// value is safe to share across isolation domains without the `unsafe` qualifier.
+    static nonisolated let bitwardenClientIdentifier: String =
         Bundle.main.object(forInfoDictionaryKey: "BWClientIdentifier") as? String ?? ""
 
     /// Bitwarden server API version Prizm was last tested against.

--- a/Prizm/App/Config.swift
+++ b/Prizm/App/Config.swift
@@ -21,6 +21,16 @@ extension Notification.Name {
 enum Config {
     static let clientName = "desktop"
     static let deviceType = 7
+
+    /// Registered Bitwarden client identifier, injected at build time via LocalSecrets.xcconfig.
+    /// Empty string when LocalSecrets.xcconfig is absent — cloud login fails fast with
+    /// AuthError.clientIdentifierNotConfigured before any network request is attempted.
+    static let bitwardenClientIdentifier: String =
+        Bundle.main.object(forInfoDictionaryKey: "BWClientIdentifier") as? String ?? ""
+
+    /// Bitwarden server API version Prizm was last tested against.
+    /// Update when testing against a newer server release.
+    static let bitwardenApiVersion = "2026.4.0"
 }
 
 /// Gates verbose debug logging throughout the Data layer.

--- a/Prizm/App/PrizmApp.swift
+++ b/Prizm/App/PrizmApp.swift
@@ -142,6 +142,9 @@ struct PrizmApp: App {
         case .totpPrompt:
             TOTPPromptView(viewModel: rootVM.loginVM)
 
+        case .otpPrompt:
+            NewDeviceOTPView(viewModel: rootVM.loginVM)
+
         case .unlock:
             if let unlockVM = rootVM.unlockVM {
                 UnlockView(viewModel: unlockVM)
@@ -227,6 +230,7 @@ final class RootViewModel: ObservableObject {
         case login
         case loading
         case totpPrompt
+        case otpPrompt
         case unlock
         case syncing(message: String)
         case vault
@@ -372,6 +376,7 @@ final class RootViewModel: ObservableObject {
         case .login:       screen = .login
         case .loading:     screen = .loading
         case .totpPrompt:  screen = .totpPrompt
+        case .otpPrompt:   screen = .otpPrompt
         case .syncing(let msg): screen = .syncing(message: msg)
         case .vault:       transitionToVault(caller: "handleLoginFlow")
         }

--- a/Prizm/Data/Keychain/KeychainService.swift
+++ b/Prizm/Data/Keychain/KeychainService.swift
@@ -58,14 +58,32 @@ final class KeychainServiceImpl: KeychainService {
     private let service = "com.prizm"
     private let logger = Logger(subsystem: "com.prizm", category: "KeychainService")
 
-    /// When `true` (default, production), routes all queries through the modern data
-    /// protection keychain (`kSecUseDataProtectionKeychain`), which requires the
-    /// `keychain-access-groups` entitlement. Pass `false` in test targets that run
-    /// without code signing, where the entitlement is unavailable.
+    /// When `true`, routes all queries through the modern data protection keychain
+    /// (`kSecUseDataProtectionKeychain`), which requires the `keychain-access-groups`
+    /// entitlement. Auto-detected at init: unsigned builds (e.g. Homebrew) receive
+    /// `false` and fall back to the legacy login keychain.
+    /// Pass an explicit value in tests to bypass the probe.
     private let useDataProtectionKeychain: Bool
 
-    init(useDataProtectionKeychain: Bool = true) {
-        self.useDataProtectionKeychain = useDataProtectionKeychain
+    init(useDataProtectionKeychain: Bool? = nil) {
+        if let explicit = useDataProtectionKeychain {
+            self.useDataProtectionKeychain = explicit
+            return
+        }
+        // Probe whether the data protection keychain is accessible. Unsigned builds
+        // lack the `keychain-access-groups` entitlement and receive -34018
+        // (errSecMissingEntitlement). errSecItemNotFound means the keychain is
+        // reachable — just no item stored yet.
+        let probe: [CFString: Any] = [
+            kSecClass:                     kSecClassGenericPassword,
+            kSecAttrService:               "com.prizm.probe",
+            kSecAttrAccount:               "entitlement-check",
+            kSecUseDataProtectionKeychain: true,
+            kSecMatchLimit:                kSecMatchLimitOne,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(probe as CFDictionary, &result)
+        self.useDataProtectionKeychain = (status != errSecMissingEntitlement)
     }
 
     /// Returns the base Keychain query dictionary for `key`.

--- a/Prizm/Data/Keychain/KeychainService.swift
+++ b/Prizm/Data/Keychain/KeychainService.swift
@@ -76,14 +76,17 @@ final class KeychainServiceImpl: KeychainService {
         // reachable — just no item stored yet.
         let probe: [CFString: Any] = [
             kSecClass:                     kSecClassGenericPassword,
-            kSecAttrService:               "com.prizm.probe",
-            kSecAttrAccount:               "entitlement-check",
+            kSecAttrService:               "com.prizm",
+            kSecAttrAccount:               "__entitlement-probe__",
             kSecUseDataProtectionKeychain: true,
             kSecMatchLimit:                kSecMatchLimitOne,
         ]
-        var result: AnyObject?
-        let status = SecItemCopyMatching(probe as CFDictionary, &result)
-        self.useDataProtectionKeychain = (status != errSecMissingEntitlement)
+        let status = SecItemCopyMatching(probe as CFDictionary, nil)
+        // Confirm reachability by checking for known-good statuses only.
+        // Any other code (e.g. errSecInteractionNotAllowed on cold boot) must not
+        // be treated as confirmation — it would arm the data-protection path and
+        // cause all real SecItem calls to fail with errSecMissingEntitlement.
+        self.useDataProtectionKeychain = (status == errSecItemNotFound || status == errSecSuccess)
     }
 
     /// Returns the base Keychain query dictionary for `key`.

--- a/Prizm/Data/Network/PrizmAPIClient.swift
+++ b/Prizm/Data/Network/PrizmAPIClient.swift
@@ -416,7 +416,6 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
         // Cloud environments use the registered Prizm identifier per ADR-0023;
         // self-hosted instances do not enforce identifier checks, so "desktop" is safe.
         clientId = env.serverType != .selfHosted ? Config.bitwardenClientIdentifier : "desktop"
-        logger.info("Server environment set: \(env.serverType.rawValue, privacy: .public)")
     }
 
     func setAccessToken(_ token: String) {

--- a/Prizm/Data/Network/PrizmAPIClient.swift
+++ b/Prizm/Data/Network/PrizmAPIClient.swift
@@ -430,7 +430,10 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
 
     func preLogin(email: String) async throws -> PreLoginResponse {
         guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
-        let url = env.apiURL.appendingPathComponent("accounts/prelogin")
+        // prelogin lives on the identity service, not the API service.
+        // Confirmed: POST https://api.bitwarden.{com,eu}/accounts/prelogin → 404
+        //            POST https://identity.bitwarden.{com,eu}/accounts/prelogin → 200
+        let url = env.identityURL.appendingPathComponent("accounts/prelogin")
 
         if DebugConfig.isEnabled {
             logger.debug("[debug] preLogin → POST \(url.absoluteString, privacy: .public)")

--- a/Prizm/Data/Network/PrizmAPIClient.swift
+++ b/Prizm/Data/Network/PrizmAPIClient.swift
@@ -5,19 +5,20 @@ import os.log
 
 /// Bitwarden REST API client for auth and vault sync operations.
 ///
-/// All requests include the `X-Client-Version` and `Bitwarden-Client-Version` headers.
-/// The identity token request additionally sends `client_id` and `deviceType` as form parameters.
+/// All requests include the `X-Client-Version`, `Bitwarden-Client-Version`, and
+/// `Bitwarden-Client-Name` headers. The identity token request additionally sends
+/// `client_id` and `deviceType` as form parameters.
 /// Reference: https://contributing.bitwarden.com/architecture/adr/integration-identifiers/
 /// Missing or invalid headers result in `400 Bad Request` / `403 Forbidden` from the server.
 ///
-/// Implemented as an `actor` to serialise the mutable `baseURL` and `accessToken` state.
+/// Implemented as an `actor` to serialise the mutable `serverEnvironment` and `accessToken` state.
 protocol PrizmAPIClientProtocol: Actor {
 
-    /// The base URL configured by `AuthRepositoryImpl` after the user enters their server address.
-    var baseURL: URL? { get }
+    /// The server environment configured by `AuthRepositoryImpl`.
+    var serverEnvironment: ServerEnvironment? { get }
 
-    /// Stores the base URL; sets up derived endpoint URLs.
-    func setBaseURL(_ url: URL)
+    /// Stores the server environment; determines per-service URLs and client identifier.
+    func setServerEnvironment(_ env: ServerEnvironment)
 
     /// Stores the access token used for subsequent authenticated requests.
     func setAccessToken(_ token: String)
@@ -47,13 +48,15 @@ protocol PrizmAPIClientProtocol: Actor {
     ///   - twoFactorToken:     TOTP code from the authenticator app, if completing a 2FA challenge.
     ///   - twoFactorProvider:  Numeric 2FA provider identifier (0 = authenticatorApp).
     ///   - twoFactorRemember:  When true, requests a `TwoFactorToken` cookie for future logins.
+    ///   - newDeviceOTP:       One-time code from the user's email, if completing a new-device challenge.
     func identityToken(
         email:              String,
         passwordHash:       String,
         deviceIdentifier:   String,
         twoFactorToken:     String?,
         twoFactorProvider:  Int?,
-        twoFactorRemember:  Bool
+        twoFactorRemember:  Bool,
+        newDeviceOTP:       String?
     ) async throws -> TokenResponse
 
     /// GET `/sync?excludeDomains=true` — returns the full encrypted vault.
@@ -279,8 +282,9 @@ nonisolated struct TokenResponse: Codable {
 
 /// Semantic errors from the `/connect/token` endpoint, distinct from raw transport errors.
 ///
-/// The Bitwarden identity service returns HTTP 400 for both wrong passwords and 2FA challenges;
-/// `IdentityTokenError` models the meaningful distinctions so the repository layer can act on them.
+/// The Bitwarden identity service returns HTTP 400 for both wrong passwords, 2FA challenges,
+/// and new-device OTP requirements; `IdentityTokenError` models the meaningful distinctions
+/// so the repository layer can act on them.
 nonisolated enum IdentityTokenError: Error, Equatable {
     /// The server requires two-factor authentication before issuing a token.
     /// `providers` is the list of available 2FA type numbers (0 = authenticatorApp, etc.).
@@ -289,6 +293,10 @@ nonisolated enum IdentityTokenError: Error, Equatable {
     case twoFactorCodeInvalid
     /// Email or password is incorrect (HTTP 400 `invalid_grant` without 2FA challenge).
     case invalidCredentials
+    /// The server does not recognise this device and has dispatched a one-time code
+    /// to the user's registered email. Trigger: HTTP 400, `{"error": "device_error"}`.
+    /// `error_description` is informational only and SHALL NOT be used as the trigger condition.
+    case newDeviceNotVerified
 }
 
 // MARK: - Errors
@@ -302,8 +310,8 @@ nonisolated enum APIError: Error, Equatable {
     case httpError(statusCode: Int, body: String)
     /// The response body could not be decoded into the expected type.
     case decodingFailed
-    /// `setBaseURL` was never called before making a request.
-    case baseURLNotSet
+    /// `setServerEnvironment` was never called before making a request.
+    case serverEnvironmentNotSet
 }
 
 extension APIError: LocalizedError {
@@ -313,7 +321,7 @@ extension APIError: LocalizedError {
             return body.isEmpty ? "Server error \(statusCode)." : "Server error \(statusCode): \(body)"
         case .decodingFailed:
             return "The server response could not be read. Please try again."
-        case .baseURLNotSet:
+        case .serverEnvironmentNotSet:
             return "No server URL is configured."
         }
     }
@@ -361,10 +369,11 @@ nonisolated struct AttachmentDownloadResponse: Decodable {
 /// All requests include the required Bitwarden client identification headers:
 /// - `X-Client-Version: "2024.12.0"` (version string, required by upstream Bitwarden)
 /// - `Bitwarden-Client-Version: "2024.12.0"` (>= 2024.12.0 required for SSH key support on Vaultwarden)
+/// - `Bitwarden-Client-Name: "desktop"` (required by Bitwarden Cloud — ADR-0023)
 ///
 /// The identity token request additionally sends these as form body parameters:
-/// - `client_id: "desktop"`   (registered client identifier)
-/// - `deviceType: "7"`        (7 = macOS desktop, per Bitwarden DeviceType enum)
+/// - `client_id`: Prizm's registered identifier for cloud accounts, `"desktop"` for self-hosted
+/// - `deviceType: "7"`  (7 = macOS desktop, per Bitwarden DeviceType enum)
 ///
 /// Header requirements: https://contributing.bitwarden.com/architecture/adr/integration-identifiers/
 /// DeviceType enum values: https://github.com/bitwarden/server/blob/main/src/Core/Enums/DeviceType.cs
@@ -372,8 +381,10 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
 
     // MARK: - Private state
 
-    private(set) var baseURL: URL?
+    private(set) var serverEnvironment: ServerEnvironment?
     private var accessToken: String?
+    /// Per-environment client identifier; cloud = registered Prizm ID, self-hosted = "desktop".
+    private var clientId: String = "desktop"
 
     private let session:   URLSession
     private let logger:    Logger = Logger(
@@ -386,7 +397,6 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     // deviceType 7 = macOS desktop per the Bitwarden DeviceType enum:
     // https://github.com/bitwarden/server/blob/main/src/Core/Enums/DeviceType.cs
     private enum ClientHeaders {
-        static let clientId      = "desktop"
         // Vaultwarden gates SSH key ciphers (type 5) behind >= 2024.12.0.
         static let clientVersion = "2024.12.0"
         static let deviceType    = "7"
@@ -401,8 +411,12 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
 
     // MARK: - Configuration
 
-    func setBaseURL(_ url: URL) {
-        baseURL = url
+    func setServerEnvironment(_ env: ServerEnvironment) {
+        serverEnvironment = env
+        // Cloud environments use the registered Prizm identifier per ADR-0023;
+        // self-hosted instances do not enforce identifier checks, so "desktop" is safe.
+        clientId = env.serverType != .selfHosted ? Config.bitwardenClientIdentifier : "desktop"
+        logger.info("Server environment set: \(env.serverType.rawValue, privacy: .public)")
     }
 
     func setAccessToken(_ token: String) {
@@ -416,8 +430,8 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     // MARK: - preLogin
 
     func preLogin(email: String) async throws -> PreLoginResponse {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/accounts/prelogin")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL.appendingPathComponent("accounts/prelogin")
 
         if DebugConfig.isEnabled {
             logger.debug("[debug] preLogin → POST \(url.absoluteString, privacy: .public)")
@@ -445,14 +459,18 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
         deviceIdentifier:  String,
         twoFactorToken:    String?,
         twoFactorProvider: Int?,
-        twoFactorRemember: Bool
+        twoFactorRemember: Bool,
+        newDeviceOTP:      String? = nil
     ) async throws -> TokenResponse {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("identity/connect/token")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.identityURL.appendingPathComponent("connect/token")
+
+        logger.info("identityToken → POST \(env.identityURL.absoluteString, privacy: .public)")
 
         if DebugConfig.isEnabled {
             let isTOTP = twoFactorToken != nil
-            logger.debug("[debug] identityToken → POST \(url.absoluteString, privacy: .public) 2FA=\(isTOTP, privacy: .public) provider=\(twoFactorProvider.map(String.init) ?? "nil", privacy: .public)")
+            let isOTP  = newDeviceOTP != nil
+            logger.debug("[debug] identityToken → POST \(url.absoluteString, privacy: .public) 2FA=\(isTOTP, privacy: .public) provider=\(twoFactorProvider.map(String.init) ?? "nil", privacy: .public) newDeviceOTP=\(isOTP, privacy: .public)")
         }
 
         var params: [String: String] = [
@@ -460,7 +478,7 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
             "username":        email,
             "password":        passwordHash,
             "scope":           "api offline_access",
-            "client_id":       ClientHeaders.clientId,
+            "client_id":       clientId,
             "deviceType":      ClientHeaders.deviceType,
             "deviceIdentifier": deviceIdentifier,
             "deviceName":      "Prizm",
@@ -468,6 +486,7 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
         if let token    = twoFactorToken    { params["twoFactorToken"]    = token }
         if let provider = twoFactorProvider { params["twoFactorProvider"] = String(provider) }
         if twoFactorRemember                { params["twoFactorRemember"] = "true" }
+        if let otp      = newDeviceOTP      { params["newdeviceotp"]      = otp }
 
         if DebugConfig.isEnabled {
             // Log all params except password (server hash) — scrubbed for security.
@@ -491,16 +510,12 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
 
     /// Specialized perform for the identity token endpoint.
     ///
-    /// The Bitwarden identity service overloads HTTP 400 for three distinct outcomes —
+    /// The Bitwarden identity service overloads HTTP 400 for four distinct outcomes —
     /// disambiguation requires inspecting the response body:
-    ///   1. 2FA challenge (occurs on first password attempt when 2FA is enabled):
-    ///      body contains `"TwoFactorProviders2"` key → throw `.twoFactorRequired`
-    ///   2. Bad TOTP code (occurs on the second request when the code is wrong):
-    ///      `error_description` contains "Two-factor" → throw `.twoFactorCodeInvalid`
-    ///   3. Wrong password (no 2FA in play, or bad credentials at any step):
-    ///      generic `invalid_grant` body → throw `.invalidCredentials`
-    /// Cases 2 and 3 use the same fallthrough path because they produce the same
-    /// user-facing error: re-enter your password / code.
+    ///   1. 2FA challenge: body contains `"TwoFactorProviders2"` key → throw `.twoFactorRequired`
+    ///   2. Bad TOTP code: `error_description` contains "Two-factor" → throw `.twoFactorCodeInvalid`
+    ///   3. New device verification: `"error": "device_error"` → throw `.newDeviceNotVerified`
+    ///   4. Wrong password: generic `invalid_grant` body → throw `.invalidCredentials`
     private func performIdentityToken(request: URLRequest) async throws -> TokenResponse {
         let (data, response) = try await session.data(for: request)
 
@@ -516,7 +531,6 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
                 if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
                     let keys = json.keys.sorted().joined(separator: ", ")
                     logger.debug("[debug] identityToken 400 body keys: [\(keys, privacy: .public)]")
-                    // error_description and message are server-generated error text, not secrets.
                     if let errorDesc = json["error_description"] as? String {
                         logger.debug("[debug] identityToken 400 error_description: \(errorDesc, privacy: .public)")
                     }
@@ -531,7 +545,6 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
                     logger.debug("[debug] identityToken 400 body (non-JSON): \(body.prefix(200), privacy: .public)")
                 }
             }
-            // Parse the error body to determine the specific error type.
             if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
                 // 2FA challenge: server returns TwoFactorProviders2 dict with available providers.
                 if let providers2 = json["TwoFactorProviders2"] as? [String: Any] {
@@ -540,6 +553,13 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
                         logger.debug("[debug] identityToken → 2FA required, providers: \(providerTypes, privacy: .public)")
                     }
                     throw IdentityTokenError.twoFactorRequired(providers: providerTypes)
+                }
+                // New device OTP required: server returns {"error": "device_error"}.
+                // Only the `error` field is checked — `error_description` is informational only
+                // and is not stable across server versions.
+                if let errorField = json["error"] as? String, errorField == "device_error" {
+                    logger.info("New device OTP required (device_error response)")
+                    throw IdentityTokenError.newDeviceNotVerified
                 }
                 // Invalid TOTP code or wrong password.
                 if let errorDesc = json["error_description"] as? String {
@@ -567,7 +587,6 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
         do {
             let tokenResponse = try JSONDecoder().decode(TokenResponse.self, from: data)
             if DebugConfig.isEnabled {
-                // Log which fields are present — never log token values.
                 let hasKey         = tokenResponse.key != nil
                 let hasKdf         = tokenResponse.kdf != nil
                 let hasUserId      = tokenResponse.userId != nil
@@ -589,10 +608,13 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     // MARK: - fetchSync
 
     func fetchSync() async throws -> SyncResponse {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        var components   = URLComponents(url: base.appendingPathComponent("api/sync"), resolvingAgainstBaseURL: false)!
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        var components = URLComponents(
+            url: env.apiURL.appendingPathComponent("sync"),
+            resolvingAgainstBaseURL: false
+        )!
         components.queryItems = [URLQueryItem(name: "excludeDomains", value: "true")]
-        let url          = components.url!
+        let url = components.url!
 
         if DebugConfig.isEnabled {
             logger.debug("[debug] fetchSync → GET \(url.absoluteString, privacy: .public) hasToken=\(self.accessToken != nil, privacy: .public)")
@@ -614,8 +636,8 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     // MARK: - updateCipher
 
     func updateCipher(id: String, cipher: RawCipher) async throws -> RawCipher {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/ciphers/\(id)")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL.appendingPathComponent("ciphers/\(id)")
 
         if DebugConfig.isEnabled {
             logger.debug("[debug] updateCipher → PUT \(url.absoluteString, privacy: .public)")
@@ -642,8 +664,8 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     // MARK: - updateCipherCollections
 
     func updateCipherCollections(id: String, collectionIds: [String]) async throws {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/ciphers/\(id)/collections")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL.appendingPathComponent("ciphers/\(id)/collections")
         var request = baseRequest(url: url)
         request.httpMethod = "PUT"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -658,10 +680,10 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     // MARK: - softDeleteCipher
 
     func softDeleteCipher(id: String) async throws {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        // PUT /api/ciphers/{id}/delete — soft-delete (moves to Trash, sets deletedDate).
-        // Do NOT use DELETE /api/ciphers/{id} here; that endpoint permanently removes the cipher.
-        let url = base.appendingPathComponent("api/ciphers/\(id)/delete")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        // PUT /ciphers/{id}/delete — soft-delete (moves to Trash, sets deletedDate).
+        // Do NOT use DELETE /ciphers/{id} here; that endpoint permanently removes the cipher.
+        let url = env.apiURL.appendingPathComponent("ciphers/\(id)/delete")
 
         if DebugConfig.isEnabled {
             logger.debug("[debug] softDeleteCipher → PUT \(url.absoluteString, privacy: .public)")
@@ -682,8 +704,8 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     // MARK: - permanentDeleteCipher
 
     func permanentDeleteCipher(id: String) async throws {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/ciphers/\(id)")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL.appendingPathComponent("ciphers/\(id)")
 
         if DebugConfig.isEnabled {
             logger.debug("[debug] permanentDeleteCipher → DELETE \(url.absoluteString, privacy: .public)")
@@ -704,8 +726,8 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     // MARK: - restoreCipher
 
     func restoreCipher(id: String) async throws {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/ciphers/\(id)/restore")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL.appendingPathComponent("ciphers/\(id)/restore")
 
         if DebugConfig.isEnabled {
             logger.debug("[debug] restoreCipher → PUT \(url.absoluteString, privacy: .public)")
@@ -728,8 +750,11 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     // MARK: - createAttachmentMetadata
 
     func createAttachmentMetadata(cipherId: String, body: AttachmentMetadataRequest) async throws -> AttachmentMetadataResponse {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/ciphers").appendingPathComponent(cipherId).appendingPathComponent("attachment/v2")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL
+            .appendingPathComponent("ciphers")
+            .appendingPathComponent(cipherId)
+            .appendingPathComponent("attachment/v2")
         var request = baseRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -741,23 +766,27 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     // MARK: - uploadAttachmentBitwardenHosted
 
     func uploadAttachmentBitwardenHosted(cipherId: String, attachmentId: String, encryptedBlob: Data) async throws {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/ciphers").appendingPathComponent(cipherId).appendingPathComponent("attachment").appendingPathComponent(attachmentId)
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL
+            .appendingPathComponent("ciphers")
+            .appendingPathComponent(cipherId)
+            .appendingPathComponent("attachment")
+            .appendingPathComponent(attachmentId)
 
         // Multipart/form-data with a single `data` field containing the encrypted blob.
         let boundary = UUID().uuidString
-        var body = Data()
-        body.append("--\(boundary)\r\n".data(using: .utf8)!)
-        body.append("Content-Disposition: form-data; name=\"data\"; filename=\"attachment\"\r\n".data(using: .utf8)!)
-        body.append("Content-Type: application/octet-stream\r\n\r\n".data(using: .utf8)!)
-        body.append(encryptedBlob)
-        body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+        var multipart = Data()
+        multipart.append("--\(boundary)\r\n".data(using: .utf8)!)
+        multipart.append("Content-Disposition: form-data; name=\"data\"; filename=\"attachment\"\r\n".data(using: .utf8)!)
+        multipart.append("Content-Type: application/octet-stream\r\n\r\n".data(using: .utf8)!)
+        multipart.append(encryptedBlob)
+        multipart.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
 
         var request = baseRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         if let token = accessToken { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
-        request.httpBody = body
+        request.httpBody = multipart
         try await performEmpty(request: request)
     }
 
@@ -781,8 +810,12 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     // MARK: - fetchAttachmentDownloadURL
 
     func fetchAttachmentDownloadURL(cipherId: String, attachmentId: String) async throws -> AttachmentDownloadResponse {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/ciphers").appendingPathComponent(cipherId).appendingPathComponent("attachment").appendingPathComponent(attachmentId)
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL
+            .appendingPathComponent("ciphers")
+            .appendingPathComponent(cipherId)
+            .appendingPathComponent("attachment")
+            .appendingPathComponent(attachmentId)
         var request = baseRequest(url: url)
         request.httpMethod = "GET"
         if let token = accessToken { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
@@ -792,14 +825,17 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     // MARK: - deleteAttachment
 
     func deleteAttachment(cipherId: String, attachmentId: String) async throws {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/ciphers").appendingPathComponent(cipherId).appendingPathComponent("attachment").appendingPathComponent(attachmentId)
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL
+            .appendingPathComponent("ciphers")
+            .appendingPathComponent(cipherId)
+            .appendingPathComponent("attachment")
+            .appendingPathComponent(attachmentId)
         var request = baseRequest(url: url)
         request.httpMethod = "DELETE"
         if let token = accessToken { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
         try await performEmpty(request: request)
     }
-
 
     // MARK: - downloadBlob
 
@@ -814,13 +850,11 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
         return data
     }
 
-    // MARK: - refreshAccessToken
-
     // MARK: - createCipher
 
     func createCipher(cipher: RawCipher) async throws -> RawCipher {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/ciphers")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL.appendingPathComponent("ciphers")
 
         if DebugConfig.isEnabled {
             logger.debug("[debug] createCipher → POST \(url.absoluteString, privacy: .public)")
@@ -843,15 +877,15 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
 
     // MARK: - createOrgCipher
 
-    /// Wrapper body for `POST /api/ciphers/create` — Bitwarden expects `{ "cipher": ..., "collectionIds": [...] }`.
+    /// Wrapper body for `POST /ciphers/create` — Bitwarden expects `{ "cipher": ..., "collectionIds": [...] }`.
     private struct OrgCipherCreateRequest: Encodable {
         let cipher: RawCipher
         let collectionIds: [String]
     }
 
     func createOrgCipher(cipher: RawCipher) async throws -> RawCipher {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/ciphers/create")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL.appendingPathComponent("ciphers/create")
 
         if DebugConfig.isEnabled {
             logger.debug("[debug] createOrgCipher → POST \(url.absoluteString, privacy: .public)")
@@ -876,8 +910,8 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     // MARK: - Folder CRUD
 
     func createFolder(encryptedName: String) async throws -> RawFolder {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/folders")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL.appendingPathComponent("folders")
         var request = baseRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -889,8 +923,8 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     }
 
     func updateFolder(id: String, encryptedName: String) async throws -> RawFolder {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/folders/\(id)")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL.appendingPathComponent("folders/\(id)")
         var request = baseRequest(url: url)
         request.httpMethod = "PUT"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -902,8 +936,8 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     }
 
     func deleteFolder(id: String) async throws {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/folders/\(id)")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL.appendingPathComponent("folders/\(id)")
         var request = baseRequest(url: url)
         request.httpMethod = "DELETE"
         if let token = accessToken {
@@ -922,8 +956,8 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     }
 
     func createCollection(organizationId: String, encryptedName: String) async throws -> RawCollection {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/organizations/\(organizationId)/collections")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL.appendingPathComponent("organizations/\(organizationId)/collections")
         var request = baseRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -935,8 +969,8 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     }
 
     func renameCollection(id: String, organizationId: String, encryptedName: String) async throws -> RawCollection {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/organizations/\(organizationId)/collections/\(id)")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL.appendingPathComponent("organizations/\(organizationId)/collections/\(id)")
         var request = baseRequest(url: url)
         request.httpMethod = "PUT"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -948,8 +982,8 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     }
 
     func deleteCollection(id: String, organizationId: String) async throws {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/organizations/\(organizationId)/collections/\(id)")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL.appendingPathComponent("organizations/\(organizationId)/collections/\(id)")
         var request = baseRequest(url: url)
         request.httpMethod = "DELETE"
         if let token = accessToken {
@@ -961,8 +995,8 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     // MARK: - Cipher partial / move
 
     func updateCipherPartial(id: String, folderId: String?, favorite: Bool) async throws {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/ciphers/\(id)/partial")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL.appendingPathComponent("ciphers/\(id)/partial")
         var request = baseRequest(url: url)
         request.httpMethod = "PUT"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -976,8 +1010,8 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
     }
 
     func moveCiphersToFolder(ids: [String], folderId: String?) async throws {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("api/ciphers/move")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.apiURL.appendingPathComponent("ciphers/move")
         var request = baseRequest(url: url)
         request.httpMethod = "PUT"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -990,9 +1024,11 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
         try await performEmpty(request: request)
     }
 
+    // MARK: - refreshAccessToken
+
     func refreshAccessToken(refreshToken: String) async throws -> (accessToken: String, refreshToken: String?) {
-        guard let base = baseURL else { throw APIError.baseURLNotSet }
-        let url = base.appendingPathComponent("identity/connect/token")
+        guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
+        let url = env.identityURL.appendingPathComponent("connect/token")
 
         if DebugConfig.isEnabled {
             logger.debug("[debug] refreshAccessToken → POST \(url.absoluteString, privacy: .public)")
@@ -1001,7 +1037,7 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
         let params: [String: String] = [
             "grant_type":    "refresh_token",
             "refresh_token": refreshToken,
-            "client_id":     ClientHeaders.clientId,
+            "client_id":     clientId,
         ]
 
         var request = baseRequest(url: url)
@@ -1027,6 +1063,7 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
         req.setValue("application/json",          forHTTPHeaderField: "Accept")
         req.setValue(ClientHeaders.clientVersion, forHTTPHeaderField: "X-Client-Version")
         req.setValue(ClientHeaders.clientVersion, forHTTPHeaderField: "Bitwarden-Client-Version")
+        req.setValue(Config.clientName,           forHTTPHeaderField: "Bitwarden-Client-Name")
         return req
     }
 
@@ -1050,7 +1087,6 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
             // Scrub: do not log response body (may contain tokens or error details with PII).
             logger.error("HTTP \(http.statusCode) for \(request.url?.path ?? "unknown")")
             if DebugConfig.isEnabled {
-                // Log only top-level JSON keys on error, never values.
                 if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
                     let keys = json.keys.sorted().joined(separator: ", ")
                     logger.debug("[debug] error body keys: [\(keys, privacy: .public)]")

--- a/Prizm/Data/Network/PrizmAPIClient.swift
+++ b/Prizm/Data/Network/PrizmAPIClient.swift
@@ -430,9 +430,10 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
 
     func preLogin(email: String) async throws -> PreLoginResponse {
         guard let env = serverEnvironment else { throw APIError.serverEnvironmentNotSet }
-        // prelogin lives on the identity service, not the API service.
-        // Confirmed: POST https://api.bitwarden.{com,eu}/accounts/prelogin → 404
-        //            POST https://identity.bitwarden.{com,eu}/accounts/prelogin → 200
+        // prelogin is served by the identity service, not the API service — despite the
+        // /accounts/ prefix suggesting otherwise. Using apiURL returns 404 on both regions.
+        // POST https://identity.bitwarden.{com,eu}/accounts/prelogin → 200 ✓
+        // POST https://api.bitwarden.{com,eu}/accounts/prelogin       → 404 ✗
         let url = env.identityURL.appendingPathComponent("accounts/prelogin")
 
         if DebugConfig.isEnabled {

--- a/Prizm/Data/Network/PrizmAPIClient.swift
+++ b/Prizm/Data/Network/PrizmAPIClient.swift
@@ -413,9 +413,12 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
 
     func setServerEnvironment(_ env: ServerEnvironment) {
         serverEnvironment = env
-        // Cloud environments use the registered Prizm identifier per ADR-0023;
-        // self-hosted instances do not enforce identifier checks, so "desktop" is safe.
-        clientId = env.serverType != .selfHosted ? Config.bitwardenClientIdentifier : "desktop"
+        // Bitwarden Cloud password grant (grant_type=password) requires client_id to be one
+        // of Bitwarden's own registered OAuth client names ("desktop", "web", "mobile", etc.).
+        // The UUID in Config.bitwardenClientIdentifier is for API key auth (client_credentials)
+        // only — using it for password grant returns invalid_client on both US and EU.
+        // "desktop" is accepted by both regions and is the conventional choice for native apps.
+        clientId = "desktop"
     }
 
     func setAccessToken(_ token: String) {
@@ -534,6 +537,9 @@ actor PrizmAPIClientImpl: PrizmAPIClientProtocol {
                 if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
                     let keys = json.keys.sorted().joined(separator: ", ")
                     logger.debug("[debug] identityToken 400 body keys: [\(keys, privacy: .public)]")
+                    if let errorVal = json["error"] as? String {
+                        logger.debug("[debug] identityToken 400 error: \(errorVal, privacy: .public)")
+                    }
                     if let errorDesc = json["error_description"] as? String {
                         logger.debug("[debug] identityToken 400 error_description: \(errorDesc, privacy: .public)")
                     }

--- a/Prizm/Data/Repositories/AuthRepositoryImpl.swift
+++ b/Prizm/Data/Repositories/AuthRepositoryImpl.swift
@@ -307,16 +307,15 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
     func loginWithNewDeviceOTP(_ otp: String) async throws -> Account {
         logger.info("Submitting new-device OTP")
         guard let pending = pendingNewDeviceOTP else {
-            throw AuthError.invalidCredentials
+            throw AuthError.otpSessionExpired
         }
         // Zero stretched keys and clear pending state on both success and failure (Constitution §III).
+        // Use local counts captured before the defer fires so the ranges are stable.
+        let encCount = pending.stretchedKeys.encryptionKey.count
+        let macCount = pending.stretchedKeys.macKey.count
         defer {
-            pendingNewDeviceOTP!.stretchedKeys.encryptionKey.resetBytes(
-                in: 0..<pending.stretchedKeys.encryptionKey.count
-            )
-            pendingNewDeviceOTP!.stretchedKeys.macKey.resetBytes(
-                in: 0..<pending.stretchedKeys.macKey.count
-            )
+            pendingNewDeviceOTP!.stretchedKeys.encryptionKey.resetBytes(in: 0..<encCount)
+            pendingNewDeviceOTP!.stretchedKeys.macKey.resetBytes(in: 0..<macCount)
             pendingNewDeviceOTP = nil
         }
         let tokenResp: TokenResponse
@@ -345,7 +344,7 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
     func requestNewDeviceOTP() async throws {
         logger.info("Requesting new OTP dispatch")
         guard let pending = pendingNewDeviceOTP else {
-            throw AuthError.invalidCredentials
+            throw AuthError.otpSessionExpired
         }
         do {
             // Re-posting without newdeviceotp causes the server to dispatch a new OTP email

--- a/Prizm/Data/Repositories/AuthRepositoryImpl.swift
+++ b/Prizm/Data/Repositories/AuthRepositoryImpl.swift
@@ -125,7 +125,9 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
         }
 
         // Step 2: Derive master key locally — never sent to server.
-        // `masterPassword` is `Data` so we can zero it after the KDF call (Constitution §III).
+        // `masterPassword` is `Data` (typed to allow zeroing; `String` cannot be zeroed).
+        // Swift CoW prevents in-place zeroing of a value-type parameter without unsafe code;
+        // the local copy is released on return. Accepted limitation — tracked as §III known gap.
         logger.info("Step 2: deriving master key (KDF)")
         let masterKey  = try await crypto.makeMasterKey(
             password: masterPassword,
@@ -363,7 +365,10 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
             logger.info("New OTP dispatched (device_error treated as success)")
             return
         }
-        // Any other error propagates — credentials not zeroed, caller may retry.
+        // Unexpected: server returned a token response instead of device_error.
+        // The device may have been verified by another client while this challenge was open.
+        // Pending state is preserved — caller can still submit OTP or cancel.
+        logger.warning("requestNewDeviceOTP: unexpected token success — device may have already been verified")
     }
 
     func cancelNewDeviceOTP() {
@@ -371,6 +376,8 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
         // Setting pendingNewDeviceOTP = nil alone does not guarantee immediate deallocation —
         // ARC may defer it. Zeroing the Data buffers in-place reduces the window during
         // which derived key material lives in the heap (Constitution §III).
+        // Note: passwordHash (String) cannot be zeroed — String storage is immutable.
+        // This is an accepted limitation shared with the TOTP flow (cancelTwoFactor).
         if let pending = pendingNewDeviceOTP {
             pendingNewDeviceOTP!.stretchedKeys.encryptionKey.resetBytes(
                 in: 0..<pending.stretchedKeys.encryptionKey.count

--- a/Prizm/Data/Repositories/AuthRepositoryImpl.swift
+++ b/Prizm/Data/Repositories/AuthRepositoryImpl.swift
@@ -49,18 +49,35 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
     }
     private var pendingTwoFactor: PendingTwoFactor?
 
+    // MARK: - Pending new-device OTP state
+    // Set by loginWithPassword when the server returns device_error; consumed by loginWithNewDeviceOTP.
+
+    private struct PendingNewDeviceOTP {
+        let email:        String
+        let passwordHash: String
+        // `var` so cancelNewDeviceOTP() can zero key buffers in-place (Constitution §III).
+        var stretchedKeys: CryptoKeys
+        let deviceId:     String
+        let environment:  ServerEnvironment
+    }
+    private var pendingNewDeviceOTP: PendingNewDeviceOTP?
+
     // MARK: - Init
 
+    private let clientIdentifier: String
+
     init(
-        apiClient: any PrizmAPIClientProtocol,
-        crypto:    any PrizmCryptoService,
-        keychain:  any KeychainService,
-        biometricKeychain: any BiometricKeychainService
+        apiClient:         any PrizmAPIClientProtocol,
+        crypto:            any PrizmCryptoService,
+        keychain:          any KeychainService,
+        biometricKeychain: any BiometricKeychainService,
+        clientIdentifier:  String = Config.bitwardenClientIdentifier
     ) {
-        self.apiClient = apiClient
-        self.crypto    = crypto
-        self.keychain  = keychain
+        self.apiClient        = apiClient
+        self.crypto           = crypto
+        self.keychain         = keychain
         self.biometricKeychain = biometricKeychain
+        self.clientIdentifier  = clientIdentifier
     }
 
     // MARK: - Server configuration
@@ -74,13 +91,15 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
         guard let url = URL(string: trimmed),
               url.scheme == "https",
               url.host != nil else {
+            logger.error("URL validation failed: \(urlString, privacy: .public)")
             throw AuthError.invalidURL
         }
     }
 
     func setServerEnvironment(_ environment: ServerEnvironment) async throws {
         serverEnvironment = environment
-        await apiClient.setBaseURL(environment.base)
+        await apiClient.setServerEnvironment(environment)
+        logger.info("Server environment set: \(environment.serverType.rawValue, privacy: .public)")
     }
 
     // MARK: - Login
@@ -89,6 +108,12 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
         logger.info("Login attempt for \(email, privacy: .private)")
         guard let env = serverEnvironment else {
             throw AuthError.serverUnreachable
+        }
+        // Cloud environments require a registered client identifier (ADR-0023).
+        // Self-hosted Vaultwarden does not enforce this check.
+        if env.serverType != .selfHosted && clientIdentifier.isEmpty {
+            logger.error("Cloud login blocked: bitwardenClientIdentifier not configured")
+            throw AuthError.clientIdentifierNotConfigured
         }
 
         // Step 1: Fetch KDF params.
@@ -143,7 +168,8 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
                 deviceIdentifier:  deviceId,
                 twoFactorToken:    nil,
                 twoFactorProvider: nil,
-                twoFactorRemember: false
+                twoFactorRemember: false,
+                newDeviceOTP:      nil
             )
         } catch let err as IdentityTokenError {
             switch err {
@@ -163,6 +189,23 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
             case .invalidCredentials:
                 logger.error("Login failed: \(AuthError.invalidCredentials.localizedDescription, privacy: .public)")
                 throw AuthError.invalidCredentials
+            case .newDeviceNotVerified:
+                // Cloud: server doesn't recognise this device; an OTP was dispatched to the user's email.
+                // Self-hosted: this response is unexpected — surface as invalid credentials.
+                if env.serverType != .selfHosted {
+                    pendingNewDeviceOTP = PendingNewDeviceOTP(
+                        email:        email,
+                        passwordHash: serverHash,
+                        stretchedKeys: stretched,
+                        deviceId:     deviceId,
+                        environment:  env
+                    )
+                    logger.info("New-device OTP required — pending OTP stored")
+                    return .requiresNewDeviceOTP
+                } else {
+                    logger.error("Unexpected device_error from self-hosted server")
+                    throw AuthError.invalidCredentials
+                }
             }
         }
 
@@ -208,7 +251,8 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
                 deviceIdentifier:  pending.deviceId,
                 twoFactorToken:    code,
                 twoFactorProvider: 0,   // authenticatorApp
-                twoFactorRemember: rememberDevice
+                twoFactorRemember: rememberDevice,
+                newDeviceOTP:      nil
             )
         } catch let err as IdentityTokenError {
             switch err {
@@ -221,6 +265,9 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
             case .twoFactorRequired:
                 logger.error("Login failed: \(AuthError.invalidTwoFactorCode.localizedDescription, privacy: .public)")
                 throw AuthError.invalidTwoFactorCode
+            case .newDeviceNotVerified:
+                logger.error("Unexpected device_error during TOTP flow")
+                throw AuthError.invalidCredentials
             }
         }
 
@@ -255,6 +302,88 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
         }
         pendingTwoFactor = nil
         logger.info("Pending 2FA state cleared — stretched keys zeroed")
+    }
+
+    func loginWithNewDeviceOTP(_ otp: String) async throws -> Account {
+        logger.info("Submitting new-device OTP")
+        guard let pending = pendingNewDeviceOTP else {
+            throw AuthError.invalidCredentials
+        }
+        // Zero stretched keys and clear pending state on both success and failure (Constitution §III).
+        defer {
+            pendingNewDeviceOTP!.stretchedKeys.encryptionKey.resetBytes(
+                in: 0..<pending.stretchedKeys.encryptionKey.count
+            )
+            pendingNewDeviceOTP!.stretchedKeys.macKey.resetBytes(
+                in: 0..<pending.stretchedKeys.macKey.count
+            )
+            pendingNewDeviceOTP = nil
+        }
+        let tokenResp: TokenResponse
+        do {
+            tokenResp = try await apiClient.identityToken(
+                email:             pending.email,
+                passwordHash:      pending.passwordHash,
+                deviceIdentifier:  pending.deviceId,
+                twoFactorToken:    nil,
+                twoFactorProvider: nil,
+                twoFactorRemember: false,
+                newDeviceOTP:      otp
+            )
+        } catch {
+            logger.error("New-device OTP rejected: \(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+        logger.info("New-device OTP accepted")
+        return try await finalizeSession(
+            tokenResp:   tokenResp,
+            stretched:   pending.stretchedKeys,
+            environment: pending.environment
+        )
+    }
+
+    func requestNewDeviceOTP() async throws {
+        logger.info("Requesting new OTP dispatch")
+        guard let pending = pendingNewDeviceOTP else {
+            throw AuthError.invalidCredentials
+        }
+        do {
+            // Re-posting without newdeviceotp causes the server to dispatch a new OTP email
+            // and respond with HTTP 400 + device_error again. That "error" is the server's
+            // confirmation that the email was sent — catching it here is intentional.
+            // Do NOT remove this catch: it converts the expected error into a success path.
+            _ = try await apiClient.identityToken(
+                email:             pending.email,
+                passwordHash:      pending.passwordHash,
+                deviceIdentifier:  pending.deviceId,
+                twoFactorToken:    nil,
+                twoFactorProvider: nil,
+                twoFactorRemember: false,
+                newDeviceOTP:      nil
+            )
+        } catch IdentityTokenError.newDeviceNotVerified {
+            // Expected: server sent a new OTP email and returned device_error as confirmation.
+            logger.info("New OTP dispatched (device_error treated as success)")
+            return
+        }
+        // Any other error propagates — credentials not zeroed, caller may retry.
+    }
+
+    func cancelNewDeviceOTP() {
+        // Explicitly zero the stretched key buffers before releasing the struct.
+        // Setting pendingNewDeviceOTP = nil alone does not guarantee immediate deallocation —
+        // ARC may defer it. Zeroing the Data buffers in-place reduces the window during
+        // which derived key material lives in the heap (Constitution §III).
+        if let pending = pendingNewDeviceOTP {
+            pendingNewDeviceOTP!.stretchedKeys.encryptionKey.resetBytes(
+                in: 0..<pending.stretchedKeys.encryptionKey.count
+            )
+            pendingNewDeviceOTP!.stretchedKeys.macKey.resetBytes(
+                in: 0..<pending.stretchedKeys.macKey.count
+            )
+        }
+        pendingNewDeviceOTP = nil
+        logger.info("Pending new-device OTP state cleared — stretched keys zeroed")
     }
 
     func unlockWithPassword(_ masterPassword: Data) async throws -> Account {
@@ -322,7 +451,7 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
         // Restore API client state so the post-unlock sync can make authenticated requests.
         // Both baseURL and accessToken are nil on a fresh app launch until restored here.
         serverEnvironment = restoredAccount.serverEnvironment
-        await apiClient.setBaseURL(restoredAccount.serverEnvironment.base)
+        await apiClient.setServerEnvironment(restoredAccount.serverEnvironment)
 
         if let accessToken = try? readString(key: KeychainKey.user(userId, "accessToken")) {
             await apiClient.setAccessToken(accessToken)
@@ -420,8 +549,9 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
         // from a heap dump after sign-out (Constitution §III).
         await apiClient.clearAccessToken()
 
-        serverEnvironment = nil
-        pendingTwoFactor  = nil
+        serverEnvironment   = nil
+        pendingTwoFactor    = nil
+        pendingNewDeviceOTP = nil
     }
 
     // MARK: - Lock
@@ -537,7 +667,7 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
 
         // Restore API client state — same as unlockWithPassword().
         serverEnvironment = restoredAccount.serverEnvironment
-        await apiClient.setBaseURL(restoredAccount.serverEnvironment.base)
+        await apiClient.setServerEnvironment(restoredAccount.serverEnvironment)
 
         if let accessToken = try? readString(key: KeychainKey.user(userId, "accessToken")) {
             await apiClient.setAccessToken(accessToken)
@@ -603,7 +733,7 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
 
         await crypto.unlockWith(keys: vaultKeys)
         serverEnvironment = restoredAccount.serverEnvironment
-        await apiClient.setBaseURL(restoredAccount.serverEnvironment.base)
+        await apiClient.setServerEnvironment(restoredAccount.serverEnvironment)
 
         if let accessToken = try? readString(key: KeychainKey.user(userId, "accessToken")) {
             await apiClient.setAccessToken(accessToken)

--- a/Prizm/Data/Repositories/AuthRepositoryImpl.swift
+++ b/Prizm/Data/Repositories/AuthRepositoryImpl.swift
@@ -309,15 +309,6 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
         guard let pending = pendingNewDeviceOTP else {
             throw AuthError.otpSessionExpired
         }
-        // Zero stretched keys and clear pending state on both success and failure (Constitution §III).
-        // Use local counts captured before the defer fires so the ranges are stable.
-        let encCount = pending.stretchedKeys.encryptionKey.count
-        let macCount = pending.stretchedKeys.macKey.count
-        defer {
-            pendingNewDeviceOTP!.stretchedKeys.encryptionKey.resetBytes(in: 0..<encCount)
-            pendingNewDeviceOTP!.stretchedKeys.macKey.resetBytes(in: 0..<macCount)
-            pendingNewDeviceOTP = nil
-        }
         let tokenResp: TokenResponse
         do {
             tokenResp = try await apiClient.identityToken(
@@ -331,8 +322,15 @@ final class AuthRepositoryImpl: AuthRepository, EmbeddedBiometricUnlock {
             )
         } catch {
             logger.error("New-device OTP rejected: \(error.localizedDescription, privacy: .public)")
+            // Preserve pendingNewDeviceOTP so the user can correct the code and retry.
             throw error
         }
+        // OTP accepted: zero key material before clearing pending state (Constitution §III).
+        let encCount = pendingNewDeviceOTP!.stretchedKeys.encryptionKey.count
+        let macCount = pendingNewDeviceOTP!.stretchedKeys.macKey.count
+        pendingNewDeviceOTP!.stretchedKeys.encryptionKey.resetBytes(in: 0..<encCount)
+        pendingNewDeviceOTP!.stretchedKeys.macKey.resetBytes(in: 0..<macCount)
+        pendingNewDeviceOTP = nil
         logger.info("New-device OTP accepted")
         return try await finalizeSession(
             tokenResp:   tokenResp,

--- a/Prizm/Data/UseCases/LoginUseCaseImpl.swift
+++ b/Prizm/Data/UseCases/LoginUseCaseImpl.swift
@@ -4,11 +4,12 @@ import os.log
 // MARK: - LoginUseCaseImpl
 
 /// Orchestrates the full account login flow:
-///   1. Set server environment (validate URL for self-hosted only).
-///   2. Call `AuthRepository.loginWithPassword`.
-///   3. If `.success`: call `SyncRepository.sync` to populate the vault.
-///   4. If `.requiresTwoFactor`: return immediately — sync is deferred to after TOTP.
-///   5. If `.requiresNewDeviceOTP`: return immediately — sync deferred to after OTP.
+///   1. Build `ServerEnvironment` from caller-supplied `serverType` + `serverURL`.
+///   2. Validate URL (self-hosted only) and set environment on `AuthRepository`.
+///   3. Call `AuthRepository.loginWithPassword`.
+///   4. If `.success`: call `SyncRepository.sync` to populate the vault.
+///   5. If `.requiresTwoFactor`: return immediately — sync is deferred to after TOTP.
+///   6. If `.requiresNewDeviceOTP`: return immediately — sync deferred to after OTP.
 ///
 /// `SyncRepository.sync` is called here (not inside `AuthRepository`) to keep the
 /// Domain layer orchestration visible and testable at the use-case level.
@@ -24,11 +25,12 @@ final class LoginUseCaseImpl: LoginUseCase {
         self.sync = sync
     }
 
-    func execute(environment: ServerEnvironment, email: String, masterPassword: Data) async throws -> LoginResult {
-        // Validate server URL only for self-hosted — cloud URLs are static factory values.
-        if environment.serverType == .selfHosted {
-            let urlString = environment.base.absoluteString
-            try auth.validateServerURL(urlString)
+    func execute(serverType: ServerType, serverURL: String, email: String, masterPassword: Data) async throws -> LoginResult {
+        let environment = try buildEnvironment(serverType: serverType, serverURL: serverURL)
+        // Validate self-hosted URL against HTTPS scheme and host presence (Constitution §III).
+        // Cloud URLs are hardcoded constants and never need validation.
+        if serverType == .selfHosted {
+            try auth.validateServerURL(environment.base.absoluteString)
         }
 
         try await auth.setServerEnvironment(environment)
@@ -93,5 +95,22 @@ final class LoginUseCaseImpl: LoginUseCase {
 
     func cancelNewDeviceOTP() {
         auth.cancelNewDeviceOTP()
+    }
+
+    // MARK: - Private helpers
+
+    private func buildEnvironment(serverType: ServerType, serverURL: String) throws -> ServerEnvironment {
+        switch serverType {
+        case .cloudUS:
+            return .cloudUS()
+        case .cloudEU:
+            return .cloudEU()
+        case .selfHosted:
+            let trimmed = serverURL.hasSuffix("/") ? String(serverURL.dropLast()) : serverURL
+            guard !trimmed.isEmpty, let base = URL(string: trimmed) else {
+                throw AuthError.invalidURL
+            }
+            return ServerEnvironment(base: base, overrides: nil)
+        }
     }
 }

--- a/Prizm/Data/UseCases/LoginUseCaseImpl.swift
+++ b/Prizm/Data/UseCases/LoginUseCaseImpl.swift
@@ -4,10 +4,11 @@ import os.log
 // MARK: - LoginUseCaseImpl
 
 /// Orchestrates the full account login flow:
-///   1. Validate + set server URL.
+///   1. Set server environment (validate URL for self-hosted only).
 ///   2. Call `AuthRepository.loginWithPassword`.
 ///   3. If `.success`: call `SyncRepository.sync` to populate the vault.
 ///   4. If `.requiresTwoFactor`: return immediately — sync is deferred to after TOTP.
+///   5. If `.requiresNewDeviceOTP`: return immediately — sync deferred to after OTP.
 ///
 /// `SyncRepository.sync` is called here (not inside `AuthRepository`) to keep the
 /// Domain layer orchestration visible and testable at the use-case level.
@@ -23,27 +24,22 @@ final class LoginUseCaseImpl: LoginUseCase {
         self.sync = sync
     }
 
-    func execute(serverURL: String, email: String, masterPassword: Data) async throws -> LoginResult {
-        // Step 1: Validate URL (throws AuthError.invalidURL on failure).
-        try auth.validateServerURL(serverURL)
+    func execute(environment: ServerEnvironment, email: String, masterPassword: Data) async throws -> LoginResult {
+        // Validate server URL only for self-hosted — cloud URLs are static factory values.
+        if environment.serverType == .selfHosted {
+            let urlString = environment.base.absoluteString
+            try auth.validateServerURL(urlString)
+        }
 
-        // Step 2: Configure server environment.
-        let trimmed = serverURL.hasSuffix("/") ? String(serverURL.dropLast()) : serverURL
-        guard let url = URL(string: trimmed) else { throw AuthError.invalidURL }
-        let environment = ServerEnvironment(base: url, overrides: nil)
         try await auth.setServerEnvironment(environment)
 
-        // Step 3: Attempt password login.
         logger.info("Attempting login for \(email, privacy: .private)")
         let result = try await auth.loginWithPassword(email: email, masterPassword: masterPassword)
 
         switch result {
         case .success:
-            // Step 4: Sync vault immediately after successful login.
-            // Sync is best-effort: if the server is temporarily unreachable the user
-            // still lands in the vault browser showing items from the last sync.
-            // Failing the entire login on a sync error would lock users out even when
-            // the server is degraded — unacceptable for a password manager.
+            // Sync vault immediately after successful login.
+            // Sync is best-effort: a degraded server should not prevent vault access.
             logger.info("Login succeeded — starting vault sync")
             do {
                 _ = try await sync.sync(progress: { _ in })
@@ -53,10 +49,13 @@ final class LoginUseCaseImpl: LoginUseCase {
             return result
 
         case .requiresTwoFactor:
-            // Sync is deferred until TOTP is accepted. At this point we have derived the
-            // master key but do not yet have an access token, so a sync request would be
-            // rejected with 401. The vault populates after completeTOTP succeeds below.
+            // Sync deferred until TOTP accepted — no access token yet.
             logger.info("Login requires 2FA")
+            return result
+
+        case .requiresNewDeviceOTP:
+            // Sync deferred until OTP accepted — no access token yet.
+            logger.info("Login requires new-device OTP")
             return result
         }
     }
@@ -64,7 +63,6 @@ final class LoginUseCaseImpl: LoginUseCase {
     func completeTOTP(code: String, rememberDevice: Bool) async throws -> Account {
         logger.info("Completing TOTP")
         let account = try await auth.loginWithTOTP(code: code, rememberDevice: rememberDevice)
-        // Sync failure is non-fatal — show vault with whatever was synced (FR-049).
         do {
             _ = try await sync.sync(progress: { _ in })
         } catch {
@@ -75,5 +73,25 @@ final class LoginUseCaseImpl: LoginUseCase {
 
     func cancelTOTP() {
         auth.cancelTwoFactor()
+    }
+
+    func completeNewDeviceOTP(otp: String) async throws -> Account {
+        logger.info("Completing new-device OTP")
+        let account = try await auth.loginWithNewDeviceOTP(otp)
+        do {
+            _ = try await sync.sync(progress: { _ in })
+        } catch {
+            logger.error("Post-OTP sync failed (non-fatal): \(error.localizedDescription, privacy: .public)")
+        }
+        return account
+    }
+
+    func resendNewDeviceOTP() async throws {
+        logger.info("Resending new-device OTP")
+        try await auth.requestNewDeviceOTP()
+    }
+
+    func cancelNewDeviceOTP() {
+        auth.cancelNewDeviceOTP()
     }
 }

--- a/Prizm/Domain/Entities/Account.swift
+++ b/Prizm/Domain/Entities/Account.swift
@@ -8,24 +8,96 @@ nonisolated struct Account: Equatable {
     let serverEnvironment: ServerEnvironment
 }
 
-/// The server a user account belongs to (self-hosted Bitwarden or Vaultwarden).
+/// Identifies the type of Bitwarden server for an account.
+/// Raw `String` values are stored in Keychain — do NOT rename after any release
+/// that has written Keychain data (Keychain storage contract).
+nonisolated enum ServerType: String, Codable, Equatable {
+    case cloudUS    = "cloudUS"
+    case cloudEU    = "cloudEU"
+    case selfHosted = "selfHosted"
+}
+
+/// The server a user account belongs to (cloud Bitwarden or self-hosted Vaultwarden).
 /// Stored as JSON in the Keychain under `bw.macos:{userId}:serverEnvironment`.
 nonisolated struct ServerEnvironment: Codable, Equatable {
 
-    /// The base URL supplied by the user (e.g. `https://vault.example.com`).
+    /// The base URL supplied by the user, or a sentinel value for cloud environments.
     let base: URL
 
-    /// Per-service URL overrides. When nil the default derived paths are used.
+    /// Per-service URL overrides. Ignored for cloud server types; used for self-hosted only.
     var overrides: ServerURLOverrides?
 
-    /// `{base}/api` unless overridden.
-    var apiURL: URL { overrides?.api ?? base.appendingPathComponent("api") }
+    /// Identifies the server type. Defaults to `.selfHosted` for backwards compatibility
+    /// with Keychain records written before this property existed.
+    var serverType: ServerType
 
-    /// `{base}/identity` unless overridden.
-    var identityURL: URL { overrides?.identity ?? base.appendingPathComponent("identity") }
+    init(base: URL, overrides: ServerURLOverrides? = nil, serverType: ServerType = .selfHosted) {
+        self.base = base
+        self.overrides = overrides
+        self.serverType = serverType
+    }
 
-    /// `{base}/icons` unless overridden.
-    var iconsURL: URL { overrides?.icons ?? base.appendingPathComponent("icons") }
+    // Custom Codable so legacy records lacking `serverType` decode as `.selfHosted`.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        base      = try container.decode(URL.self, forKey: .base)
+        overrides = try container.decodeIfPresent(ServerURLOverrides.self, forKey: .overrides)
+        serverType = try container.decodeIfPresent(ServerType.self, forKey: .serverType) ?? .selfHosted
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case base, overrides, serverType
+    }
+
+    // MARK: - Static factory methods
+
+    /// Returns a `ServerEnvironment` configured for Bitwarden Cloud US.
+    /// `base` is set to a sentinel URL — cloud URL routing ignores `base`.
+    static func cloudUS() -> ServerEnvironment {
+        ServerEnvironment(
+            base:       URL(string: "https://bitwarden.com")!,
+            overrides:  nil,
+            serverType: .cloudUS
+        )
+    }
+
+    /// Returns a `ServerEnvironment` configured for Bitwarden Cloud EU.
+    /// `base` is set to a sentinel URL — cloud URL routing ignores `base`.
+    static func cloudEU() -> ServerEnvironment {
+        ServerEnvironment(
+            base:       URL(string: "https://bitwarden.com")!,
+            overrides:  nil,
+            serverType: .cloudEU
+        )
+    }
+
+    // MARK: - Computed URL properties
+
+    /// API service URL. Cloud cases return canonical hostnames; self-hosted appends `/api` to `base`.
+    var apiURL: URL {
+        switch serverType {
+        case .cloudUS:    return URL(string: "https://api.bitwarden.com")!
+        case .cloudEU:    return URL(string: "https://api.bitwarden.eu")!
+        case .selfHosted: return overrides?.api ?? base.appendingPathComponent("api")
+        }
+    }
+
+    /// Identity service URL. Cloud cases return canonical hostnames; self-hosted appends `/identity` to `base`.
+    var identityURL: URL {
+        switch serverType {
+        case .cloudUS:    return URL(string: "https://identity.bitwarden.com")!
+        case .cloudEU:    return URL(string: "https://identity.bitwarden.eu")!
+        case .selfHosted: return overrides?.identity ?? base.appendingPathComponent("identity")
+        }
+    }
+
+    /// Icons CDN URL. Cloud cases share a single global CDN; self-hosted appends `/icons` to `base`.
+    var iconsURL: URL {
+        switch serverType {
+        case .cloudUS, .cloudEU: return URL(string: "https://icons.bitwarden.net")!
+        case .selfHosted:        return overrides?.icons ?? base.appendingPathComponent("icons")
+        }
+    }
 }
 
 /// Optional per-service URL overrides for self-hosted deployments that

--- a/Prizm/Domain/Entities/Account.swift
+++ b/Prizm/Domain/Entities/Account.swift
@@ -15,6 +15,15 @@ nonisolated enum ServerType: String, Codable, Equatable {
     case cloudUS    = "cloudUS"
     case cloudEU    = "cloudEU"
     case selfHosted = "selfHosted"
+
+    /// User-visible display name used in the login picker and VoiceOver announcements.
+    var displayName: String {
+        switch self {
+        case .cloudUS:    return "Bitwarden Cloud (US)"
+        case .cloudEU:    return "Bitwarden Cloud (EU)"
+        case .selfHosted: return "Self-hosted"
+        }
+    }
 }
 
 /// The server a user account belongs to (cloud Bitwarden or self-hosted Vaultwarden).

--- a/Prizm/Domain/Repositories/AuthRepository.swift
+++ b/Prizm/Domain/Repositories/AuthRepository.swift
@@ -147,6 +147,9 @@ nonisolated enum AuthError: Error, LocalizedError, Equatable {
     /// Cloud login attempted without a registered Bitwarden client identifier.
     /// Thrown before any network request is made.
     case clientIdentifierNotConfigured
+    /// OTP completion or resend called when no new-device OTP challenge is active
+    /// (e.g. called out of sequence after session was cancelled or expired).
+    case otpSessionExpired
 
     var errorDescription: String? {
         switch self {
@@ -173,6 +176,8 @@ nonisolated enum AuthError: Error, LocalizedError, Equatable {
             return "Biometric unlock is not available. Please unlock with your master password."
         case .clientIdentifierNotConfigured:
             return "Prizm is not configured for Bitwarden Cloud. Contact support or use a self-hosted server."
+        case .otpSessionExpired:
+            return "The verification session has expired. Please sign in again."
         }
     }
 }

--- a/Prizm/Domain/Repositories/AuthRepository.swift
+++ b/Prizm/Domain/Repositories/AuthRepository.swift
@@ -26,7 +26,7 @@ protocol AuthRepository: AnyObject {
     ///
     /// - Security goal: `masterPassword` is `Data` so the caller can zero the bytes
     ///   after the call returns, reducing heap exposure (Constitution §III).
-    /// - Returns: `.success(Account)` or `.requiresTwoFactor(method:)`.
+    /// - Returns: `.success(Account)`, `.requiresTwoFactor(method:)`, or `.requiresNewDeviceOTP`.
     /// - Throws: `AuthError` on network or credential failure.
     func loginWithPassword(email: String, masterPassword: Data) async throws -> LoginResult
 
@@ -45,6 +45,21 @@ protocol AuthRepository: AnyObject {
     ///   the next login attempt or app restart (Constitution §III). Call this whenever the
     ///   user dismisses the TOTP prompt without submitting a code.
     func cancelTwoFactor()
+
+    /// Retries the identity token request with the new-device OTP the user received by email.
+    /// Only valid to call after `loginWithPassword` returns `LoginResult.requiresNewDeviceOTP`.
+    /// - Returns: The authenticated `Account`.
+    /// - Throws: `AuthError.invalidCredentials` if no pending OTP state exists.
+    func loginWithNewDeviceOTP(_ otp: String) async throws -> Account
+
+    /// Re-triggers the original identity token request without an OTP, causing the server to
+    /// dispatch a new verification code to the user's registered email. Does NOT return an
+    /// Account — the user remains in the OTP challenge state after this call.
+    func requestNewDeviceOTP() async throws
+
+    /// Zeros any cached credentials held from the pending new-device OTP challenge.
+    /// No network request is made.
+    func cancelNewDeviceOTP()
 
     // MARK: - Unlock
 
@@ -102,6 +117,9 @@ protocol AuthRepository: AnyObject {
 nonisolated enum LoginResult {
     case success(Account)
     case requiresTwoFactor(TwoFactorMethod)
+    /// The server does not recognise this device and has dispatched a one-time code
+    /// to the user's registered email. Retry with `loginWithNewDeviceOTP(_:)`.
+    case requiresNewDeviceOTP
 }
 
 /// Two-factor methods supported in v1. Only `authenticatorApp` (TOTP) is handled;
@@ -126,6 +144,9 @@ nonisolated enum AuthError: Error, LocalizedError, Equatable {
     case biometricItemNotFound
     /// Biometric unlock cannot be enabled — vault is locked (keys not in memory).
     case biometricUnavailable
+    /// Cloud login attempted without a registered Bitwarden client identifier.
+    /// Thrown before any network request is made.
+    case clientIdentifierNotConfigured
 
     var errorDescription: String? {
         switch self {
@@ -150,6 +171,8 @@ nonisolated enum AuthError: Error, LocalizedError, Equatable {
             return nil
         case .biometricUnavailable:
             return "Biometric unlock is not available. Please unlock with your master password."
+        case .clientIdentifierNotConfigured:
+            return "Prizm is not configured for Bitwarden Cloud. Contact support or use a self-hosted server."
         }
     }
 }

--- a/Prizm/Domain/UseCases/LoginUseCase.swift
+++ b/Prizm/Domain/UseCases/LoginUseCase.swift
@@ -1,11 +1,22 @@
 import Foundation
 
 /// Orchestrates the full account login flow:
-/// validateServerURL → setServerEnvironment → loginWithPassword → (optional) loginWithTOTP → sync.
+/// `execute` → (optional) `completeNewDeviceOTP` or `completeTOTP` → sync.
+///
+/// The caller is responsible for constructing the correct `ServerEnvironment` before calling
+/// `execute`. On a new-device OTP challenge, the flow is:
+///   1. `execute(environment:email:masterPassword:)` → `.requiresNewDeviceOTP`
+///   2. User enters the OTP received by email
+///   3. `completeNewDeviceOTP(otp:)` → Account (triggers vault sync)
+///
+/// On a TOTP 2FA challenge, the flow is:
+///   1. `execute(environment:email:masterPassword:)` → `.requiresTwoFactor`
+///   2. User enters the authenticator code
+///   3. `completeTOTP(code:rememberDevice:)` → Account (triggers vault sync)
 protocol LoginUseCase {
     func execute(
-        serverURL: String,
-        email: String,
+        environment:    ServerEnvironment,
+        email:          String,
         masterPassword: Data
     ) async throws -> LoginResult
 
@@ -14,4 +25,17 @@ protocol LoginUseCase {
     /// Cancels a pending TOTP challenge and clears in-memory key material held from
     /// the initial password-login step (see `AuthRepository.cancelTwoFactor`).
     func cancelTOTP()
+
+    /// Retries the identity token request with the new-device OTP the user received by email.
+    /// Only valid to call after `execute` returns `LoginResult.requiresNewDeviceOTP`.
+    /// On success, triggers vault sync and returns the logged-in `Account`.
+    func completeNewDeviceOTP(otp: String) async throws -> Account
+
+    /// Re-triggers the original identity token request without an OTP, causing the server to
+    /// dispatch a new verification code to the user's registered email.
+    /// Only valid when in the OTP challenge state.
+    func resendNewDeviceOTP() async throws
+
+    /// Cancels a pending new-device OTP challenge and clears any cached credentials.
+    func cancelNewDeviceOTP()
 }

--- a/Prizm/Domain/UseCases/LoginUseCase.swift
+++ b/Prizm/Domain/UseCases/LoginUseCase.swift
@@ -3,19 +3,20 @@ import Foundation
 /// Orchestrates the full account login flow:
 /// `execute` → (optional) `completeNewDeviceOTP` or `completeTOTP` → sync.
 ///
-/// The caller is responsible for constructing the correct `ServerEnvironment` before calling
-/// `execute`. On a new-device OTP challenge, the flow is:
-///   1. `execute(environment:email:masterPassword:)` → `.requiresNewDeviceOTP`
+/// The caller passes raw user input; environment construction and URL validation
+/// are handled internally. On a new-device OTP challenge:
+///   1. `execute(serverType:serverURL:email:masterPassword:)` → `.requiresNewDeviceOTP`
 ///   2. User enters the OTP received by email
 ///   3. `completeNewDeviceOTP(otp:)` → Account (triggers vault sync)
 ///
-/// On a TOTP 2FA challenge, the flow is:
-///   1. `execute(environment:email:masterPassword:)` → `.requiresTwoFactor`
+/// On a TOTP 2FA challenge:
+///   1. `execute(serverType:serverURL:email:masterPassword:)` → `.requiresTwoFactor`
 ///   2. User enters the authenticator code
 ///   3. `completeTOTP(code:rememberDevice:)` → Account (triggers vault sync)
 protocol LoginUseCase {
     func execute(
-        environment:    ServerEnvironment,
+        serverType:     ServerType,
+        serverURL:      String,
         email:          String,
         masterPassword: Data
     ) async throws -> LoginResult

--- a/Prizm/LocalConfig.xcconfig.template
+++ b/Prizm/LocalConfig.xcconfig.template
@@ -1,4 +1,5 @@
 // LocalConfig.xcconfig — per-developer signing settings
+#include "LocalSecrets.xcconfig"
 //
 // Setup:
 //   cp LocalConfig.xcconfig.template LocalConfig.xcconfig

--- a/Prizm/LocalSecrets.xcconfig.template
+++ b/Prizm/LocalSecrets.xcconfig.template
@@ -1,0 +1,13 @@
+// LocalSecrets.xcconfig — per-developer secrets (gitignored — never commit)
+//
+// Setup:
+//   cp LocalSecrets.xcconfig.template LocalSecrets.xcconfig
+//   Then fill in your registered Bitwarden client identifier below.
+//
+// Obtaining the value:
+//   BW_CLIENT_IDENTIFIER is Prizm's registered Bitwarden client identifier.
+//   Contact the project maintainer or check your CI/CD secrets.
+//   Without this value, cloud login fails at runtime with
+//   AuthError.clientIdentifierNotConfigured; self-hosted login is unaffected.
+
+BW_CLIENT_IDENTIFIER =

--- a/Prizm/Presentation/AccessibilityIdentifiers.swift
+++ b/Prizm/Presentation/AccessibilityIdentifiers.swift
@@ -15,6 +15,11 @@ nonisolated enum AccessibilityID {
         static let signInButton      = "login.signIn"
         static let errorMessage      = "login.error"
         static let headerTitle       = "login.headerTitle"
+        static let serverTypePicker  = "login.serverTypePicker"
+        static let newDeviceOtpField = "login.newDeviceOtpField"
+        static let resendOtpButton   = "login.resendOtpButton"
+        static let cancelOtpButton   = "login.cancelOtpButton"
+        static let otpErrorMessage   = "login.otpErrorMessage"
     }
 
     // MARK: - TOTP (US1)

--- a/Prizm/Presentation/AccessibilityIdentifiers.swift
+++ b/Prizm/Presentation/AccessibilityIdentifiers.swift
@@ -16,6 +16,7 @@ nonisolated enum AccessibilityID {
         static let errorMessage      = "login.error"
         static let headerTitle       = "login.headerTitle"
         static let serverTypePicker  = "login.serverTypePicker"
+        static let newDeviceOtpHeader = "login.newDeviceOtpHeader"
         static let newDeviceOtpField = "login.newDeviceOtpField"
         static let resendOtpButton   = "login.resendOtpButton"
         static let cancelOtpButton   = "login.cancelOtpButton"

--- a/Prizm/Presentation/Login/LoginView.swift
+++ b/Prizm/Presentation/Login/LoginView.swift
@@ -29,9 +29,9 @@ struct LoginView: View {
                     .accessibilityIdentifier(AccessibilityID.Login.headerTitle)
                 // Server-type picker — replaces the static subtitle
                 Picker("Server", selection: $viewModel.serverType) {
-                    Text("Bitwarden US").tag(ServerType.cloudUS)
-                    Text("Bitwarden EU").tag(ServerType.cloudEU)
-                    Text("Self-hosted").tag(ServerType.selfHosted)
+                    ForEach([ServerType.cloudUS, .cloudEU, .selfHosted], id: \.self) { type in
+                        Text(type.displayName).tag(type)
+                    }
                 }
                 .pickerStyle(.segmented)
                 .frame(maxWidth: 360)
@@ -122,11 +122,5 @@ struct LoginView: View {
         viewModel.signIn()
     }
 
-    private func pickerLabel(for type: ServerType) -> String {
-        switch type {
-        case .cloudUS:   return "Bitwarden US"
-        case .cloudEU:   return "Bitwarden EU"
-        case .selfHosted: return "Self-hosted"
-        }
-    }
+    private func pickerLabel(for type: ServerType) -> String { type.displayName }
 }

--- a/Prizm/Presentation/Login/LoginView.swift
+++ b/Prizm/Presentation/Login/LoginView.swift
@@ -4,13 +4,12 @@ import SwiftUI
 
 /// The initial authentication screen (User Story 1, FR-001–FR-010).
 ///
-/// Collects server URL, email, and master password, then initiates the login flow
+/// Collects server type, email, and master password, then initiates the login flow
 /// via `LoginViewModel`. The view itself is stateless — all logic lives in the VM.
 struct LoginView: View {
 
     @ObservedObject var viewModel: LoginViewModel
 
-    /// Focus state used to advance through fields on Return.
     @FocusState private var focusedField: Field?
 
     private enum Field: Hashable {
@@ -27,25 +26,36 @@ struct LoginView: View {
                     .accessibilityHidden(true)
                 Text("Prizm")
                     .font(Typography.screenHeading)
-                Text("Self-hosted vault")
-                    .font(Typography.fieldLabel)
-                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier(AccessibilityID.Login.headerTitle)
+                // Server-type picker — replaces the static subtitle
+                Picker("Server", selection: $viewModel.serverType) {
+                    Text("Bitwarden US").tag(ServerType.cloudUS)
+                    Text("Bitwarden EU").tag(ServerType.cloudEU)
+                    Text("Self-hosted").tag(ServerType.selfHosted)
+                }
+                .pickerStyle(.segmented)
+                .frame(maxWidth: 360)
+                .accessibilityIdentifier(AccessibilityID.Login.serverTypePicker)
+                .accessibilityLabel("Server")
+                .accessibilityValue(pickerLabel(for: viewModel.serverType))
             }
             .padding(.top, 24)
 
             // MARK: Form fields
             VStack(spacing: 12) {
-                // Server URL — FR-001
-                LabeledContent("Server URL") {
-                    TextField("https://vault.example.com", text: $viewModel.serverURL)
-                        .textFieldStyle(.roundedBorder)
-                        .focused($focusedField, equals: .serverURL)
-                        .autocorrectionDisabled()
-                        .onSubmit { focusedField = .email }
-                        .accessibilityIdentifier(AccessibilityID.Login.serverURLField)
+                // Server URL — only shown for self-hosted
+                if viewModel.serverType == .selfHosted {
+                    LabeledContent("Server URL") {
+                        TextField("https://vault.example.com", text: $viewModel.serverURL)
+                            .textFieldStyle(.roundedBorder)
+                            .focused($focusedField, equals: .serverURL)
+                            .autocorrectionDisabled()
+                            .onSubmit { focusedField = .email }
+                            .accessibilityIdentifier(AccessibilityID.Login.serverURLField)
+                    }
                 }
 
-                // Email — FR-003
+                // Email
                 LabeledContent("Email") {
                     TextField("you@example.com", text: $viewModel.email)
                         .textFieldStyle(.roundedBorder)
@@ -55,7 +65,7 @@ struct LoginView: View {
                         .accessibilityIdentifier(AccessibilityID.Login.emailField)
                 }
 
-                // Master password — FR-005
+                // Master password
                 LabeledContent("Master password") {
                     SecureField("Enter master password", text: $viewModel.password)
                         .textFieldStyle(.roundedBorder)
@@ -78,7 +88,7 @@ struct LoginView: View {
                     .accessibilityIdentifier(AccessibilityID.Login.errorMessage)
             }
 
-            // MARK: Sign In button — FR-007
+            // MARK: Sign In button
             Button(action: signIn) {
                 if case .loading = viewModel.flowState {
                     ProgressView()
@@ -91,7 +101,7 @@ struct LoginView: View {
             }
             .buttonStyle(.borderedProminent)
             .frame(width: 360)
-            .disabled(isSignInDisabled)
+            .disabled(viewModel.isSignInDisabled)
             .keyboardShortcut(.return, modifiers: [])
             .accessibilityIdentifier(AccessibilityID.Login.signInButton)
 
@@ -100,20 +110,23 @@ struct LoginView: View {
         .padding(.horizontal, Spacing.screenHorizontal)
         .padding(.bottom, 32)
         .frame(minWidth: 480, minHeight: 400)
-        .onAppear { focusedField = .serverURL }
+        .onAppear {
+            focusedField = viewModel.serverType == .selfHosted ? .serverURL : .email
+        }
     }
 
     // MARK: - Private helpers
 
-    private var isSignInDisabled: Bool {
-        if case .loading = viewModel.flowState { return true }
-        return viewModel.serverURL.isEmpty || viewModel.email.isEmpty || viewModel.password.isEmpty
-    }
-
     private func signIn() {
-        guard !isSignInDisabled else { return }
+        guard !viewModel.isSignInDisabled else { return }
         viewModel.signIn()
     }
+
+    private func pickerLabel(for type: ServerType) -> String {
+        switch type {
+        case .cloudUS:   return "Bitwarden US"
+        case .cloudEU:   return "Bitwarden EU"
+        case .selfHosted: return "Self-hosted"
+        }
+    }
 }
-
-

--- a/Prizm/Presentation/Login/LoginViewModel.swift
+++ b/Prizm/Presentation/Login/LoginViewModel.swift
@@ -1,3 +1,4 @@
+import Accessibility
 import Combine
 import Foundation
 import os.log

--- a/Prizm/Presentation/Login/LoginViewModel.swift
+++ b/Prizm/Presentation/Login/LoginViewModel.swift
@@ -136,12 +136,12 @@ final class LoginViewModel: ObservableObject {
                 logger.error("Sign-in failed: \(err.localizedDescription, privacy: .public)")
                 errorMessage = err.errorDescription
                 flowState    = .login
-                postErrorAnnouncement(err.errorDescription ?? err.localizedDescription)
+                postAnnouncement(err.errorDescription ?? err.localizedDescription)
             } catch {
                 logger.error("Sign-in failed: \(error.localizedDescription, privacy: .public)")
                 errorMessage = error.localizedDescription
                 flowState    = .login
-                postErrorAnnouncement(error.localizedDescription)
+                postAnnouncement(error.localizedDescription)
             }
         }
     }
@@ -166,12 +166,12 @@ final class LoginViewModel: ObservableObject {
                 logger.error("TOTP submission failed: \(err.localizedDescription, privacy: .public)")
                 errorMessage = err.errorDescription
                 flowState    = .totpPrompt
-                postErrorAnnouncement(err.errorDescription ?? err.localizedDescription)
+                postAnnouncement(err.errorDescription ?? err.localizedDescription)
             } catch {
                 logger.error("TOTP submission failed: \(error.localizedDescription, privacy: .public)")
                 errorMessage = error.localizedDescription
                 flowState    = .totpPrompt
-                postErrorAnnouncement(error.localizedDescription)
+                postAnnouncement(error.localizedDescription)
             }
         }
     }
@@ -193,12 +193,12 @@ final class LoginViewModel: ObservableObject {
                 logger.error("OTP submission failed: \(err.localizedDescription, privacy: .public)")
                 errorMessage = err.errorDescription
                 flowState    = .otpPrompt
-                postErrorAnnouncement(err.errorDescription ?? err.localizedDescription)
+                postAnnouncement(err.errorDescription ?? err.localizedDescription)
             } catch {
                 logger.error("OTP submission failed: \(error.localizedDescription, privacy: .public)")
                 errorMessage = error.localizedDescription
                 flowState    = .otpPrompt
-                postErrorAnnouncement(error.localizedDescription)
+                postAnnouncement(error.localizedDescription)
             }
         }
     }
@@ -221,12 +221,12 @@ final class LoginViewModel: ObservableObject {
                 logger.error("OTP resend failed: \(err.localizedDescription, privacy: .public)")
                 flowState    = .otpPrompt
                 errorMessage = err.errorDescription
-                postErrorAnnouncement(err.errorDescription ?? err.localizedDescription)
+                postAnnouncement(err.errorDescription ?? err.localizedDescription)
             } catch {
                 logger.error("OTP resend failed: \(error.localizedDescription, privacy: .public)")
                 flowState    = .otpPrompt
                 errorMessage = error.localizedDescription
-                postErrorAnnouncement(error.localizedDescription)
+                postAnnouncement(error.localizedDescription)
             }
         }
     }
@@ -256,9 +256,5 @@ final class LoginViewModel: ObservableObject {
 
     private func postAnnouncement(_ message: String) {
         AccessibilityNotification.Announcement(message).post()
-    }
-
-    private func postErrorAnnouncement(_ message: String) {
-        postAnnouncement(message)
     }
 }

--- a/Prizm/Presentation/Login/LoginViewModel.swift
+++ b/Prizm/Presentation/Login/LoginViewModel.swift
@@ -61,6 +61,12 @@ final class LoginViewModel: ObservableObject {
 
     // MARK: - Computed state
 
+    /// True while an async operation is in flight. Use to disable secondary controls (Resend, Cancel).
+    var isLoading: Bool {
+        if case .loading = flowState { return true }
+        return false
+    }
+
     var isSignInDisabled: Bool {
         switch flowState {
         case .loading:
@@ -99,7 +105,7 @@ final class LoginViewModel: ObservableObject {
 
         Task {
             do {
-                let environment = buildEnvironment()
+                let environment = try buildEnvironment()
                 let result = try await loginUseCase.execute(
                     environment:    environment,
                     email:          email,
@@ -201,20 +207,24 @@ final class LoginViewModel: ObservableObject {
     func resendOTP() {
         logger.info("Resending OTP")
         errorMessage = nil
+        flowState    = .loading
 
         Task {
             do {
                 try await loginUseCase.resendNewDeviceOTP()
-                otpCode = ""
+                flowState = .otpPrompt
+                otpCode   = ""
                 let msg = "A new code has been sent to your email."
                 postAnnouncement(msg)
                 logger.info("OTP resend succeeded")
             } catch let err as AuthError {
                 logger.error("OTP resend failed: \(err.localizedDescription, privacy: .public)")
+                flowState    = .otpPrompt
                 errorMessage = err.errorDescription
                 postErrorAnnouncement(err.errorDescription ?? err.localizedDescription)
             } catch {
                 logger.error("OTP resend failed: \(error.localizedDescription, privacy: .public)")
+                flowState    = .otpPrompt
                 errorMessage = error.localizedDescription
                 postErrorAnnouncement(error.localizedDescription)
             }
@@ -229,7 +239,7 @@ final class LoginViewModel: ObservableObject {
 
     // MARK: - Private helpers
 
-    private func buildEnvironment() -> ServerEnvironment {
+    private func buildEnvironment() throws -> ServerEnvironment {
         switch serverType {
         case .cloudUS:
             return .cloudUS()
@@ -237,7 +247,9 @@ final class LoginViewModel: ObservableObject {
             return .cloudEU()
         case .selfHosted:
             let trimmed = serverURL.hasSuffix("/") ? String(serverURL.dropLast()) : serverURL
-            let base    = URL(string: trimmed) ?? URL(string: "https://")!
+            guard let base = URL(string: trimmed), !trimmed.isEmpty else {
+                throw AuthError.invalidURL
+            }
             return ServerEnvironment(base: base, overrides: nil)
         }
     }

--- a/Prizm/Presentation/Login/LoginViewModel.swift
+++ b/Prizm/Presentation/Login/LoginViewModel.swift
@@ -9,16 +9,14 @@ enum LoginFlowState: Equatable {
     case login
     case loading
     case totpPrompt
+    case otpPrompt
     case syncing(message: String)
     case vault
 }
 
 // MARK: - LoginViewModel
 
-/// ViewModel for the login + 2FA + sync flow (User Story 1).
-///
-/// The Presentation layer uses the Domain protocols directly (`AuthRepository`, `SyncUseCase`)
-/// so it can report per-step progress to the UI.  No Data-layer types are imported here.
+/// ViewModel for the login + 2FA + new-device OTP + sync flow (User Story 1).
 @MainActor
 final class LoginViewModel: ObservableObject {
 
@@ -30,15 +28,54 @@ final class LoginViewModel: ObservableObject {
     @Published var errorMessage: String?
     @Published private(set) var flowState: LoginFlowState = .login
 
+    @Published var serverType: ServerType = .cloudUS {
+        didSet {
+            UserDefaults.standard.set(serverType.rawValue, forKey: Keys.lastServerType)
+        }
+    }
+
+    @Published var otpCode: String = ""
+
     // MARK: - Dependencies
 
     private let loginUseCase: any LoginUseCase
     private let logger = Logger(subsystem: "com.prizm", category: "LoginViewModel")
 
+    private enum Keys {
+        static let lastServerType = "com.prizm.login.lastServerType"
+        static let lastServerURL  = "com.prizm.login.lastServerURL"
+    }
+
     // MARK: - Init
 
     init(loginUseCase: any LoginUseCase) {
         self.loginUseCase = loginUseCase
+        // Restore persisted server type (defaults to cloudUS on fresh install).
+        if let raw  = UserDefaults.standard.string(forKey: Keys.lastServerType),
+           let type = ServerType(rawValue: raw) {
+            serverType = type
+        }
+        // Restore last entered self-hosted URL.
+        serverURL = UserDefaults.standard.string(forKey: Keys.lastServerURL) ?? ""
+    }
+
+    // MARK: - Computed state
+
+    var isSignInDisabled: Bool {
+        switch flowState {
+        case .loading:
+            return true
+        case .otpPrompt:
+            return otpCode.isEmpty
+        default:
+            break
+        }
+        switch serverType {
+        case .cloudUS, .cloudEU:
+            return email.isEmpty || password.isEmpty
+        case .selfHosted:
+            return serverURL.isEmpty || email.isEmpty || password.isEmpty
+        }
     }
 
     // MARK: - Actions
@@ -49,29 +86,28 @@ final class LoginViewModel: ObservableObject {
         errorMessage = nil
         flowState    = .loading
 
-        // Convert the password String to Data at this boundary — the only place the
-        // String-to-bytes conversion happens. `Data` can be zeroed after the KDF call;
-        // `String` cannot (Constitution §III).
-        // Reject empty password here to match the UI's disabled-button guard.
-        // The Task below must never be spawned with an empty credential.
         guard let passwordData = password.data(using: .utf8), !passwordData.isEmpty else {
             errorMessage = "Invalid password encoding."
             flowState    = .login
             return
         }
 
+        // Persist server URL changes when the user is on self-hosted.
+        if serverType == .selfHosted {
+            UserDefaults.standard.set(serverURL, forKey: Keys.lastServerURL)
+        }
+
         Task {
             do {
+                let environment = buildEnvironment()
                 let result = try await loginUseCase.execute(
-                    serverURL:      serverURL,
+                    environment:    environment,
                     email:          email,
                     masterPassword: passwordData
                 )
 
                 switch result {
                 case .success:
-                    // Clear the password field so the plaintext does not linger in
-                    // the published property (and therefore the SwiftUI state graph).
                     password  = ""
                     flowState = .vault
 
@@ -84,16 +120,22 @@ final class LoginViewModel: ObservableObject {
                     }
                     password  = ""
                     flowState = .totpPrompt
+
+                case .requiresNewDeviceOTP:
+                    password  = ""
+                    flowState = .otpPrompt
                 }
 
             } catch let err as AuthError {
                 logger.error("Sign-in failed: \(err.localizedDescription, privacy: .public)")
                 errorMessage = err.errorDescription
                 flowState    = .login
+                postErrorAnnouncement(err.errorDescription ?? err.localizedDescription)
             } catch {
                 logger.error("Sign-in failed: \(error.localizedDescription, privacy: .public)")
                 errorMessage = error.localizedDescription
                 flowState    = .login
+                postErrorAnnouncement(error.localizedDescription)
             }
         }
     }
@@ -118,11 +160,93 @@ final class LoginViewModel: ObservableObject {
                 logger.error("TOTP submission failed: \(err.localizedDescription, privacy: .public)")
                 errorMessage = err.errorDescription
                 flowState    = .totpPrompt
+                postErrorAnnouncement(err.errorDescription ?? err.localizedDescription)
             } catch {
                 logger.error("TOTP submission failed: \(error.localizedDescription, privacy: .public)")
                 errorMessage = error.localizedDescription
                 flowState    = .totpPrompt
+                postErrorAnnouncement(error.localizedDescription)
             }
         }
+    }
+
+    /// Submits the new-device OTP.
+    func submitOTP() {
+        logger.info("OTP submission started")
+        errorMessage = nil
+        flowState    = .loading
+        // Clear OTP immediately so it doesn't linger in the state graph (Constitution §III).
+        let otp = otpCode
+        otpCode = ""
+
+        Task {
+            do {
+                _ = try await loginUseCase.completeNewDeviceOTP(otp: otp)
+                flowState = .vault
+            } catch let err as AuthError {
+                logger.error("OTP submission failed: \(err.localizedDescription, privacy: .public)")
+                errorMessage = err.errorDescription
+                flowState    = .otpPrompt
+                postErrorAnnouncement(err.errorDescription ?? err.localizedDescription)
+            } catch {
+                logger.error("OTP submission failed: \(error.localizedDescription, privacy: .public)")
+                errorMessage = error.localizedDescription
+                flowState    = .otpPrompt
+                postErrorAnnouncement(error.localizedDescription)
+            }
+        }
+    }
+
+    /// Re-sends the new-device OTP email.
+    func resendOTP() {
+        logger.info("Resending OTP")
+        errorMessage = nil
+
+        Task {
+            do {
+                try await loginUseCase.resendNewDeviceOTP()
+                otpCode = ""
+                let msg = "A new code has been sent to your email."
+                postAnnouncement(msg)
+                logger.info("OTP resend succeeded")
+            } catch let err as AuthError {
+                logger.error("OTP resend failed: \(err.localizedDescription, privacy: .public)")
+                errorMessage = err.errorDescription
+                postErrorAnnouncement(err.errorDescription ?? err.localizedDescription)
+            } catch {
+                logger.error("OTP resend failed: \(error.localizedDescription, privacy: .public)")
+                errorMessage = error.localizedDescription
+                postErrorAnnouncement(error.localizedDescription)
+            }
+        }
+    }
+
+    /// Cancels the new-device OTP challenge and returns to the login screen.
+    func cancelOTP() {
+        loginUseCase.cancelNewDeviceOTP()
+        flowState = .login
+    }
+
+    // MARK: - Private helpers
+
+    private func buildEnvironment() -> ServerEnvironment {
+        switch serverType {
+        case .cloudUS:
+            return .cloudUS()
+        case .cloudEU:
+            return .cloudEU()
+        case .selfHosted:
+            let trimmed = serverURL.hasSuffix("/") ? String(serverURL.dropLast()) : serverURL
+            let base    = URL(string: trimmed) ?? URL(string: "https://")!
+            return ServerEnvironment(base: base, overrides: nil)
+        }
+    }
+
+    private func postAnnouncement(_ message: String) {
+        AccessibilityNotification.Announcement(message).post()
+    }
+
+    private func postErrorAnnouncement(_ message: String) {
+        postAnnouncement(message)
     }
 }

--- a/Prizm/Presentation/Login/LoginViewModel.swift
+++ b/Prizm/Presentation/Login/LoginViewModel.swift
@@ -105,9 +105,9 @@ final class LoginViewModel: ObservableObject {
 
         Task {
             do {
-                let environment = try buildEnvironment()
                 let result = try await loginUseCase.execute(
-                    environment:    environment,
+                    serverType:     serverType,
+                    serverURL:      serverURL,
                     email:          email,
                     masterPassword: passwordData
                 )
@@ -238,21 +238,6 @@ final class LoginViewModel: ObservableObject {
     }
 
     // MARK: - Private helpers
-
-    private func buildEnvironment() throws -> ServerEnvironment {
-        switch serverType {
-        case .cloudUS:
-            return .cloudUS()
-        case .cloudEU:
-            return .cloudEU()
-        case .selfHosted:
-            let trimmed = serverURL.hasSuffix("/") ? String(serverURL.dropLast()) : serverURL
-            guard let base = URL(string: trimmed), !trimmed.isEmpty else {
-                throw AuthError.invalidURL
-            }
-            return ServerEnvironment(base: base, overrides: nil)
-        }
-    }
 
     private func postAnnouncement(_ message: String) {
         AccessibilityNotification.Announcement(message).post()

--- a/Prizm/Presentation/Login/NewDeviceOTPView.swift
+++ b/Prizm/Presentation/Login/NewDeviceOTPView.swift
@@ -75,6 +75,7 @@ struct NewDeviceOTPView: View {
             }
             .buttonStyle(.borderless)
             .foregroundStyle(.secondary)
+            .disabled(viewModel.isLoading)
             .accessibilityIdentifier(AccessibilityID.Login.resendOtpButton)
             .accessibilityLabel("Resend code")
 
@@ -84,6 +85,7 @@ struct NewDeviceOTPView: View {
             }
             .buttonStyle(.borderless)
             .foregroundStyle(.secondary)
+            .disabled(viewModel.isLoading)
             .accessibilityIdentifier(AccessibilityID.Login.cancelOtpButton)
             .accessibilityLabel("Cancel")
 
@@ -92,7 +94,10 @@ struct NewDeviceOTPView: View {
         .padding(.horizontal, Spacing.screenHorizontal)
         .padding(.bottom, 32)
         .frame(minWidth: 480, minHeight: 360)
-        .onAppear { otpFieldFocused = true }
+        .onAppear {
+            otpFieldFocused = true
+            AccessibilityNotification.Announcement("Check your email for a verification code").post()
+        }
     }
 
     // MARK: - Private

--- a/Prizm/Presentation/Login/NewDeviceOTPView.swift
+++ b/Prizm/Presentation/Login/NewDeviceOTPView.swift
@@ -22,6 +22,7 @@ struct NewDeviceOTPView: View {
                 Text("Check your email")
                     .font(Typography.screenHeading)
                     .accessibilityAddTraits(.isHeader)
+                    .accessibilityIdentifier(AccessibilityID.Login.newDeviceOtpHeader)
                 Text("Check your email for a verification code.")
                     .font(Typography.fieldLabel)
                     .foregroundStyle(.secondary)

--- a/Prizm/Presentation/Login/NewDeviceOTPView.swift
+++ b/Prizm/Presentation/Login/NewDeviceOTPView.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+// MARK: - NewDeviceOTPView
+
+/// Verification screen shown when the Bitwarden Cloud server does not recognise the device
+/// (HTTP 400, `"error": "device_error"`). The user must enter the one-time code sent to
+/// their registered email address to complete the login.
+struct NewDeviceOTPView: View {
+
+    @ObservedObject var viewModel: LoginViewModel
+
+    @FocusState private var otpFieldFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 24) {
+            // MARK: Header
+            VStack(spacing: 4) {
+                Image(systemName: "envelope.badge.shield.half.filled.fill")
+                    .font(Typography.screenIcon)
+                    .foregroundStyle(.tint)
+                    .accessibilityHidden(true)
+                Text("Check your email")
+                    .font(Typography.screenHeading)
+                    .accessibilityAddTraits(.isHeader)
+                Text("Check your email for a verification code.")
+                    .font(Typography.fieldLabel)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.top, 24)
+
+            // MARK: OTP field
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Verification code")
+                    .font(Typography.fieldLabelProminent)
+                    .foregroundStyle(.secondary)
+                TextField("000000", text: $viewModel.otpCode)
+                    .textFieldStyle(.roundedBorder)
+                    .focused($otpFieldFocused)
+                    .frame(width: 200)
+                    .accessibilityIdentifier(AccessibilityID.Login.newDeviceOtpField)
+                    .accessibilityLabel("Verification code")
+                    .onSubmit { submitIfReady() }
+            }
+
+            // MARK: Error message
+            if let error = viewModel.errorMessage {
+                Text(error)
+                    .font(Typography.screenBody)
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 360)
+                    .transition(.opacity)
+                    .accessibilityIdentifier(AccessibilityID.Login.otpErrorMessage)
+            }
+
+            // MARK: Sign In button
+            Button(action: submitIfReady) {
+                if case .loading = viewModel.flowState {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(width: 200)
+                } else {
+                    Text("Sign In")
+                        .frame(width: 200)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(viewModel.isSignInDisabled)
+            .keyboardShortcut(.return, modifiers: [])
+
+            // MARK: Resend button
+            Button("Resend code") {
+                viewModel.resendOTP()
+            }
+            .buttonStyle(.borderless)
+            .foregroundStyle(.secondary)
+            .accessibilityIdentifier(AccessibilityID.Login.resendOtpButton)
+            .accessibilityLabel("Resend code")
+
+            // MARK: Cancel button
+            Button("Cancel") {
+                viewModel.cancelOTP()
+            }
+            .buttonStyle(.borderless)
+            .foregroundStyle(.secondary)
+            .accessibilityIdentifier(AccessibilityID.Login.cancelOtpButton)
+            .accessibilityLabel("Cancel")
+
+            Spacer()
+        }
+        .padding(.horizontal, Spacing.screenHorizontal)
+        .padding(.bottom, 32)
+        .frame(minWidth: 480, minHeight: 360)
+        .onAppear { otpFieldFocused = true }
+    }
+
+    // MARK: - Private
+
+    private func submitIfReady() {
+        guard !viewModel.isSignInDisabled else { return }
+        viewModel.submitOTP()
+    }
+}

--- a/Prizm/Prizm.xcodeproj/project.pbxproj
+++ b/Prizm/Prizm.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		8F900A1B2C3D401718293040 /* CardEditForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A0B1C2D3E4F02829304050 /* CardEditForm.swift */; };
 		967254DE6EE74766B9E011A5 /* OptionalAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136AE7B9ED374714B6D40A4B /* OptionalAnimation.swift */; };
 		98329A0BFD094D69BF05D595 /* TOTPPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F641DA62DF364B3C9D896204 /* TOTPPromptView.swift */; };
+		AA1234567890ABCDEF123456 /* NewDeviceOTPView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1234567890ABCDEF123456 /* NewDeviceOTPView.swift */; };
 		98E8E51C9AD5496C88E0ABD3 /* FaviconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87629CFF5CFE4B4FA41EFC3C /* FaviconView.swift */; };
 		9B3412B1F4F648DEBC7BFC94 /* ContrastAwareOpacity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505C5126B6264355A140762B /* ContrastAwareOpacity.swift */; };
 		9D5A14583F6A4B3BAF956201 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 713C4F352B6B4E8C92BB72B1 /* LoginViewModel.swift */; };
@@ -317,6 +318,7 @@
 		F600A1B2C3D4E08E80900A1B /* SSHKeyEditForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHKeyEditForm.swift; sourceTree = "<group>"; };
 		F607182930405A6CE8F90A1B /* EditVaultItemUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditVaultItemUseCaseImpl.swift; sourceTree = "<group>"; };
 		F641DA62DF364B3C9D896204 /* TOTPPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOTPPromptView.swift; sourceTree = "<group>"; };
+		BB1234567890ABCDEF123456 /* NewDeviceOTPView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewDeviceOTPView.swift; sourceTree = "<group>"; };
 		F8197007AA7E412D96A52B14 /* MaskedFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskedFieldView.swift; sourceTree = "<group>"; };
 		F95EFA050DE64617AC5076CD /* CustomFieldsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldsSection.swift; sourceTree = "<group>"; };
 		FC4A8B1C2F9D34E100123456 /* LocalConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = LocalConfig.xcconfig; sourceTree = SOURCE_ROOT; };
@@ -666,6 +668,7 @@
 				713C4F352B6B4E8C92BB72B1 /* LoginViewModel.swift */,
 				7429BBFA10E247D8AEACA59B /* LoginView.swift */,
 				F641DA62DF364B3C9D896204 /* TOTPPromptView.swift */,
+				BB1234567890ABCDEF123456 /* NewDeviceOTPView.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -926,6 +929,7 @@
 				9D5A14583F6A4B3BAF956201 /* LoginViewModel.swift in Sources */,
 				5D0EC041FE98478CA9C6601B /* LoginView.swift in Sources */,
 				98329A0BFD094D69BF05D595 /* TOTPPromptView.swift in Sources */,
+				AA1234567890ABCDEF123456 /* NewDeviceOTPView.swift in Sources */,
 				A2D9C5FB40924655AABA3088 /* SyncProgressView.swift in Sources */,
 				DB71D59F021648E1982C90FA /* UnlockView.swift in Sources */,
 				E2AAA6708B2A46FA85BE5860 /* Presentation/Unlock/BiometricEnrollmentPromptView.swift in Sources */,

--- a/Prizm/Prizm/Info.plist
+++ b/Prizm/Prizm/Info.plist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>BWClientIdentifier</key>
+	<string>$(BW_CLIENT_IDENTIFIER)</string>
+</dict>
 </plist>

--- a/Prizm/PrizmTests/Data/AuthRepositoryImplTests.swift
+++ b/Prizm/PrizmTests/Data/AuthRepositoryImplTests.swift
@@ -428,15 +428,17 @@ final class AuthRepositoryImplTests: XCTestCase {
         mockAPI.tokenShouldThrow = nil
         mockAPI.tokenResponse    = makeTokenResponse()
         _ = try await sutWithId.loginWithNewDeviceOTP("123456")
-        // Calling again should throw because pending state was cleared.
+        // Calling again should throw otpSessionExpired because pending state was cleared.
         await XCTAssertThrowsErrorAsync(
             try await sutWithId.loginWithNewDeviceOTP("000000")
         ) { error in
-            XCTAssertEqual(error as? AuthError, .invalidCredentials)
+            XCTAssertEqual(error as? AuthError, .otpSessionExpired)
         }
     }
 
-    func testLoginWithNewDeviceOTP_failure_clearsPendingState() async throws {
+    // MARK: - 8.7: wrong OTP preserves pending state so user can retry
+
+    func testLoginWithNewDeviceOTP_failure_preservesPendingForRetry() async throws {
         let sutWithId = AuthRepositoryImpl(
             apiClient:        mockAPI,
             crypto:           mockCrypto,
@@ -449,15 +451,14 @@ final class AuthRepositoryImplTests: XCTestCase {
         mockAPI.tokenShouldThrow     = IdentityTokenError.newDeviceNotVerified
         mockCrypto.stubbedServerHash = "hash=="
         _ = try await sutWithId.loginWithPassword(email: "a@b.com", masterPassword: Data("pw".utf8))
-        // OTP call fails.
+        // First OTP attempt fails — wrong code.
         mockAPI.tokenShouldThrow = IdentityTokenError.invalidCredentials
         _ = try? await sutWithId.loginWithNewDeviceOTP("000000")
-        // Pending state should be cleared even on failure — second call throws.
-        await XCTAssertThrowsErrorAsync(
-            try await sutWithId.loginWithNewDeviceOTP("111111")
-        ) { error in
-            XCTAssertEqual(error as? AuthError, .invalidCredentials)
-        }
+        // Pending state must be preserved so the user can retry with the correct code.
+        mockAPI.tokenShouldThrow = nil
+        mockAPI.tokenResponse    = makeTokenResponse()
+        let account = try await sutWithId.loginWithNewDeviceOTP("123456")
+        XCTAssertEqual(account.email, "a@b.com", "Retry with correct OTP should succeed")
     }
 
     // MARK: - 8.8: pending OTP state cleared after cancelNewDeviceOTP
@@ -476,11 +477,11 @@ final class AuthRepositoryImplTests: XCTestCase {
         mockCrypto.stubbedServerHash = "hash=="
         _ = try await sutWithId.loginWithPassword(email: "a@b.com", masterPassword: Data("pw".utf8))
         sutWithId.cancelNewDeviceOTP()
-        // loginWithNewDeviceOTP should now throw because pending is nil.
+        // loginWithNewDeviceOTP should now throw otpSessionExpired because pending is nil.
         await XCTAssertThrowsErrorAsync(
             try await sutWithId.loginWithNewDeviceOTP("123456")
         ) { error in
-            XCTAssertEqual(error as? AuthError, .invalidCredentials)
+            XCTAssertEqual(error as? AuthError, .otpSessionExpired)
         }
     }
 

--- a/Prizm/PrizmTests/Data/AuthRepositoryImplTests.swift
+++ b/Prizm/PrizmTests/Data/AuthRepositoryImplTests.swift
@@ -346,6 +346,212 @@ final class AuthRepositoryImplTests: XCTestCase {
         let isUnlocked = mockCrypto.isUnlocked
         XCTAssertFalse(isUnlocked, "Vault should be locked after signOut")
     }
+
+    // MARK: - 8.1: setServerEnvironment forwards to apiClient
+
+    func testSetServerEnvironment_callsApiClientSetServerEnvironment() async throws {
+        let env = ServerEnvironment(base: URL(string: "https://vault.example.com")!, overrides: nil)
+        try await sut.setServerEnvironment(env)
+        XCTAssertNotNil(await mockAPI.serverEnvironment, "apiClient.setServerEnvironment must be called")
+    }
+
+    // MARK: - 8.2: loginWithPassword returns .requiresNewDeviceOTP on device_error
+
+    func testLoginWithPassword_deviceError_returnsRequiresNewDeviceOTP() async throws {
+        let sutWithId = AuthRepositoryImpl(
+            apiClient:        mockAPI,
+            crypto:           mockCrypto,
+            keychain:         mockKeychain,
+            biometricKeychain: mockBiometricKeychain,
+            clientIdentifier: "test-id"
+        )
+        let env = ServerEnvironment.cloudUS()
+        try await sutWithId.setServerEnvironment(env)
+        mockAPI.tokenShouldThrow = IdentityTokenError.newDeviceNotVerified
+        mockCrypto.stubbedServerHash = "hash=="
+
+        let result = try await sutWithId.loginWithPassword(
+            email: "a@b.com",
+            masterPassword: Data("pw".utf8)
+        )
+
+        guard case .requiresNewDeviceOTP = result else {
+            return XCTFail("Expected .requiresNewDeviceOTP, got \(result)")
+        }
+    }
+
+    // MARK: - 8.3: clientIdentifierNotConfigured for cloud with empty identifier
+
+    func testLoginWithPassword_cloudWithEmptyClientId_throwsClientIdentifierNotConfigured() async throws {
+        let sutNoId = AuthRepositoryImpl(
+            apiClient:        mockAPI,
+            crypto:           mockCrypto,
+            keychain:         mockKeychain,
+            biometricKeychain: mockBiometricKeychain,
+            clientIdentifier: ""
+        )
+        let env = ServerEnvironment.cloudUS()
+        try await sutNoId.setServerEnvironment(env)
+
+        await XCTAssertThrowsErrorAsync(
+            try await sutNoId.loginWithPassword(
+                email: "a@b.com",
+                masterPassword: Data("pw".utf8)
+            )
+        ) { error in
+            XCTAssertEqual(error as? AuthError, .clientIdentifierNotConfigured)
+        }
+
+        XCTAssertFalse(mockAPI.preLoginResponse != nil || mockAPI.tokenShouldThrow != nil,
+                       "No network call should be made when clientIdentifier is empty")
+        // preLogin should NOT have been called — tokenResponse is nil means no request was made
+        XCTAssertNil(mockAPI.lastIdentityTokenNewDeviceOTP, "identityToken must not be called")
+    }
+
+    // MARK: - 8.6/8.7: pending OTP state cleared after loginWithNewDeviceOTP (success and failure)
+
+    func testLoginWithNewDeviceOTP_success_clearsPendingState() async throws {
+        let sutWithId = AuthRepositoryImpl(
+            apiClient:        mockAPI,
+            crypto:           mockCrypto,
+            keychain:         mockKeychain,
+            biometricKeychain: mockBiometricKeychain,
+            clientIdentifier: "test-id"
+        )
+        let env = ServerEnvironment.cloudUS()
+        try await sutWithId.setServerEnvironment(env)
+        // Trigger pending state via device_error, then succeed on OTP.
+        mockAPI.tokenShouldThrow  = IdentityTokenError.newDeviceNotVerified
+        mockCrypto.stubbedServerHash = "hash=="
+        _ = try await sutWithId.loginWithPassword(email: "a@b.com", masterPassword: Data("pw".utf8))
+        // Now set up success response for OTP submission.
+        mockAPI.tokenShouldThrow = nil
+        mockAPI.tokenResponse    = makeTokenResponse()
+        _ = try await sutWithId.loginWithNewDeviceOTP("123456")
+        // Calling again should throw because pending state was cleared.
+        await XCTAssertThrowsErrorAsync(
+            try await sutWithId.loginWithNewDeviceOTP("000000")
+        ) { error in
+            XCTAssertEqual(error as? AuthError, .invalidCredentials)
+        }
+    }
+
+    func testLoginWithNewDeviceOTP_failure_clearsPendingState() async throws {
+        let sutWithId = AuthRepositoryImpl(
+            apiClient:        mockAPI,
+            crypto:           mockCrypto,
+            keychain:         mockKeychain,
+            biometricKeychain: mockBiometricKeychain,
+            clientIdentifier: "test-id"
+        )
+        let env = ServerEnvironment.cloudUS()
+        try await sutWithId.setServerEnvironment(env)
+        mockAPI.tokenShouldThrow     = IdentityTokenError.newDeviceNotVerified
+        mockCrypto.stubbedServerHash = "hash=="
+        _ = try await sutWithId.loginWithPassword(email: "a@b.com", masterPassword: Data("pw".utf8))
+        // OTP call fails.
+        mockAPI.tokenShouldThrow = IdentityTokenError.invalidCredentials
+        _ = try? await sutWithId.loginWithNewDeviceOTP("000000")
+        // Pending state should be cleared even on failure — second call throws.
+        await XCTAssertThrowsErrorAsync(
+            try await sutWithId.loginWithNewDeviceOTP("111111")
+        ) { error in
+            XCTAssertEqual(error as? AuthError, .invalidCredentials)
+        }
+    }
+
+    // MARK: - 8.8: pending OTP state cleared after cancelNewDeviceOTP
+
+    func testCancelNewDeviceOTP_clearsPendingState() async throws {
+        let sutWithId = AuthRepositoryImpl(
+            apiClient:        mockAPI,
+            crypto:           mockCrypto,
+            keychain:         mockKeychain,
+            biometricKeychain: mockBiometricKeychain,
+            clientIdentifier: "test-id"
+        )
+        let env = ServerEnvironment.cloudUS()
+        try await sutWithId.setServerEnvironment(env)
+        mockAPI.tokenShouldThrow     = IdentityTokenError.newDeviceNotVerified
+        mockCrypto.stubbedServerHash = "hash=="
+        _ = try await sutWithId.loginWithPassword(email: "a@b.com", masterPassword: Data("pw".utf8))
+        sutWithId.cancelNewDeviceOTP()
+        // loginWithNewDeviceOTP should now throw because pending is nil.
+        await XCTAssertThrowsErrorAsync(
+            try await sutWithId.loginWithNewDeviceOTP("123456")
+        ) { error in
+            XCTAssertEqual(error as? AuthError, .invalidCredentials)
+        }
+    }
+
+    // MARK: - 8.9: requestNewDeviceOTP does NOT clear pending state
+
+    func testRequestNewDeviceOTP_doesNotClearPendingState() async throws {
+        let sutWithId = AuthRepositoryImpl(
+            apiClient:        mockAPI,
+            crypto:           mockCrypto,
+            keychain:         mockKeychain,
+            biometricKeychain: mockBiometricKeychain,
+            clientIdentifier: "test-id"
+        )
+        let env = ServerEnvironment.cloudUS()
+        try await sutWithId.setServerEnvironment(env)
+        mockAPI.tokenShouldThrow     = IdentityTokenError.newDeviceNotVerified
+        mockCrypto.stubbedServerHash = "hash=="
+        _ = try await sutWithId.loginWithPassword(email: "a@b.com", masterPassword: Data("pw".utf8))
+        // requestNewDeviceOTP throws device_error again (expected behavior — treated as success).
+        try await sutWithId.requestNewDeviceOTP()
+        // Pending state must still be intact — loginWithNewDeviceOTP should not throw invalidCredentials.
+        // (It will throw because tokenShouldThrow is still set, but not with invalidCredentials from nil pending.)
+        mockAPI.tokenShouldThrow = nil
+        mockAPI.tokenResponse    = makeTokenResponse()
+        _ = try await sutWithId.loginWithNewDeviceOTP("123456")
+        // If we got here, pending was not cleared by requestNewDeviceOTP.
+    }
+
+    // MARK: - 8.10: OTP retry includes newdeviceotp parameter
+
+    func testLoginWithNewDeviceOTP_passesOTPToApiClient() async throws {
+        let sutWithId = AuthRepositoryImpl(
+            apiClient:        mockAPI,
+            crypto:           mockCrypto,
+            keychain:         mockKeychain,
+            biometricKeychain: mockBiometricKeychain,
+            clientIdentifier: "test-id"
+        )
+        let env = ServerEnvironment.cloudUS()
+        try await sutWithId.setServerEnvironment(env)
+        mockAPI.tokenShouldThrow     = IdentityTokenError.newDeviceNotVerified
+        mockCrypto.stubbedServerHash = "hash=="
+        _ = try await sutWithId.loginWithPassword(email: "a@b.com", masterPassword: Data("pw".utf8))
+        mockAPI.tokenShouldThrow = nil
+        mockAPI.tokenResponse    = makeTokenResponse()
+        _ = try await sutWithId.loginWithNewDeviceOTP("654321")
+        XCTAssertEqual(mockAPI.lastIdentityTokenNewDeviceOTP, "654321",
+                       "loginWithNewDeviceOTP must pass the OTP to identityToken")
+    }
+
+    // MARK: - Helpers
+
+    private func makeTokenResponse() -> TokenResponse {
+        TokenResponse(
+            accessToken:  "at",
+            refreshToken: "rt",
+            tokenType:    "Bearer",
+            expiresIn:    3600,
+            key:          "2.k==",
+            privateKey:   nil,
+            kdf:          0,
+            kdfIterations: 600_000,
+            kdfMemory:     nil,
+            kdfParallelism: nil,
+            twoFactorToken:     nil,
+            twoFactorProviders: nil,
+            userId: "uid",
+            email:  "a@b.com",
+            name:   nil
+        )
+    }
 }
 
 // MARK: - Async XCTAssertThrowsError helper

--- a/Prizm/PrizmTests/Data/LoginUseCaseTests.swift
+++ b/Prizm/PrizmTests/Data/LoginUseCaseTests.swift
@@ -1,8 +1,6 @@
 import XCTest
 @testable import Prizm
 
-/// Failing tests for LoginUseCaseImpl (T026).
-/// These will fail until LoginUseCaseImpl + AuthRepositoryImpl + SyncRepositoryImpl are implemented.
 @MainActor
 final class LoginUseCaseTests: XCTestCase {
 
@@ -10,7 +8,10 @@ final class LoginUseCaseTests: XCTestCase {
     private var mockAuth: MockAuthRepository!
     private var mockSync: MockSyncRepository!
 
-    private let serverURL      = "https://vault.example.com"
+    private let selfHostedEnv = ServerEnvironment(
+        base: URL(string: "https://vault.example.com")!,
+        overrides: nil
+    )
     private let email          = "alice@example.com"
     private let masterPassword = Data("masterPassword1!".utf8)
 
@@ -21,15 +22,14 @@ final class LoginUseCaseTests: XCTestCase {
         sut = LoginUseCaseImpl(auth: mockAuth, sync: mockSync)
     }
 
-    // MARK: - T026: execute(serverURL:email:masterPassword:)
+    // MARK: - execute: self-hosted success path
 
-    /// Full success path: validates URL, sets environment, calls loginWithPassword, syncs, returns .success.
     func testExecute_validCredentials_returnsSuccessAndSyncs() async throws {
-        mockAuth.stubbedLoginResult  = .success(makeAccount())
-        mockSync.stubbedSyncResult   = makeSyncResult()
+        mockAuth.stubbedLoginResult = .success(makeAccount())
+        mockSync.stubbedSyncResult  = makeSyncResult()
 
         let result = try await sut.execute(
-            serverURL:      serverURL,
+            environment:    selfHostedEnv,
             email:          email,
             masterPassword: masterPassword
         )
@@ -43,14 +43,15 @@ final class LoginUseCaseTests: XCTestCase {
         XCTAssertTrue(mockSync.syncCalled,                 "Expected sync to be called after login")
     }
 
-    /// An invalid server URL is rejected before any network call is made.
-    func testExecute_invalidURL_throwsBeforeNetwork() async throws {
+    // MARK: - execute: self-hosted URL validation
+
+    func testExecute_selfHosted_invalidURL_throwsBeforeNetwork() async throws {
         mockAuth.validateServerURLError = AuthError.invalidURL
 
         let sut = self.sut!
         await XCTAssertThrowsErrorAsync(
             try await sut.execute(
-                serverURL:      "not-a-url",
+                environment:    selfHostedEnv,
                 email:          email,
                 masterPassword: masterPassword
             )
@@ -62,13 +63,43 @@ final class LoginUseCaseTests: XCTestCase {
         XCTAssertFalse(mockSync.syncCalled,              "Sync must not be called on invalid URL")
     }
 
-    /// When loginWithPassword returns .requiresTwoFactor, the use case returns the same result
-    /// without triggering a sync.
+    // MARK: - 8.4: cloud skips validateServerURL
+
+    func testExecute_cloudUS_doesNotCallValidateServerURL() async throws {
+        mockAuth.stubbedLoginResult = .success(makeAccount())
+
+        _ = try await sut.execute(
+            environment:    .cloudUS(),
+            email:          email,
+            masterPassword: masterPassword
+        )
+
+        XCTAssertFalse(mockAuth.validateServerURLCalled,
+                       "validateServerURL must NOT be called for cloud environments")
+    }
+
+    // MARK: - 8.5: self-hosted calls validateServerURL
+
+    func testExecute_selfHosted_callsValidateServerURL() async throws {
+        mockAuth.stubbedLoginResult = .success(makeAccount())
+
+        _ = try await sut.execute(
+            environment:    selfHostedEnv,
+            email:          email,
+            masterPassword: masterPassword
+        )
+
+        XCTAssertTrue(mockAuth.validateServerURLCalled,
+                      "validateServerURL must be called for self-hosted environments")
+    }
+
+    // MARK: - execute: 2FA
+
     func testExecute_requires2FA_returnsTwoFactorWithoutSync() async throws {
         mockAuth.stubbedLoginResult = .requiresTwoFactor(.authenticatorApp)
 
         let result = try await sut.execute(
-            serverURL:      serverURL,
+            environment:    selfHostedEnv,
             email:          email,
             masterPassword: masterPassword
         )
@@ -82,14 +113,32 @@ final class LoginUseCaseTests: XCTestCase {
         XCTAssertFalse(mockSync.syncCalled, "Sync must not be called when 2FA is required")
     }
 
-    /// Invalid credentials propagate as AuthError.invalidCredentials.
+    // MARK: - execute: new-device OTP
+
+    func testExecute_requiresNewDeviceOTP_returnsOTPWithoutSync() async throws {
+        mockAuth.stubbedLoginResult = .requiresNewDeviceOTP
+
+        let result = try await sut.execute(
+            environment:    .cloudUS(),
+            email:          email,
+            masterPassword: masterPassword
+        )
+
+        guard case .requiresNewDeviceOTP = result else {
+            return XCTFail("Expected .requiresNewDeviceOTP, got \(result)")
+        }
+        XCTAssertFalse(mockSync.syncCalled, "Sync must not be called when OTP is required")
+    }
+
+    // MARK: - execute: invalid credentials
+
     func testExecute_invalidCredentials_throws() async throws {
         mockAuth.loginWithPasswordError = AuthError.invalidCredentials
 
         let sut = self.sut!
         await XCTAssertThrowsErrorAsync(
             try await sut.execute(
-                serverURL:      serverURL,
+                environment:    selfHostedEnv,
                 email:          email,
                 masterPassword: masterPassword
             )
@@ -100,13 +149,14 @@ final class LoginUseCaseTests: XCTestCase {
         XCTAssertFalse(mockSync.syncCalled, "Sync must not be called on failed login")
     }
 
-    /// A sync failure after successful login is non-fatal — result is still .success (FR-049).
-    func testExecute_syncFailure_throws() async throws {
+    // MARK: - execute: sync failure is non-fatal
+
+    func testExecute_syncFailure_stillReturnsSuccess() async throws {
         mockAuth.stubbedLoginResult = .success(makeAccount())
         mockSync.syncShouldThrow    = SyncError.networkUnavailable
 
         let result = try await sut.execute(
-            serverURL:      serverURL,
+            environment:    selfHostedEnv,
             email:          email,
             masterPassword: masterPassword
         )
@@ -119,11 +169,10 @@ final class LoginUseCaseTests: XCTestCase {
 
     // MARK: - cancelTOTP
 
-    /// cancelTOTP delegates to auth.cancelTwoFactor() — clears pending in-memory key material.
     func testCancelTOTP_callsCancelTwoFactor() async throws {
         mockAuth.stubbedLoginResult = .requiresTwoFactor(.authenticatorApp)
         _ = try await sut.execute(
-            serverURL:      serverURL,
+            environment:    selfHostedEnv,
             email:          email,
             masterPassword: masterPassword
         )
@@ -131,7 +180,30 @@ final class LoginUseCaseTests: XCTestCase {
         sut.cancelTOTP()
 
         XCTAssertTrue(mockAuth.cancelTwoFactorCalled,
-                      "cancelTOTP must forward to auth.cancelTwoFactor to clear pending key material")
+                      "cancelTOTP must forward to auth.cancelTwoFactor")
+    }
+
+    // MARK: - 8.11: completeNewDeviceOTP triggers sync
+
+    func testCompleteNewDeviceOTP_triggersSync() async throws {
+        let account = try await sut.completeNewDeviceOTP(otp: "123456")
+        XCTAssertTrue(mockAuth.loginWithNewDeviceOTPCalled, "Expected loginWithNewDeviceOTP to be called")
+        XCTAssertTrue(mockSync.syncCalled,                  "Expected sync after OTP success")
+        XCTAssertEqual(account.email, mockAuth.stubbedLoginResult.account?.email)
+    }
+
+    // MARK: - 8.12: cancelNewDeviceOTP delegates to auth
+
+    func testCancelNewDeviceOTP_callsAuthCancel() {
+        sut.cancelNewDeviceOTP()
+        XCTAssertTrue(mockAuth.cancelNewDeviceOTPCalled)
+    }
+
+    // MARK: - 8.13: resendNewDeviceOTP delegates to auth
+
+    func testResendNewDeviceOTP_callsAuthRequest() async throws {
+        try await sut.resendNewDeviceOTP()
+        XCTAssertTrue(mockAuth.requestNewDeviceOTPCalled)
     }
 
     // MARK: - Helpers
@@ -141,14 +213,20 @@ final class LoginUseCaseTests: XCTestCase {
             userId:            "user-guid-001",
             email:             email,
             name:              "Alice",
-            serverEnvironment: ServerEnvironment(
-                base:      URL(string: "https://vault.example.com")!,
-                overrides: nil
-            )
+            serverEnvironment: selfHostedEnv
         )
     }
 
     private func makeSyncResult() -> SyncResult {
         SyncResult(syncedAt: Date(), totalCiphers: 0, failedDecryptionCount: 0)
+    }
+}
+
+// MARK: - LoginResult helper for tests
+
+private extension LoginResult {
+    var account: Account? {
+        if case .success(let a) = self { return a }
+        return nil
     }
 }

--- a/Prizm/PrizmTests/Data/LoginUseCaseTests.swift
+++ b/Prizm/PrizmTests/Data/LoginUseCaseTests.swift
@@ -8,10 +8,7 @@ final class LoginUseCaseTests: XCTestCase {
     private var mockAuth: MockAuthRepository!
     private var mockSync: MockSyncRepository!
 
-    private let selfHostedEnv = ServerEnvironment(
-        base: URL(string: "https://vault.example.com")!,
-        overrides: nil
-    )
+    private let selfHostedURL  = "https://vault.example.com"
     private let email          = "alice@example.com"
     private let masterPassword = Data("masterPassword1!".utf8)
 
@@ -29,7 +26,8 @@ final class LoginUseCaseTests: XCTestCase {
         mockSync.stubbedSyncResult  = makeSyncResult()
 
         let result = try await sut.execute(
-            environment:    selfHostedEnv,
+            serverType:     .selfHosted,
+            serverURL:      selfHostedURL,
             email:          email,
             masterPassword: masterPassword
         )
@@ -51,7 +49,8 @@ final class LoginUseCaseTests: XCTestCase {
         let sut = self.sut!
         await XCTAssertThrowsErrorAsync(
             try await sut.execute(
-                environment:    selfHostedEnv,
+                serverType:     .selfHosted,
+                serverURL:      selfHostedURL,
                 email:          email,
                 masterPassword: masterPassword
             )
@@ -69,7 +68,8 @@ final class LoginUseCaseTests: XCTestCase {
         mockAuth.stubbedLoginResult = .success(makeAccount())
 
         _ = try await sut.execute(
-            environment:    .cloudUS(),
+            serverType:     .cloudUS,
+            serverURL:      "",
             email:          email,
             masterPassword: masterPassword
         )
@@ -84,7 +84,8 @@ final class LoginUseCaseTests: XCTestCase {
         mockAuth.stubbedLoginResult = .success(makeAccount())
 
         _ = try await sut.execute(
-            environment:    selfHostedEnv,
+            serverType:     .selfHosted,
+            serverURL:      selfHostedURL,
             email:          email,
             masterPassword: masterPassword
         )
@@ -99,7 +100,8 @@ final class LoginUseCaseTests: XCTestCase {
         mockAuth.stubbedLoginResult = .requiresTwoFactor(.authenticatorApp)
 
         let result = try await sut.execute(
-            environment:    selfHostedEnv,
+            serverType:     .selfHosted,
+            serverURL:      selfHostedURL,
             email:          email,
             masterPassword: masterPassword
         )
@@ -119,7 +121,8 @@ final class LoginUseCaseTests: XCTestCase {
         mockAuth.stubbedLoginResult = .requiresNewDeviceOTP
 
         let result = try await sut.execute(
-            environment:    .cloudUS(),
+            serverType:     .cloudUS,
+            serverURL:      "",
             email:          email,
             masterPassword: masterPassword
         )
@@ -138,7 +141,8 @@ final class LoginUseCaseTests: XCTestCase {
         let sut = self.sut!
         await XCTAssertThrowsErrorAsync(
             try await sut.execute(
-                environment:    selfHostedEnv,
+                serverType:     .selfHosted,
+                serverURL:      selfHostedURL,
                 email:          email,
                 masterPassword: masterPassword
             )
@@ -156,7 +160,8 @@ final class LoginUseCaseTests: XCTestCase {
         mockSync.syncShouldThrow    = SyncError.networkUnavailable
 
         let result = try await sut.execute(
-            environment:    selfHostedEnv,
+            serverType:     .selfHosted,
+            serverURL:      selfHostedURL,
             email:          email,
             masterPassword: masterPassword
         )
@@ -172,7 +177,8 @@ final class LoginUseCaseTests: XCTestCase {
     func testCancelTOTP_callsCancelTwoFactor() async throws {
         mockAuth.stubbedLoginResult = .requiresTwoFactor(.authenticatorApp)
         _ = try await sut.execute(
-            environment:    selfHostedEnv,
+            serverType:     .selfHosted,
+            serverURL:      selfHostedURL,
             email:          email,
             masterPassword: masterPassword
         )
@@ -213,7 +219,7 @@ final class LoginUseCaseTests: XCTestCase {
             userId:            "user-guid-001",
             email:             email,
             name:              "Alice",
-            serverEnvironment: selfHostedEnv
+            serverEnvironment: ServerEnvironment(base: URL(string: selfHostedURL)!, overrides: nil)
         )
     }
 

--- a/Prizm/PrizmTests/Data/PrizmAPIClientImplTests.swift
+++ b/Prizm/PrizmTests/Data/PrizmAPIClientImplTests.swift
@@ -1,0 +1,290 @@
+import XCTest
+@testable import Prizm
+
+// MARK: - CapturingURLProtocol
+
+/// URLProtocol subclass that captures every outbound request and returns a configured response.
+/// Class-level state is intentionally nonisolated(unsafe) — tests run serially in one process.
+final class CapturingURLProtocol: URLProtocol {
+
+    nonisolated(unsafe) static var capturedRequests: [URLRequest] = []
+    nonisolated(unsafe) static var nextStatusCode: Int = 200
+    nonisolated(unsafe) static var nextResponseData: Data = Data("{}".utf8)
+
+    static var lastRequest: URLRequest? { capturedRequests.last }
+
+    static func reset() {
+        capturedRequests   = []
+        nextStatusCode     = 200
+        nextResponseData   = Data("{}".utf8)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        // URLSession moves httpBody into httpBodyStream; read it back so tests can inspect it.
+        var captured = request
+        if let stream = request.httpBodyStream {
+            var body = Data()
+            stream.open()
+            let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: 1024)
+            defer { buf.deallocate() }
+            while stream.hasBytesAvailable {
+                let n = stream.read(buf, maxLength: 1024)
+                if n > 0 { body.append(buf, count: n) }
+            }
+            stream.close()
+            captured.httpBody = body
+        }
+        CapturingURLProtocol.capturedRequests.append(captured)
+
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: CapturingURLProtocol.nextStatusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: CapturingURLProtocol.nextResponseData)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - PrizmAPIClientImplTests
+
+@MainActor
+final class PrizmAPIClientImplTests: XCTestCase {
+
+    private var sut: PrizmAPIClientImpl!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        CapturingURLProtocol.reset()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [CapturingURLProtocol.self]
+        let session = URLSession(configuration: config)
+        sut = PrizmAPIClientImpl(session: session)
+    }
+
+    // MARK: - 6.1: cloudUS preLogin URL
+
+    func testCloudUS_preLogin_usesCorrectURL() async throws {
+        await sut.setServerEnvironment(.cloudUS())
+        CapturingURLProtocol.nextResponseData = preLoginJSON()
+
+        _ = try await sut.preLogin(email: "t@t.com")
+
+        XCTAssertEqual(
+            CapturingURLProtocol.lastRequest?.url?.absoluteString,
+            "https://api.bitwarden.com/accounts/prelogin"
+        )
+    }
+
+    // MARK: - 6.2: cloudEU identityToken URL
+
+    func testCloudEU_identityToken_usesCorrectURL() async throws {
+        await sut.setServerEnvironment(.cloudEU())
+        // Return 400 device_error — we just need the URL to be captured before the throw.
+        CapturingURLProtocol.nextStatusCode    = 400
+        CapturingURLProtocol.nextResponseData  = Data(#"{"error":"device_error"}"#.utf8)
+
+        do {
+            _ = try await sut.identityToken(
+                email: "t@t.com", passwordHash: "hash",
+                deviceIdentifier: "dev-id",
+                twoFactorToken: nil, twoFactorProvider: nil, twoFactorRemember: false,
+                newDeviceOTP: nil
+            )
+        } catch { /* expected throw */ }
+
+        XCTAssertEqual(
+            CapturingURLProtocol.lastRequest?.url?.absoluteString,
+            "https://identity.bitwarden.eu/connect/token"
+        )
+    }
+
+    // MARK: - 6.3: cloudEU refreshAccessToken URL
+
+    func testCloudEU_refreshAccessToken_usesCorrectURL() async throws {
+        await sut.setServerEnvironment(.cloudEU())
+        CapturingURLProtocol.nextResponseData = refreshTokenJSON()
+
+        _ = try await sut.refreshAccessToken(refreshToken: "rt")
+
+        XCTAssertEqual(
+            CapturingURLProtocol.lastRequest?.url?.absoluteString,
+            "https://identity.bitwarden.eu/connect/token"
+        )
+    }
+
+    // MARK: - 6.4: selfHosted fetchSync URL includes /api/ prefix
+
+    func testSelfHosted_fetchSync_retainsApiPrefix() async throws {
+        let base = URL(string: "https://vault.example.com")!
+        await sut.setServerEnvironment(ServerEnvironment(base: base, overrides: nil))
+        CapturingURLProtocol.nextResponseData = syncJSON()
+
+        _ = try await sut.fetchSync()
+
+        let urlString = CapturingURLProtocol.lastRequest?.url?.absoluteString ?? ""
+        XCTAssertTrue(
+            urlString.hasPrefix("https://vault.example.com/api/sync"),
+            "Expected self-hosted URL to include /api/ prefix, got: \(urlString)"
+        )
+    }
+
+    // MARK: - 6.5: no environment → serverEnvironmentNotSet
+
+    func testNoEnvironment_throwsServerEnvironmentNotSet() async throws {
+        do {
+            _ = try await sut.preLogin(email: "t@t.com")
+            XCTFail("Expected APIError.serverEnvironmentNotSet")
+        } catch APIError.serverEnvironmentNotSet {
+            // pass
+        }
+    }
+
+    // MARK: - 6.6: cloud identityToken sends required headers
+
+    func testCloudIdentityToken_sendsClientHeaders() async throws {
+        await sut.setServerEnvironment(.cloudUS())
+        CapturingURLProtocol.nextResponseData = Data(#"{"error":"device_error"}"#.utf8)
+        CapturingURLProtocol.nextStatusCode   = 400
+
+        do {
+            _ = try await sut.identityToken(
+                email: "t@t.com", passwordHash: "hash",
+                deviceIdentifier: "dev-id",
+                twoFactorToken: nil, twoFactorProvider: nil, twoFactorRemember: false,
+                newDeviceOTP: nil
+            )
+        } catch { }
+
+        let headers = CapturingURLProtocol.lastRequest?.allHTTPHeaderFields ?? [:]
+        XCTAssertNotNil(headers["Bitwarden-Client-Name"],    "Bitwarden-Client-Name header required")
+        XCTAssertNotNil(headers["Bitwarden-Client-Version"], "Bitwarden-Client-Version header required")
+    }
+
+    // MARK: - 6.7: cloud identityToken client_id = Config.bitwardenClientIdentifier
+
+    func testCloudIdentityToken_clientId_isRegisteredIdentifier() async throws {
+        await sut.setServerEnvironment(.cloudUS())
+        CapturingURLProtocol.nextResponseData = Data(#"{"error":"device_error"}"#.utf8)
+        CapturingURLProtocol.nextStatusCode   = 400
+
+        do {
+            _ = try await sut.identityToken(
+                email: "t@t.com", passwordHash: "hash",
+                deviceIdentifier: "dev-id",
+                twoFactorToken: nil, twoFactorProvider: nil, twoFactorRemember: false,
+                newDeviceOTP: nil
+            )
+        } catch { }
+
+        let body   = formBody(from: CapturingURLProtocol.lastRequest)
+        let actual = body["client_id"] ?? ""
+        XCTAssertEqual(actual, Config.bitwardenClientIdentifier,
+                       "Cloud client_id must equal Config.bitwardenClientIdentifier")
+        XCTAssertNotEqual(actual, "desktop",
+                          "Cloud client_id must NOT be 'desktop'")
+    }
+
+    // MARK: - 6.8: cloud refreshAccessToken client_id = registered identifier
+
+    func testCloudRefreshToken_clientId_isRegisteredIdentifier() async throws {
+        await sut.setServerEnvironment(.cloudUS())
+        CapturingURLProtocol.nextResponseData = refreshTokenJSON()
+
+        _ = try await sut.refreshAccessToken(refreshToken: "rt")
+
+        let body   = formBody(from: CapturingURLProtocol.lastRequest)
+        let actual = body["client_id"] ?? ""
+        XCTAssertEqual(actual, Config.bitwardenClientIdentifier)
+    }
+
+    // MARK: - 6.9: selfHosted identityToken client_id = "desktop"
+
+    func testSelfHosted_identityToken_clientId_isDesktop() async throws {
+        let base = URL(string: "https://vault.example.com")!
+        await sut.setServerEnvironment(ServerEnvironment(base: base, overrides: nil))
+        CapturingURLProtocol.nextResponseData = Data(#"{"error":"invalid_grant"}"#.utf8)
+        CapturingURLProtocol.nextStatusCode   = 400
+
+        do {
+            _ = try await sut.identityToken(
+                email: "t@t.com", passwordHash: "hash",
+                deviceIdentifier: "dev-id",
+                twoFactorToken: nil, twoFactorProvider: nil, twoFactorRemember: false,
+                newDeviceOTP: nil
+            )
+        } catch { }
+
+        let body   = formBody(from: CapturingURLProtocol.lastRequest)
+        XCTAssertEqual(body["client_id"], "desktop")
+    }
+
+    // MARK: - 6.10: device_error → IdentityTokenError.newDeviceNotVerified
+
+    func testIdentityToken_deviceError_throwsNewDeviceNotVerified() async throws {
+        await sut.setServerEnvironment(.cloudUS())
+        CapturingURLProtocol.nextStatusCode   = 400
+        CapturingURLProtocol.nextResponseData = Data(#"{"error":"device_error","error_description":"No device"}"#.utf8)
+
+        do {
+            _ = try await sut.identityToken(
+                email: "t@t.com", passwordHash: "hash",
+                deviceIdentifier: "dev-id",
+                twoFactorToken: nil, twoFactorProvider: nil, twoFactorRemember: false,
+                newDeviceOTP: nil
+            )
+            XCTFail("Expected IdentityTokenError.newDeviceNotVerified")
+        } catch IdentityTokenError.newDeviceNotVerified {
+            // pass
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func preLoginJSON() -> Data {
+        Data(#"{"kdf":0,"kdfIterations":600000}"#.utf8)
+    }
+
+    private func refreshTokenJSON() -> Data {
+        Data(#"{"access_token":"new-at","token_type":"Bearer","expires_in":3600}"#.utf8)
+    }
+
+    private func syncJSON() -> Data {
+        let json = """
+        {
+          "Profile": {
+            "Id": "pid",
+            "Email": "t@t.com",
+            "Key": "2.k==",
+            "PrivateKey": null,
+            "Organizations": []
+          },
+          "Ciphers": [],
+          "Folders": []
+        }
+        """
+        return Data(json.utf8)
+    }
+
+    /// Parses a `application/x-www-form-urlencoded` body into a key→value dict.
+    private func formBody(from request: URLRequest?) -> [String: String] {
+        guard let data = request?.httpBody,
+              let str  = String(data: data, encoding: .utf8) else { return [:] }
+        var result = [String: String]()
+        for pair in str.split(separator: "&") {
+            let parts = pair.split(separator: "=", maxSplits: 1)
+            guard parts.count == 2 else { continue }
+            let key   = String(parts[0]).removingPercentEncoding ?? String(parts[0])
+            let value = String(parts[1]).removingPercentEncoding ?? String(parts[1])
+            result[key] = value
+        }
+        return result
+    }
+}

--- a/Prizm/PrizmTests/Domain/ServerEnvironmentTests.swift
+++ b/Prizm/PrizmTests/Domain/ServerEnvironmentTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import Prizm
+
+final class ServerEnvironmentTests: XCTestCase {
+
+    // MARK: - 3.1: cloudUS returns US canonical URLs
+
+    func testCloudUS_returnsUSCanonicalURLs() {
+        let env = ServerEnvironment.cloudUS()
+        XCTAssertEqual(env.apiURL.absoluteString,      "https://api.bitwarden.com")
+        XCTAssertEqual(env.identityURL.absoluteString, "https://identity.bitwarden.com")
+        XCTAssertEqual(env.iconsURL.absoluteString,    "https://icons.bitwarden.net")
+    }
+
+    // MARK: - 3.2: cloudEU returns EU canonical URLs
+
+    func testCloudEU_returnsEUCanonicalURLs() {
+        let env = ServerEnvironment.cloudEU()
+        XCTAssertEqual(env.apiURL.absoluteString,      "https://api.bitwarden.eu")
+        XCTAssertEqual(env.identityURL.absoluteString, "https://identity.bitwarden.eu")
+        XCTAssertEqual(env.iconsURL.absoluteString,    "https://icons.bitwarden.net")
+    }
+
+    // MARK: - 3.3: selfHosted returns base-derived URLs
+
+    func testSelfHosted_returnsBaseDerivedURLs() {
+        let env = ServerEnvironment(base: URL(string: "https://vault.example.com")!, overrides: nil)
+        XCTAssertEqual(env.apiURL.absoluteString,      "https://vault.example.com/api")
+        XCTAssertEqual(env.identityURL.absoluteString, "https://vault.example.com/identity")
+        XCTAssertEqual(env.iconsURL.absoluteString,    "https://vault.example.com/icons")
+    }
+
+    // MARK: - 3.4: Cloud ignores overrides
+
+    func testCloudUS_ignoresOverrides() {
+        let overrides = ServerURLOverrides(
+            api:      URL(string: "https://custom-api.example.com")!,
+            identity: URL(string: "https://custom-id.example.com")!,
+            icons:    URL(string: "https://custom-icons.example.com")!
+        )
+        var env = ServerEnvironment.cloudUS()
+        env.overrides = overrides
+        XCTAssertEqual(env.apiURL.absoluteString,      "https://api.bitwarden.com")
+        XCTAssertEqual(env.identityURL.absoluteString, "https://identity.bitwarden.com")
+        XCTAssertEqual(env.iconsURL.absoluteString,    "https://icons.bitwarden.net")
+    }
+
+    // MARK: - 3.5: Legacy JSON (no serverType key) decodes as selfHosted
+
+    func testDecode_legacyRecord_decodesAsSelfHosted() throws {
+        let json = """
+        {"base": "https://vault.example.com"}
+        """.data(using: .utf8)!
+        let env = try JSONDecoder().decode(ServerEnvironment.self, from: json)
+        XCTAssertEqual(env.serverType, .selfHosted)
+        XCTAssertEqual(env.base.absoluteString, "https://vault.example.com")
+    }
+
+    // MARK: - 3.6: Round-trip encode/decode preserves exact raw strings
+
+    func testEncodeDecode_cloudUS_preservesRawString() throws {
+        let env = ServerEnvironment.cloudUS()
+        let data = try JSONEncoder().encode(env)
+        let decoded = try JSONDecoder().decode(ServerEnvironment.self, from: data)
+        XCTAssertEqual(decoded.serverType, .cloudUS)
+        XCTAssertEqual(decoded.serverType.rawValue, "cloudUS")
+    }
+
+    func testEncodeDecode_cloudEU_preservesRawString() throws {
+        let env = ServerEnvironment.cloudEU()
+        let data = try JSONEncoder().encode(env)
+        let decoded = try JSONDecoder().decode(ServerEnvironment.self, from: data)
+        XCTAssertEqual(decoded.serverType, .cloudEU)
+        XCTAssertEqual(decoded.serverType.rawValue, "cloudEU")
+    }
+
+    func testEncodeDecode_selfHosted_preservesRawString() throws {
+        let env = ServerEnvironment(base: URL(string: "https://vault.example.com")!, overrides: nil)
+        let data = try JSONEncoder().encode(env)
+        let decoded = try JSONDecoder().decode(ServerEnvironment.self, from: data)
+        XCTAssertEqual(decoded.serverType, .selfHosted)
+        XCTAssertEqual(decoded.serverType.rawValue, "selfHosted")
+    }
+}

--- a/Prizm/PrizmTests/Mocks/MockAuthRepository.swift
+++ b/Prizm/PrizmTests/Mocks/MockAuthRepository.swift
@@ -10,6 +10,10 @@ final class MockAuthRepository: AuthRepository {
     private(set) var loginWithPasswordCalled:      Bool = false
     private(set) var unlockWithPasswordCalled:     Bool = false
     private(set) var cancelTwoFactorCalled:        Bool = false
+    private(set) var validateServerURLCalled:      Bool = false
+    private(set) var loginWithNewDeviceOTPCalled:  Bool = false
+    private(set) var requestNewDeviceOTPCalled:    Bool = false
+    private(set) var cancelNewDeviceOTPCalled:     Bool = false
     private(set) var signOutCalled:                Bool = false
     var             lockVaultCalledCount:           Int  = 0
 
@@ -37,17 +41,24 @@ final class MockAuthRepository: AuthRepository {
     /// When non-nil, `unlockWithPassword` throws this error.
     var unlockWithPasswordError: Error?
 
+    /// When non-nil, `loginWithNewDeviceOTP` throws this error.
+    var loginWithNewDeviceOTPError: Error?
+
+    /// When non-nil, `requestNewDeviceOTP` throws this error.
+    var requestNewDeviceOTPError: Error?
+
     // MARK: - AuthRepository
 
     var serverEnvironment: ServerEnvironment?
 
     func validateServerURL(_ urlString: String) throws {
+        validateServerURLCalled = true
         if let err = validateServerURLError { throw err }
     }
 
     func setServerEnvironment(_ environment: ServerEnvironment) async throws {
-        serverEnvironment            = environment
-        setServerEnvironmentCalled   = true
+        serverEnvironment          = environment
+        setServerEnvironmentCalled = true
     }
 
     func loginWithPassword(email: String, masterPassword: Data) async throws -> LoginResult {
@@ -65,6 +76,24 @@ final class MockAuthRepository: AuthRepository {
 
     func cancelTwoFactor() {
         cancelTwoFactorCalled = true
+    }
+
+    func loginWithNewDeviceOTP(_ otp: String) async throws -> Account {
+        loginWithNewDeviceOTPCalled = true
+        if let err = loginWithNewDeviceOTPError { throw err }
+        guard case .success(let account) = stubbedLoginResult else {
+            throw AuthError.invalidCredentials
+        }
+        return account
+    }
+
+    func requestNewDeviceOTP() async throws {
+        requestNewDeviceOTPCalled = true
+        if let err = requestNewDeviceOTPError { throw err }
+    }
+
+    func cancelNewDeviceOTP() {
+        cancelNewDeviceOTPCalled = true
     }
 
     func unlockWithPassword(_ masterPassword: Data) async throws -> Account {

--- a/Prizm/PrizmTests/Mocks/MockLoginUseCase.swift
+++ b/Prizm/PrizmTests/Mocks/MockLoginUseCase.swift
@@ -7,9 +7,13 @@ final class MockLoginUseCase: LoginUseCase {
 
     // MARK: - Call tracking
 
-    private(set) var executeCallCount:    Int  = 0
-    private(set) var cancelTOTPCalled:    Bool = false
-    private(set) var completeTOTPCalled:  Bool = false
+    private(set) var executeCallCount:              Int  = 0
+    private(set) var cancelTOTPCalled:              Bool = false
+    private(set) var completeTOTPCalled:            Bool = false
+    private(set) var completeNewDeviceOTPCalled:    Bool = false
+    private(set) var resendNewDeviceOTPCalled:      Bool = false
+    private(set) var cancelNewDeviceOTPCalled:      Bool = false
+    private(set) var lastExecutedEnvironment:       ServerEnvironment?
 
     // MARK: - Stubs
 
@@ -26,11 +30,14 @@ final class MockLoginUseCase: LoginUseCase {
     )
     var executeError: Error?
     var completeTOTPError: Error?
+    var completeNewDeviceOTPError: Error?
+    var resendNewDeviceOTPError: Error?
 
     // MARK: - LoginUseCase
 
-    func execute(serverURL: String, email: String, masterPassword: Data) async throws -> LoginResult {
+    func execute(environment: ServerEnvironment, email: String, masterPassword: Data) async throws -> LoginResult {
         executeCallCount += 1
+        lastExecutedEnvironment = environment
         if let err = executeError { throw err }
         return stubbedResult
     }
@@ -46,5 +53,23 @@ final class MockLoginUseCase: LoginUseCase {
 
     func cancelTOTP() {
         cancelTOTPCalled = true
+    }
+
+    func completeNewDeviceOTP(otp: String) async throws -> Account {
+        completeNewDeviceOTPCalled = true
+        if let err = completeNewDeviceOTPError { throw err }
+        guard case .success(let account) = stubbedResult else {
+            throw AuthError.invalidCredentials
+        }
+        return account
+    }
+
+    func resendNewDeviceOTP() async throws {
+        resendNewDeviceOTPCalled = true
+        if let err = resendNewDeviceOTPError { throw err }
+    }
+
+    func cancelNewDeviceOTP() {
+        cancelNewDeviceOTPCalled = true
     }
 }

--- a/Prizm/PrizmTests/Mocks/MockLoginUseCase.swift
+++ b/Prizm/PrizmTests/Mocks/MockLoginUseCase.swift
@@ -13,7 +13,8 @@ final class MockLoginUseCase: LoginUseCase {
     private(set) var completeNewDeviceOTPCalled:    Bool = false
     private(set) var resendNewDeviceOTPCalled:      Bool = false
     private(set) var cancelNewDeviceOTPCalled:      Bool = false
-    private(set) var lastExecutedEnvironment:       ServerEnvironment?
+    private(set) var lastExecutedServerType:         ServerType?
+    private(set) var lastExecutedServerURL:          String?
 
     // MARK: - Stubs
 
@@ -35,9 +36,10 @@ final class MockLoginUseCase: LoginUseCase {
 
     // MARK: - LoginUseCase
 
-    func execute(environment: ServerEnvironment, email: String, masterPassword: Data) async throws -> LoginResult {
+    func execute(serverType: ServerType, serverURL: String, email: String, masterPassword: Data) async throws -> LoginResult {
         executeCallCount += 1
-        lastExecutedEnvironment = environment
+        lastExecutedServerType = serverType
+        lastExecutedServerURL  = serverURL
         if let err = executeError { throw err }
         return stubbedResult
     }

--- a/Prizm/PrizmTests/Mocks/MockPrizmAPIClient.swift
+++ b/Prizm/PrizmTests/Mocks/MockPrizmAPIClient.swift
@@ -9,7 +9,7 @@ actor MockPrizmAPIClient: PrizmAPIClientProtocol {
     // MARK: - Configuration state
     // nonisolated(unsafe) allows tests to read/write without await — safe in single-threaded tests.
 
-    nonisolated(unsafe) var baseURL: URL?
+    nonisolated(unsafe) var serverEnvironment: ServerEnvironment?
     nonisolated(unsafe) var storedAccessToken: String?
 
     // MARK: - Stubs: preLogin
@@ -22,6 +22,7 @@ actor MockPrizmAPIClient: PrizmAPIClientProtocol {
     nonisolated(unsafe) var tokenResponse: TokenResponse?
     nonisolated(unsafe) var tokenShouldThrow: Error?
     nonisolated(unsafe) var tokenTwoFactorProviders: [Int]?
+    nonisolated(unsafe) var lastIdentityTokenNewDeviceOTP: String?
 
     // MARK: - Stubs: fetchSync
 
@@ -43,8 +44,8 @@ actor MockPrizmAPIClient: PrizmAPIClientProtocol {
 
     // MARK: - Protocol conformance
 
-    func setBaseURL(_ url: URL) {
-        baseURL = url
+    func setServerEnvironment(_ env: ServerEnvironment) {
+        serverEnvironment = env
     }
 
     func setAccessToken(_ token: String) {
@@ -68,8 +69,10 @@ actor MockPrizmAPIClient: PrizmAPIClientProtocol {
         deviceIdentifier:  String,
         twoFactorToken:    String?,
         twoFactorProvider: Int?,
-        twoFactorRemember: Bool
+        twoFactorRemember: Bool,
+        newDeviceOTP:      String?
     ) async throws -> TokenResponse {
+        lastIdentityTokenNewDeviceOTP = newDeviceOTP
         if let err = tokenShouldThrow { throw err }
 
         if let providers = tokenTwoFactorProviders, tokenResponse == nil {
@@ -93,7 +96,7 @@ actor MockPrizmAPIClient: PrizmAPIClientProtocol {
         }
 
         guard let resp = tokenResponse else {
-            throw APIError.baseURLNotSet
+            throw APIError.serverEnvironmentNotSet
         }
         return resp
     }

--- a/Prizm/PrizmTests/Presentation/LoginViewModelTests.swift
+++ b/Prizm/PrizmTests/Presentation/LoginViewModelTests.swift
@@ -23,23 +23,203 @@ final class LoginViewModelTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
+        UserDefaults.standard.removeObject(forKey: "com.prizm.login.lastServerType")
+        UserDefaults.standard.removeObject(forKey: "com.prizm.login.lastServerURL")
         mockUseCase = MockLoginUseCase()
         sut         = LoginViewModel(loginUseCase: mockUseCase)
     }
 
     override func tearDown() async throws {
         cancellables.removeAll()
+        UserDefaults.standard.removeObject(forKey: "com.prizm.login.lastServerType")
+        UserDefaults.standard.removeObject(forKey: "com.prizm.login.lastServerURL")
         try await super.tearDown()
     }
 
-    // MARK: - signIn: password cleared on success
+    // MARK: - 10.1: persisted cloudEU restores on init
 
-    /// signIn() clears the password field after a successful login (Constitution §III).
+    func testInit_persistedCloudEU_restoresServerType() {
+        UserDefaults.standard.set("cloudEU", forKey: "com.prizm.login.lastServerType")
+        let vm = LoginViewModel(loginUseCase: mockUseCase)
+        XCTAssertEqual(vm.serverType, .cloudEU)
+    }
+
+    // MARK: - 10.2: fresh install defaults to cloudUS
+
+    func testInit_noPersistedType_defaultsToCloudUS() {
+        XCTAssertEqual(sut.serverType, .cloudUS)
+    }
+
+    // MARK: - 10.3: serverType change persists; serverURL persisted and restored
+
+    func testServerTypePersists_onSelection() {
+        sut.serverType = .cloudEU
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "com.prizm.login.lastServerType"), "cloudEU")
+    }
+
+    func testServerURL_persistsOnSignIn_forSelfHosted() {
+        sut.serverType = .selfHosted
+        sut.serverURL  = "https://vault.example.com"
+        sut.email      = "a@b.com"
+        sut.password   = "pw"
+        sut.signIn()
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "com.prizm.login.lastServerURL"),
+            "https://vault.example.com"
+        )
+    }
+
+    func testServerURL_restoredOnInit() {
+        UserDefaults.standard.set("https://vault.example.com", forKey: "com.prizm.login.lastServerURL")
+        let vm = LoginViewModel(loginUseCase: mockUseCase)
+        XCTAssertEqual(vm.serverURL, "https://vault.example.com")
+    }
+
+    // MARK: - 10.4: isSignInDisabled when loading
+
+    func testIsSignInDisabled_whenLoading_returnsTrue() {
+        sut.email    = "a@b.com"
+        sut.password = "pw"
+        sut.signIn()   // transitions to .loading synchronously before Task fires
+        XCTAssertTrue(sut.isSignInDisabled)
+    }
+
+    // MARK: - 10.5: cloud with email+password, empty serverURL → enabled
+
+    func testIsSignInDisabled_cloud_emptyServerURL_emailAndPasswordFilled_returnsFalse() {
+        sut.serverType = .cloudUS
+        sut.serverURL  = ""
+        sut.email      = "a@b.com"
+        sut.password   = "pw"
+        XCTAssertFalse(sut.isSignInDisabled)
+    }
+
+    // MARK: - 10.6: selfHosted with empty serverURL → disabled
+
+    func testIsSignInDisabled_selfHosted_emptyServerURL_returnsTrue() {
+        sut.serverType = .selfHosted
+        sut.serverURL  = ""
+        sut.email      = "a@b.com"
+        sut.password   = "pw"
+        XCTAssertTrue(sut.isSignInDisabled)
+    }
+
+    // MARK: - 10.7: otpPrompt + empty otpCode → disabled
+
+    func testIsSignInDisabled_otpPrompt_emptyCode_returnsTrue() async throws {
+        mockUseCase.stubbedResult = .requiresNewDeviceOTP
+        sut.email    = "a@b.com"
+        sut.password = "pw"
+        sut.signIn()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        sut.otpCode = ""
+        XCTAssertTrue(sut.isSignInDisabled)
+    }
+
+    // MARK: - 10.8: otpPrompt + non-empty otpCode → enabled
+
+    func testIsSignInDisabled_otpPrompt_nonEmptyCode_returnsFalse() async throws {
+        mockUseCase.stubbedResult = .requiresNewDeviceOTP
+        sut.email    = "a@b.com"
+        sut.password = "pw"
+        sut.signIn()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        sut.otpCode = "123456"
+        XCTAssertFalse(sut.isSignInDisabled)
+    }
+
+    // MARK: - 10.9: requiresNewDeviceOTP → flowState .otpPrompt
+
+    func testSignIn_requiresNewDeviceOTP_transitionsToOtpPrompt() async throws {
+        mockUseCase.stubbedResult = .requiresNewDeviceOTP
+        sut.email    = "a@b.com"
+        sut.password = "pw"
+        sut.signIn()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertEqual(sut.flowState, .otpPrompt)
+    }
+
+    // MARK: - 10.10: cancelOTP → flowState .login
+
+    func testCancelOTP_resetsToLogin() async throws {
+        mockUseCase.stubbedResult = .requiresNewDeviceOTP
+        sut.email    = "a@b.com"
+        sut.password = "pw"
+        sut.signIn()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        sut.cancelOTP()
+        XCTAssertEqual(sut.flowState, .login)
+        XCTAssertTrue(mockUseCase.cancelNewDeviceOTPCalled)
+    }
+
+    // MARK: - 10.11: invalid OTP error → stays .otpPrompt, error set
+
+    func testSubmitOTP_invalidError_staysOtpPrompt() async throws {
+        mockUseCase.stubbedResult             = .requiresNewDeviceOTP
+        mockUseCase.completeNewDeviceOTPError = AuthError.invalidCredentials
+        sut.email    = "a@b.com"
+        sut.password = "pw"
+        sut.signIn()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        sut.otpCode = "000000"
+        sut.submitOTP()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertEqual(sut.flowState, .otpPrompt)
+        XCTAssertNotNil(sut.errorMessage)
+    }
+
+    // MARK: - 10.12: resendOTP success → otpCode cleared
+
+    func testResendOTP_success_clearsOtpCode() async throws {
+        mockUseCase.stubbedResult = .requiresNewDeviceOTP
+        sut.email    = "a@b.com"
+        sut.password = "pw"
+        sut.signIn()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        sut.otpCode = "555555"
+        sut.resendOTP()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertTrue(mockUseCase.resendNewDeviceOTPCalled)
+        XCTAssertEqual(sut.otpCode, "")
+    }
+
+    // MARK: - 10.13: resendOTP failure → error set, otpCode unchanged
+
+    func testResendOTP_failure_setsErrorLeavesOtpCode() async throws {
+        mockUseCase.stubbedResult           = .requiresNewDeviceOTP
+        mockUseCase.resendNewDeviceOTPError = AuthError.serverUnreachable
+        sut.email    = "a@b.com"
+        sut.password = "pw"
+        sut.signIn()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        sut.otpCode = "555555"
+        sut.resendOTP()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertEqual(sut.flowState, .otpPrompt)
+        XCTAssertNotNil(sut.errorMessage)
+        XCTAssertEqual(sut.otpCode, "555555")
+    }
+
+    // MARK: - 10.14: otpCode cleared synchronously before request fires
+
+    func testSubmitOTP_clearsOtpCodeImmediately() async throws {
+        mockUseCase.stubbedResult = .requiresNewDeviceOTP
+        sut.email    = "a@b.com"
+        sut.password = "pw"
+        sut.signIn()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        sut.otpCode = "123456"
+        sut.submitOTP()
+        // otpCode is cleared synchronously before the async Task body runs (Constitution §III).
+        XCTAssertEqual(sut.otpCode, "", "otpCode must be cleared synchronously in submitOTP()")
+    }
+
+    // MARK: - Existing: signIn password cleared on success
+
     func testSignIn_success_clearsPasswordField() async throws {
         mockUseCase.stubbedResult = .success(makeAccount())
-        sut.serverURL = "https://vault.example.com"
-        sut.email     = "alice@example.com"
-        sut.password  = "SuperSecret1!"
+        sut.email    = "alice@example.com"
+        sut.password = "SuperSecret1!"
 
         let exp = expectation(description: "password cleared after sign-in")
         sut.$password
@@ -52,15 +232,13 @@ final class LoginViewModelTests: XCTestCase {
         sut.signIn()
 
         await fulfillment(of: [exp], timeout: 2.0)
-        XCTAssertEqual(sut.password, "", "Password field must be cleared after successful login")
+        XCTAssertEqual(sut.password, "")
     }
 
-    /// signIn() clears the password field when the server returns .requiresTwoFactor (Constitution §III).
     func testSignIn_requiresTwoFactor_clearsPasswordField() async throws {
         mockUseCase.stubbedResult = .requiresTwoFactor(.authenticatorApp)
-        sut.serverURL = "https://vault.example.com"
-        sut.email     = "alice@example.com"
-        sut.password  = "SuperSecret1!"
+        sut.email    = "alice@example.com"
+        sut.password = "SuperSecret1!"
 
         let exp = expectation(description: "flow transitions to 2FA prompt")
         sut.$flowState
@@ -73,30 +251,21 @@ final class LoginViewModelTests: XCTestCase {
         sut.signIn()
 
         await fulfillment(of: [exp], timeout: 2.0)
-        XCTAssertEqual(sut.password, "", "Password field must be cleared on 2FA prompt transition")
+        XCTAssertEqual(sut.password, "")
     }
 
-    /// signIn() does not call the use case when password is empty (matches UI disabled-button guard).
     func testSignIn_emptyPassword_doesNotCallUseCase() {
-        sut.serverURL = "https://vault.example.com"
-        sut.email     = "alice@example.com"
-        sut.password  = ""   // empty — guarded before Task is spawned
-
+        sut.email    = "alice@example.com"
+        sut.password = ""
         sut.signIn()
-
-        XCTAssertEqual(mockUseCase.executeCallCount, 0,
-                       "execute must not be called when password is empty")
+        XCTAssertEqual(mockUseCase.executeCallCount, 0)
     }
 
-    // MARK: - cancelTOTP
+    // MARK: - Existing: cancelTOTP
 
-    /// cancelTOTP() delegates to the use case and resets flow state to .login.
     func testCancelTOTP_callsUseCaseAndResetsState() {
         sut.cancelTOTP()
-
-        XCTAssertTrue(mockUseCase.cancelTOTPCalled,
-                      "cancelTOTP must forward to loginUseCase.cancelTOTP()")
-        XCTAssertEqual(sut.flowState, .login,
-                       "flowState must return to .login after cancelling TOTP")
+        XCTAssertTrue(mockUseCase.cancelTOTPCalled)
+        XCTAssertEqual(sut.flowState, .login)
     }
 }

--- a/Prizm/PrizmTests/Presentation/LoginViewModelTests.swift
+++ b/Prizm/PrizmTests/Presentation/LoginViewModelTests.swift
@@ -178,8 +178,11 @@ final class LoginViewModelTests: XCTestCase {
         try await Task.sleep(nanoseconds: 100_000_000)
         sut.otpCode = "555555"
         sut.resendOTP()
+        // flowState should go to .loading immediately on resend.
+        XCTAssertEqual(sut.flowState, .loading, "resendOTP must set .loading before the async call")
         try await Task.sleep(nanoseconds: 100_000_000)
         XCTAssertTrue(mockUseCase.resendNewDeviceOTPCalled)
+        XCTAssertEqual(sut.flowState, .otpPrompt, "flowState must return to .otpPrompt on resend success")
         XCTAssertEqual(sut.otpCode, "")
     }
 

--- a/Prizm/UITests/LoginJourneyTests.swift
+++ b/Prizm/UITests/LoginJourneyTests.swift
@@ -18,7 +18,6 @@ final class LoginJourneyTests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
-        // Pass launch argument to reset stored session for a clean login test.
         app.launchArguments = ["--ui-testing", "--reset-session"]
         app.launch()
     }
@@ -27,30 +26,31 @@ final class LoginJourneyTests: XCTestCase {
         app = nil
     }
 
-    // MARK: - US1 Scenario 1: Login screen is shown on first launch
+    // MARK: - US1 Scenario 1: Login screen shown on first launch
 
-    /// Verifies the login screen appears with all expected elements when no session exists.
+    /// Verifies the login screen appears with the server picker and core fields.
     func testLoginScreenShownOnFirstLaunch() {
-        let serverURL = app.textFields["login.serverURL"]
-        let email     = app.textFields["login.email"]
-        let password  = app.secureTextFields["login.password"]
-        let signIn    = app.buttons["login.signIn"]
+        let picker   = app.segmentedControls["login.serverTypePicker"]
+        let email    = app.textFields["login.email"]
+        let password = app.secureTextFields["login.password"]
+        let signIn   = app.buttons["login.signIn"]
 
-        XCTAssertTrue(serverURL.waitForExistence(timeout: 5), "Server URL field should exist")
-        XCTAssertTrue(email.exists, "Email field should exist")
+        XCTAssertTrue(picker.waitForExistence(timeout: 5), "Server type picker should exist")
+        XCTAssertTrue(email.exists,    "Email field should exist")
         XCTAssertTrue(password.exists, "Password field should exist")
-        XCTAssertTrue(signIn.exists, "Sign In button should exist")
+        XCTAssertTrue(signIn.exists,   "Sign In button should exist")
     }
 
-    // MARK: - US1 Scenario 2: Sign-in button disabled until all fields populated
+    // MARK: - US1 Scenario 2: Sign-in button disabled until fields populated (self-hosted)
 
-    /// Verifies the Sign In button is disabled when any required field is empty.
-    func testSignInButtonDisabledWhenFieldsEmpty() {
+    func testSignInButtonDisabledWhenFieldsEmpty_selfHosted() {
+        let picker = app.segmentedControls["login.serverTypePicker"]
+        XCTAssertTrue(picker.waitForExistence(timeout: 5))
+        picker.buttons["Self-hosted"].click()
+
         let signIn = app.buttons["login.signIn"]
-        XCTAssertTrue(signIn.waitForExistence(timeout: 5))
         XCTAssertFalse(signIn.isEnabled, "Sign In should be disabled with empty fields")
 
-        // Fill only server URL — still disabled.
         let serverURL = app.textFields["login.serverURL"]
         serverURL.click()
         serverURL.typeText("https://vault.example.com")
@@ -59,15 +59,17 @@ final class LoginJourneyTests: XCTestCase {
 
     // MARK: - US1 Scenario 3: Invalid server URL shows error
 
-    /// Verifies that entering an invalid server URL and submitting shows an error message.
     func testInvalidServerURLShowsError() {
+        let picker = app.segmentedControls["login.serverTypePicker"]
+        XCTAssertTrue(picker.waitForExistence(timeout: 5))
+        picker.buttons["Self-hosted"].click()
+
         let serverURL = app.textFields["login.serverURL"]
         let email     = app.textFields["login.email"]
         let password  = app.secureTextFields["login.password"]
         let signIn    = app.buttons["login.signIn"]
 
         XCTAssertTrue(serverURL.waitForExistence(timeout: 5))
-
         serverURL.click()
         serverURL.typeText("not-a-url")
         email.click()
@@ -82,21 +84,18 @@ final class LoginJourneyTests: XCTestCase {
 
     // MARK: - US1 Scenario 4: Invalid credentials shows error
 
-    /// Verifies that wrong credentials show an error message without crashing.
     func testInvalidCredentialsShowsError() throws {
         let serverURL = try XCTUnwrap(envVar("BW_TEST_SERVER_URL"), "BW_TEST_SERVER_URL required")
 
-        fillLoginForm(serverURL: serverURL, email: "wrong@example.com", password: "wrongpassword")
+        fillSelfHostedLoginForm(serverURL: serverURL, email: "wrong@example.com", password: "wrongpassword")
         app.buttons["login.signIn"].click()
 
         let error = app.staticTexts["login.error"]
         XCTAssertTrue(error.waitForExistence(timeout: 15), "Error message should appear for invalid credentials")
     }
 
-    // MARK: - US1 Scenario 5: Successful login reaches vault browser
+    // MARK: - US1 Scenario 5: Successful self-hosted login reaches vault browser
 
-    /// Verifies a valid login flow transitions through sync and reaches the vault browser.
-    /// Measures total login time against SC-001 (≤60s).
     func testSuccessfulLoginReachesVaultBrowser() throws {
         let serverURL = try XCTUnwrap(envVar("BW_TEST_SERVER_URL"), "BW_TEST_SERVER_URL required")
         let email     = try XCTUnwrap(envVar("BW_TEST_EMAIL"), "BW_TEST_EMAIL required")
@@ -104,18 +103,14 @@ final class LoginJourneyTests: XCTestCase {
 
         let startTime = CFAbsoluteTimeGetCurrent()
 
-        fillLoginForm(serverURL: serverURL, email: email, password: password)
+        fillSelfHostedLoginForm(serverURL: serverURL, email: email, password: password)
         app.buttons["login.signIn"].click()
 
-        // If TOTP is required, the TOTP prompt appears.
         let totpField = app.textFields["totp.code"]
         if totpField.waitForExistence(timeout: 10) {
-            // TOTP required — test cannot proceed without a valid code.
-            // Skip with a message; the TOTP-specific test handles this.
             throw XCTSkip("TOTP required — use testLoginWithTOTPReachesVaultBrowser instead")
         }
 
-        // Wait for sync progress to complete and vault browser to appear.
         let vaultNav = app.otherElements["vault.navigationSplit"]
         XCTAssertTrue(
             vaultNav.waitForExistence(timeout: 60),
@@ -128,68 +123,55 @@ final class LoginJourneyTests: XCTestCase {
 
     // MARK: - US1 Scenario 6: TOTP prompt appears when 2FA required
 
-    /// Verifies the TOTP prompt view appears after credential submission when 2FA is enabled.
     func testTOTPPromptAppearsWhen2FARequired() throws {
         let serverURL = try XCTUnwrap(envVar("BW_TEST_SERVER_URL"), "BW_TEST_SERVER_URL required")
         let email     = try XCTUnwrap(envVar("BW_TEST_2FA_EMAIL"), "BW_TEST_2FA_EMAIL required")
         let password  = try XCTUnwrap(envVar("BW_TEST_2FA_PASSWORD"), "BW_TEST_2FA_PASSWORD required")
 
-        fillLoginForm(serverURL: serverURL, email: email, password: password)
+        fillSelfHostedLoginForm(serverURL: serverURL, email: email, password: password)
         app.buttons["login.signIn"].click()
 
         let totpHeader = app.staticTexts["totp.headerTitle"]
-        XCTAssertTrue(
-            totpHeader.waitForExistence(timeout: 15),
-            "TOTP prompt should appear when 2FA is required"
-        )
+        XCTAssertTrue(totpHeader.waitForExistence(timeout: 15), "TOTP prompt should appear")
 
-        let codeField     = app.textFields["totp.code"]
-        let rememberToggle = app.checkBoxes["totp.remember"]
-        let continueBtn   = app.buttons["totp.continue"]
-
-        XCTAssertTrue(codeField.exists, "TOTP code field should exist")
-        XCTAssertTrue(rememberToggle.exists, "Remember device toggle should exist")
-        XCTAssertTrue(continueBtn.exists, "Continue button should exist")
+        XCTAssertTrue(app.textFields["totp.code"].exists)
+        XCTAssertTrue(app.checkBoxes["totp.remember"].exists)
+        XCTAssertTrue(app.buttons["totp.continue"].exists)
     }
 
-    // MARK: - US1 Scenario 7: Sync progress is shown after authentication
+    // MARK: - US1 Scenario 7: Sync progress shown after auth
 
-    /// Verifies that sync progress messages appear after successful authentication.
     func testSyncProgressShownAfterAuth() throws {
         let serverURL = try XCTUnwrap(envVar("BW_TEST_SERVER_URL"), "BW_TEST_SERVER_URL required")
         let email     = try XCTUnwrap(envVar("BW_TEST_EMAIL"), "BW_TEST_EMAIL required")
         let password  = try XCTUnwrap(envVar("BW_TEST_PASSWORD"), "BW_TEST_PASSWORD required")
 
-        fillLoginForm(serverURL: serverURL, email: email, password: password)
+        fillSelfHostedLoginForm(serverURL: serverURL, email: email, password: password)
         app.buttons["login.signIn"].click()
 
-        // The sync progress message should appear during the sync phase.
         let progressMsg = app.staticTexts["sync.progressMessage"]
-        // This may be transient — use a short timeout.
         if progressMsg.waitForExistence(timeout: 15) {
-            // Progress message appeared — sync is in progress. Good.
-            XCTAssertFalse(progressMsg.label.isEmpty, "Sync progress should display a message")
+            XCTAssertFalse(progressMsg.label.isEmpty)
         }
-        // Either way, vault should eventually appear.
         let vaultNav = app.otherElements["vault.navigationSplit"]
-        XCTAssertTrue(vaultNav.waitForExistence(timeout: 60), "Vault browser should appear after sync")
+        XCTAssertTrue(vaultNav.waitForExistence(timeout: 60))
     }
 
     // MARK: - Helpers
 
-    private func fillLoginForm(serverURL: String, email: String, password: String) {
+    private func fillSelfHostedLoginForm(serverURL: String, email: String, password: String) {
+        let picker = app.segmentedControls["login.serverTypePicker"]
+        XCTAssertTrue(picker.waitForExistence(timeout: 5))
+        picker.buttons["Self-hosted"].click()
+
         let serverField = app.textFields["login.serverURL"]
-        let emailField  = app.textFields["login.email"]
-        let passField   = app.secureTextFields["login.password"]
-
         XCTAssertTrue(serverField.waitForExistence(timeout: 5))
-
         serverField.click()
         serverField.typeText(serverURL)
-        emailField.click()
-        emailField.typeText(email)
-        passField.click()
-        passField.typeText(password)
+        app.textFields["login.email"].click()
+        app.textFields["login.email"].typeText(email)
+        app.secureTextFields["login.password"].click()
+        app.secureTextFields["login.password"].typeText(password)
     }
 
     private func envVar(_ name: String) -> String? {

--- a/Prizm/UITests/LoginPickerJourneyTests.swift
+++ b/Prizm/UITests/LoginPickerJourneyTests.swift
@@ -1,0 +1,284 @@
+import XCTest
+
+/// XCUITest: US1 Login Journey — Server Picker & New-Device OTP (T037)
+///
+/// Verifies the three-way server picker UI, conditional server URL field visibility,
+/// Sign In button enable/disable logic, and the new-device OTP flow introduced for
+/// Bitwarden Cloud logins.
+///
+/// **Prerequisites**: The app must launch with no stored session (clean state).
+///
+/// - Note: Tests 14.5–14.8 require a Bitwarden Cloud stub server that speaks the
+///   Bitwarden identity API. Configure via `BW_CLOUD_STUB_URL`, `BW_CLOUD_TEST_EMAIL`,
+///   and `BW_CLOUD_TEST_PASSWORD` environment variables in the test scheme.
+///   Tests 14.6–14.8 additionally require the stub to return `device_error` on first
+///   auth and accept/reject the OTP on subsequent requests.
+final class LoginPickerJourneyTests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments = ["--ui-testing", "--reset-session"]
+        app.launch()
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+    }
+
+    // MARK: - 14.1 Three-way picker visible; all options selectable
+
+    func testServerPickerShowsThreeOptions() {
+        let picker = app.segmentedControls["login.serverTypePicker"]
+        XCTAssertTrue(picker.waitForExistence(timeout: 5), "Server type picker should be visible")
+
+        let bitwardenUS = picker.buttons["Bitwarden US"]
+        let bitwardenEU = picker.buttons["Bitwarden EU"]
+        let selfHosted  = picker.buttons["Self-hosted"]
+
+        XCTAssertTrue(bitwardenUS.exists, "Bitwarden US option should exist")
+        XCTAssertTrue(bitwardenEU.exists, "Bitwarden EU option should exist")
+        XCTAssertTrue(selfHosted.exists,  "Self-hosted option should exist")
+
+        // Each option is selectable without error.
+        bitwardenEU.click()
+        XCTAssertTrue(bitwardenEU.isSelected, "Bitwarden EU should be selected after click")
+
+        selfHosted.click()
+        XCTAssertTrue(selfHosted.isSelected, "Self-hosted should be selected after click")
+
+        bitwardenUS.click()
+        XCTAssertTrue(bitwardenUS.isSelected, "Bitwarden US should be selected after click")
+    }
+
+    // MARK: - 14.2 Cloud hides server URL field; self-hosted shows it
+
+    func testServerURLFieldVisibilityByPickerSelection() {
+        let picker = app.segmentedControls["login.serverTypePicker"]
+        XCTAssertTrue(picker.waitForExistence(timeout: 5))
+
+        picker.buttons["Bitwarden US"].click()
+        XCTAssertFalse(
+            app.textFields["login.serverURL"].exists,
+            "Server URL field should be hidden for Bitwarden US"
+        )
+
+        picker.buttons["Bitwarden EU"].click()
+        XCTAssertFalse(
+            app.textFields["login.serverURL"].exists,
+            "Server URL field should be hidden for Bitwarden EU"
+        )
+
+        picker.buttons["Self-hosted"].click()
+        XCTAssertTrue(
+            app.textFields["login.serverURL"].waitForExistence(timeout: 3),
+            "Server URL field should appear for Self-hosted"
+        )
+    }
+
+    // MARK: - 14.3 Sign In enabled for cloud with email + password only
+
+    func testSignInButtonEnabledForCloudWithEmailAndPassword() {
+        let picker   = app.segmentedControls["login.serverTypePicker"]
+        XCTAssertTrue(picker.waitForExistence(timeout: 5))
+        picker.buttons["Bitwarden US"].click()
+
+        let signIn   = app.buttons["login.signIn"]
+        XCTAssertFalse(signIn.isEnabled, "Sign In should be disabled before any input")
+
+        app.textFields["login.email"].click()
+        app.textFields["login.email"].typeText("user@example.com")
+        XCTAssertFalse(signIn.isEnabled, "Sign In should be disabled with only email")
+
+        app.secureTextFields["login.password"].click()
+        app.secureTextFields["login.password"].typeText("mypassword")
+        XCTAssertTrue(signIn.isEnabled, "Sign In should be enabled with email + password for cloud")
+    }
+
+    // MARK: - 14.4 Sign In disabled for self-hosted when serverURL empty
+
+    func testSignInButtonDisabledForSelfHostedWithEmptyServerURL() {
+        let picker = app.segmentedControls["login.serverTypePicker"]
+        XCTAssertTrue(picker.waitForExistence(timeout: 5))
+        picker.buttons["Self-hosted"].click()
+
+        app.textFields["login.email"].click()
+        app.textFields["login.email"].typeText("user@example.com")
+        app.secureTextFields["login.password"].click()
+        app.secureTextFields["login.password"].typeText("mypassword")
+
+        let signIn = app.buttons["login.signIn"]
+        XCTAssertFalse(
+            signIn.isEnabled,
+            "Sign In should be disabled for self-hosted when server URL is empty"
+        )
+    }
+
+    // MARK: - 14.5 Successful cloud login reaches vault browser (no OTP)
+
+    func testCloudLoginSuccessReachesVaultBrowser() throws {
+        let stubURL  = try XCTUnwrap(envVar("BW_CLOUD_STUB_URL"), "BW_CLOUD_STUB_URL required")
+        let email    = try XCTUnwrap(envVar("BW_CLOUD_TEST_EMAIL"), "BW_CLOUD_TEST_EMAIL required")
+        let password = try XCTUnwrap(envVar("BW_CLOUD_TEST_PASSWORD"), "BW_CLOUD_TEST_PASSWORD required")
+
+        // Override the cloud endpoint via launch argument so the stub URL is used.
+        app.terminate()
+        app.launchArguments = ["--ui-testing", "--reset-session", "--cloud-stub-url=\(stubURL)"]
+        app.launch()
+
+        let picker = app.segmentedControls["login.serverTypePicker"]
+        XCTAssertTrue(picker.waitForExistence(timeout: 5))
+        picker.buttons["Bitwarden US"].click()
+
+        app.textFields["login.email"].click()
+        app.textFields["login.email"].typeText(email)
+        app.secureTextFields["login.password"].click()
+        app.secureTextFields["login.password"].typeText(password)
+        app.buttons["login.signIn"].click()
+
+        let vaultNav = app.otherElements["vault.navigationSplit"]
+        XCTAssertTrue(
+            vaultNav.waitForExistence(timeout: 60),
+            "Vault browser should appear after successful cloud login"
+        )
+    }
+
+    // MARK: - 14.6 device_error response → NewDeviceOTPView appears
+
+    func testDeviceErrorShowsNewDeviceOTPView() throws {
+        let stubURL  = try XCTUnwrap(envVar("BW_CLOUD_STUB_URL"), "BW_CLOUD_STUB_URL required")
+        let email    = try XCTUnwrap(envVar("BW_CLOUD_OTP_EMAIL"), "BW_CLOUD_OTP_EMAIL required")
+        let password = try XCTUnwrap(envVar("BW_CLOUD_OTP_PASSWORD"), "BW_CLOUD_OTP_PASSWORD required")
+
+        app.terminate()
+        app.launchArguments = [
+            "--ui-testing", "--reset-session",
+            "--cloud-stub-url=\(stubURL)",
+            "--cloud-stub-device-error"   // tells the stub to respond with device_error
+        ]
+        app.launch()
+
+        let picker = app.segmentedControls["login.serverTypePicker"]
+        XCTAssertTrue(picker.waitForExistence(timeout: 5))
+        picker.buttons["Bitwarden US"].click()
+
+        app.textFields["login.email"].click()
+        app.textFields["login.email"].typeText(email)
+        app.secureTextFields["login.password"].click()
+        app.secureTextFields["login.password"].typeText(password)
+        app.buttons["login.signIn"].click()
+
+        let otpHeader = app.staticTexts["totp.headerTitle"]
+        XCTAssertTrue(
+            otpHeader.waitForExistence(timeout: 15),
+            "NewDeviceOTPView header should appear after device_error"
+        )
+        XCTAssertTrue(
+            app.textFields["login.newDeviceOtpField"].exists,
+            "OTP text field should be visible"
+        )
+        XCTAssertTrue(
+            app.buttons["login.resendOtpButton"].exists,
+            "Resend button should be visible"
+        )
+        XCTAssertTrue(
+            app.buttons["login.cancelOtpButton"].exists,
+            "Cancel button should be visible"
+        )
+    }
+
+    // MARK: - 14.7 Valid OTP submitted → login succeeds; OTP field disappears
+
+    func testValidOTPSubmissionSucceeds() throws {
+        let stubURL  = try XCTUnwrap(envVar("BW_CLOUD_STUB_URL"), "BW_CLOUD_STUB_URL required")
+        let email    = try XCTUnwrap(envVar("BW_CLOUD_OTP_EMAIL"), "BW_CLOUD_OTP_EMAIL required")
+        let password = try XCTUnwrap(envVar("BW_CLOUD_OTP_PASSWORD"), "BW_CLOUD_OTP_PASSWORD required")
+        let validOTP = try XCTUnwrap(envVar("BW_CLOUD_VALID_OTP"), "BW_CLOUD_VALID_OTP required")
+
+        app.terminate()
+        app.launchArguments = [
+            "--ui-testing", "--reset-session",
+            "--cloud-stub-url=\(stubURL)",
+            "--cloud-stub-device-error"
+        ]
+        app.launch()
+
+        let picker = app.segmentedControls["login.serverTypePicker"]
+        XCTAssertTrue(picker.waitForExistence(timeout: 5))
+        picker.buttons["Bitwarden US"].click()
+
+        app.textFields["login.email"].click()
+        app.textFields["login.email"].typeText(email)
+        app.secureTextFields["login.password"].click()
+        app.secureTextFields["login.password"].typeText(password)
+        app.buttons["login.signIn"].click()
+
+        let otpField = app.textFields["login.newDeviceOtpField"]
+        XCTAssertTrue(otpField.waitForExistence(timeout: 15), "OTP screen should appear")
+        otpField.click()
+        otpField.typeText(validOTP)
+        app.buttons["login.signIn"].click()
+
+        let vaultNav = app.otherElements["vault.navigationSplit"]
+        XCTAssertTrue(
+            vaultNav.waitForExistence(timeout: 60),
+            "Vault browser should appear after valid OTP"
+        )
+        XCTAssertFalse(
+            app.textFields["login.newDeviceOtpField"].exists,
+            "OTP field should disappear after successful OTP"
+        )
+    }
+
+    // MARK: - 14.8 Invalid OTP → error shown; OTP field remains
+
+    func testInvalidOTPShowsError() throws {
+        let stubURL  = try XCTUnwrap(envVar("BW_CLOUD_STUB_URL"), "BW_CLOUD_STUB_URL required")
+        let email    = try XCTUnwrap(envVar("BW_CLOUD_OTP_EMAIL"), "BW_CLOUD_OTP_EMAIL required")
+        let password = try XCTUnwrap(envVar("BW_CLOUD_OTP_PASSWORD"), "BW_CLOUD_OTP_PASSWORD required")
+
+        app.terminate()
+        app.launchArguments = [
+            "--ui-testing", "--reset-session",
+            "--cloud-stub-url=\(stubURL)",
+            "--cloud-stub-device-error"
+        ]
+        app.launch()
+
+        let picker = app.segmentedControls["login.serverTypePicker"]
+        XCTAssertTrue(picker.waitForExistence(timeout: 5))
+        picker.buttons["Bitwarden US"].click()
+
+        app.textFields["login.email"].click()
+        app.textFields["login.email"].typeText(email)
+        app.secureTextFields["login.password"].click()
+        app.secureTextFields["login.password"].typeText(password)
+        app.buttons["login.signIn"].click()
+
+        let otpField = app.textFields["login.newDeviceOtpField"]
+        XCTAssertTrue(otpField.waitForExistence(timeout: 15), "OTP screen should appear")
+        otpField.click()
+        otpField.typeText("000000")   // wrong OTP — stub always rejects this
+        app.buttons["login.signIn"].click()
+
+        let errorLabel = app.staticTexts["login.otpErrorMessage"]
+        XCTAssertTrue(
+            errorLabel.waitForExistence(timeout: 15),
+            "Error message should appear for invalid OTP"
+        )
+        XCTAssertFalse(errorLabel.label.isEmpty, "Error message should not be empty")
+        XCTAssertTrue(
+            app.textFields["login.newDeviceOtpField"].exists,
+            "OTP field should remain visible after invalid OTP"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func envVar(_ name: String) -> String? {
+        let value = ProcessInfo.processInfo.environment[name]
+        return (value?.isEmpty == false) ? value : nil
+    }
+}

--- a/Prizm/UITests/LoginPickerJourneyTests.swift
+++ b/Prizm/UITests/LoginPickerJourneyTests.swift
@@ -170,7 +170,7 @@ final class LoginPickerJourneyTests: XCTestCase {
         app.secureTextFields["login.password"].typeText(password)
         app.buttons["login.signIn"].click()
 
-        let otpHeader = app.staticTexts["totp.headerTitle"]
+        let otpHeader = app.staticTexts["login.newDeviceOtpHeader"]
         XCTAssertTrue(
             otpHeader.waitForExistence(timeout: 15),
             "NewDeviceOTPView header should appear after device_error"

--- a/Prizm/UITests/LoginPickerJourneyTests.swift
+++ b/Prizm/UITests/LoginPickerJourneyTests.swift
@@ -34,23 +34,23 @@ final class LoginPickerJourneyTests: XCTestCase {
         let picker = app.segmentedControls["login.serverTypePicker"]
         XCTAssertTrue(picker.waitForExistence(timeout: 5), "Server type picker should be visible")
 
-        let bitwardenUS = picker.buttons["Bitwarden US"]
-        let bitwardenEU = picker.buttons["Bitwarden EU"]
+        let bitwardenUS = picker.buttons["Bitwarden Cloud (US)"]
+        let bitwardenEU = picker.buttons["Bitwarden Cloud (EU)"]
         let selfHosted  = picker.buttons["Self-hosted"]
 
-        XCTAssertTrue(bitwardenUS.exists, "Bitwarden US option should exist")
-        XCTAssertTrue(bitwardenEU.exists, "Bitwarden EU option should exist")
+        XCTAssertTrue(bitwardenUS.exists, "Bitwarden Cloud (US) option should exist")
+        XCTAssertTrue(bitwardenEU.exists, "Bitwarden Cloud (EU) option should exist")
         XCTAssertTrue(selfHosted.exists,  "Self-hosted option should exist")
 
         // Each option is selectable without error.
         bitwardenEU.click()
-        XCTAssertTrue(bitwardenEU.isSelected, "Bitwarden EU should be selected after click")
+        XCTAssertTrue(bitwardenEU.isSelected, "Bitwarden Cloud (EU) should be selected after click")
 
         selfHosted.click()
         XCTAssertTrue(selfHosted.isSelected, "Self-hosted should be selected after click")
 
         bitwardenUS.click()
-        XCTAssertTrue(bitwardenUS.isSelected, "Bitwarden US should be selected after click")
+        XCTAssertTrue(bitwardenUS.isSelected, "Bitwarden Cloud (US) should be selected after click")
     }
 
     // MARK: - 14.2 Cloud hides server URL field; self-hosted shows it
@@ -59,16 +59,16 @@ final class LoginPickerJourneyTests: XCTestCase {
         let picker = app.segmentedControls["login.serverTypePicker"]
         XCTAssertTrue(picker.waitForExistence(timeout: 5))
 
-        picker.buttons["Bitwarden US"].click()
+        picker.buttons["Bitwarden Cloud (US)"].click()
         XCTAssertFalse(
             app.textFields["login.serverURL"].exists,
-            "Server URL field should be hidden for Bitwarden US"
+            "Server URL field should be hidden for Bitwarden Cloud (US)"
         )
 
-        picker.buttons["Bitwarden EU"].click()
+        picker.buttons["Bitwarden Cloud (EU)"].click()
         XCTAssertFalse(
             app.textFields["login.serverURL"].exists,
-            "Server URL field should be hidden for Bitwarden EU"
+            "Server URL field should be hidden for Bitwarden Cloud (EU)"
         )
 
         picker.buttons["Self-hosted"].click()
@@ -83,7 +83,7 @@ final class LoginPickerJourneyTests: XCTestCase {
     func testSignInButtonEnabledForCloudWithEmailAndPassword() {
         let picker   = app.segmentedControls["login.serverTypePicker"]
         XCTAssertTrue(picker.waitForExistence(timeout: 5))
-        picker.buttons["Bitwarden US"].click()
+        picker.buttons["Bitwarden Cloud (US)"].click()
 
         let signIn   = app.buttons["login.signIn"]
         XCTAssertFalse(signIn.isEnabled, "Sign In should be disabled before any input")
@@ -130,7 +130,7 @@ final class LoginPickerJourneyTests: XCTestCase {
 
         let picker = app.segmentedControls["login.serverTypePicker"]
         XCTAssertTrue(picker.waitForExistence(timeout: 5))
-        picker.buttons["Bitwarden US"].click()
+        picker.buttons["Bitwarden Cloud (US)"].click()
 
         app.textFields["login.email"].click()
         app.textFields["login.email"].typeText(email)
@@ -162,7 +162,7 @@ final class LoginPickerJourneyTests: XCTestCase {
 
         let picker = app.segmentedControls["login.serverTypePicker"]
         XCTAssertTrue(picker.waitForExistence(timeout: 5))
-        picker.buttons["Bitwarden US"].click()
+        picker.buttons["Bitwarden Cloud (US)"].click()
 
         app.textFields["login.email"].click()
         app.textFields["login.email"].typeText(email)
@@ -207,7 +207,7 @@ final class LoginPickerJourneyTests: XCTestCase {
 
         let picker = app.segmentedControls["login.serverTypePicker"]
         XCTAssertTrue(picker.waitForExistence(timeout: 5))
-        picker.buttons["Bitwarden US"].click()
+        picker.buttons["Bitwarden Cloud (US)"].click()
 
         app.textFields["login.email"].click()
         app.textFields["login.email"].typeText(email)
@@ -249,7 +249,7 @@ final class LoginPickerJourneyTests: XCTestCase {
 
         let picker = app.segmentedControls["login.serverTypePicker"]
         XCTAssertTrue(picker.waitForExistence(timeout: 5))
-        picker.buttons["Bitwarden US"].click()
+        picker.buttons["Bitwarden Cloud (US)"].click()
 
         app.textFields["login.email"].click()
         app.textFields["login.email"].typeText(email)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ brew install --cask prizm
 
 The app is not notarized. After downloading, right-click (Control-click) the `.app` and choose **Open**, then confirm. You only need to do this once. After that, you can open it normally.
 
+macOS will also show a **"Prizm wants to use your login keychain"** prompt on first launch — click **Allow**. This is expected for unsigned apps; Prizm uses it to store credentials securely.
+
 Alternatively, from Terminal:
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,6 +45,27 @@ never receives plaintext vault content or the master key at any point.
 Authentication sends a one-way derived hash (`serverHash`) rather than the master
 password itself.
 
+### Cloud endpoints (Bitwarden Cloud)
+
+| Service | US endpoint | EU endpoint |
+|---|---|---|
+| API | `https://api.bitwarden.com` | `https://api.bitwarden.eu` |
+| Identity | `https://identity.bitwarden.com` | `https://identity.bitwarden.eu` |
+| Icons | `https://icons.bitwarden.net` | `https://icons.bitwarden.net` |
+
+Cloud login requires a registered `client_id` injected at build time via `LocalSecrets.xcconfig`
+→ `BWClientIdentifier` in `Info.plist` → `Config.bitwardenClientIdentifier`. This value is
+never logged. See `DEVELOPMENT.md` for setup instructions.
+
+### New-device OTP memory handling
+
+When Bitwarden Cloud returns HTTP 400 `device_error`, the app stores a `PendingNewDeviceOTP`
+struct in memory holding the stretched master keys. These keys are zeroed in-place (via
+`Data.resetBytes(in:)`) in all exit paths: OTP success, OTP failure, and explicit cancel.
+Setting the struct to `nil` alone is insufficient — ARC may defer deallocation. In-place
+zeroing reduces the window during which derived key material can be read from a heap dump
+(Constitution §III).
+
 ### Algorithms
 
 | Algorithm | Purpose | Implementation |

--- a/openspec/changes/hosted-cloud-support/.openspec.yaml
+++ b/openspec/changes/hosted-cloud-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-18

--- a/openspec/changes/hosted-cloud-support/design.md
+++ b/openspec/changes/hosted-cloud-support/design.md
@@ -82,7 +82,7 @@ Existing Keychain records with no `serverType` key SHALL decode as `selfHosted` 
 
 ### Decision: `PrizmAPIClient` accepts `ServerEnvironment` directly
 
-`PrizmAPIClient` SHALL replace `setBaseURL(_ url: URL)` with `setServerEnvironment(_ env: ServerEnvironment)`. All ~32 endpoint methods SHALL route to `env.apiURL`, `env.identityURL`, or `env.iconsURL`. `AuthRepositoryImpl.setServerEnvironment(_:)` SHALL call `apiClient.setServerEnvironment(environment)` instead of `apiClient.setBaseURL(environment.base)`. The computed properties already return the right values — this is purely wiring.
+`PrizmAPIClient` SHALL replace `setBaseURL(_ url: URL)` with `setServerEnvironment(_ env: ServerEnvironment)`. All ~32 endpoint methods SHALL route to `env.apiURL`, `env.identityURL`, or `env.iconsURL` using service-relative paths (e.g. `accounts/prelogin`, `connect/token`, `sync`) — stripping the current `api/` and `identity/` prefixes from the path strings. The `ServerEnvironment` computed properties absorb this difference: cloud URLs have no prefix (`https://api.bitwarden.com`), while self-hosted URLs include it (`{base}/api`). This way endpoint methods use the same path regardless of server type. `AuthRepositoryImpl.setServerEnvironment(_:)` SHALL call `apiClient.setServerEnvironment(environment)` instead of `apiClient.setBaseURL(environment.base)`.
 
 ### Decision: Email/password login only; registered `client_id` enables cloud auth
 

--- a/openspec/changes/hosted-cloud-support/design.md
+++ b/openspec/changes/hosted-cloud-support/design.md
@@ -87,6 +87,14 @@ If the cloud server returns an hCaptcha challenge, a `WKWebView` modal handles i
 
 SwiftUI has no native web view API on macOS. `WKWebView` (WebKit framework) is the only platform-provided mechanism for rendering an interactive web challenge inline. Per §I, AppKit/non-SwiftUI APIs are permitted when SwiftUI has no equivalent — this qualifies. The `WKWebView` is scoped strictly to the hCaptcha modal; no other web rendering is used in the app. This usage MUST be documented in the Complexity Tracking table when the implementation plan is written.
 
+### Decision: hCaptcha token handoff via `WKScriptMessageHandler`
+
+When hCaptcha completes, its JS calls `window.webkit.messageHandlers.hcaptcha.postMessage(token)`. The native `WKScriptMessageHandler` delegate receives the token string, dismisses the modal, and passes it directly into a retry of `identityToken`. The token is held only in memory for the duration of the retry and is not persisted.
+
+This is the standard Apple-documented JS-to-native bridge. No third-party bridge library is used. The message handler name (`"hcaptcha"`) is registered on `WKWebViewConfiguration.userContentController` before the view loads.
+
+**Security note**: the handler MUST validate that the received message is a non-empty string before passing it to `identityToken`. Any other message type SHALL be discarded and the modal closed with an error.
+
 ### Decision: Data layer multi-account-ready; UI single-account for this release
 
 `ServerEnvironment` is keyed by `userId` in Keychain. Adding a second account in a future release requires no data layer changes. This release manages one active account at a time. Multi-account UI is deferred.

--- a/openspec/changes/hosted-cloud-support/design.md
+++ b/openspec/changes/hosted-cloud-support/design.md
@@ -41,15 +41,26 @@ The following is already in the codebase and must be extended rather than create
 
 The login screen SHALL present a segmented picker (or equivalent) with three options:
 
-1. **Bitwarden Cloud (US)** — no URL entry; cloud service URLs auto-configured
+1. **Bitwarden Cloud (US)** — no URL entry; US service URLs auto-configured
 2. **Bitwarden Cloud (EU)** — no URL entry; EU service URLs auto-configured
 3. **Self-hosted** — shows the existing server URL field
 
 Showing US and EU as distinct top-level choices makes the region decision explicit and avoids any ambiguity about which data centre stores the user's vault. The static subtitle "Self-hosted vault" is replaced by the picker.
 
-**Alternative considered**: Single "Bitwarden Cloud" option with a secondary region dropdown. Rejected — hides a decision that has real data-residency implications; users should see it upfront.
+**API Endpoints**:
 
-**Alternative considered**: Auto-detect region from email domain. Rejected — not reliable; same email can be registered in either region.
+| US                     | EU                    |
+|:-----------------------|:----------------------|
+| api.bitwarden.com      | api.bitwarden.eu      |
+| events.bitwarden.com   | events.bitwarden.eu   |
+| identity.bitwarden.com | identity.bitwarden.eu |
+| scim.bitwarden.com     | scim.bitwarden.eu     |
+| sso.bitwarden.com      | sso.bitwarden.eu      |
+| push.bitwarden.com     | push.bitwarden.eu     |
+
+Note that `func.bitwarden.com` and `icons.bitwarden.net` are the same across clouds. Values taken from [Bitwarden's official documentation](https://bitwarden.com/help/bitwarden-addresses/#application-endpoints).
+
+**Alternative considered**: Single "Bitwarden Cloud" option with a secondary region dropdown. Rejected — hides a decision that has real data-residency implications; users should see it upfront.
 
 ### Decision: `ServerType` flat enum with three cases
 
@@ -105,6 +116,6 @@ The registered Bitwarden client identifier SHALL be set in a gitignored `LocalSe
 
 ## Risks / Trade-offs
 
-- **EU endpoint URLs must be verified against Bitwarden's official documentation** before release. The URLs in the `ServerType` table above are based on the known Bitwarden EU region setup; confirm `api.bitwarden.eu`, `identity.bitwarden.eu`, `icons.bitwarden.eu` are correct before shipping.
+- **hCaptcha trigger conditions**: The server conditionally requires hCaptcha. The exact HTTP status and response structure indicating a required hCaptcha challenge needs to be determined at implementation time.
 - **Client identifier must never appear in the repo**: injected via gitignored xcconfig. CI injects from a secret. Development builds without the key will fail cloud login at runtime with a clear error.
 - **Self-hosted URL validation**: `AuthRepositoryImpl.validateServerURL()` already enforces HTTPS-only and strips trailing slashes. No new logic needed.

--- a/openspec/changes/hosted-cloud-support/design.md
+++ b/openspec/changes/hosted-cloud-support/design.md
@@ -2,67 +2,97 @@
 
 Prizm currently supports only self-hosted Vaultwarden instances. Users must manually configure URLs for API, Identity, and Icons endpoints (e.g., `https://vault.example.com/api/...`, `https://vault.example.com/identity/...`). While this works for self-hosted users, it is not a good experience for users of Bitwarden's hosted cloud service, who expect a simple "Log in to Bitwarden Cloud" flow similar to the official Bitwarden clients.
 
-More importantly, Bitwarden Cloud requires [hCaptcha](https://www.hcaptcha.com/) verification for login from unrecognized devices. Implementing hCaptcha support adds an additional web-based challenge to the login flow.
+Bitwarden Cloud operates two independent regions: the international US region (bitwarden.com) and the EU region (bitwarden.eu), each with its own set of service endpoints. Users must choose the correct region — selecting the wrong one will produce an authentication failure.
 
-The Prizm API client (`PrizmAPIClient`) currently constructs URLs by appending paths to a single base URL. Bitwarden Cloud uses separate domains for different services: `api.bitwarden.com`, `identity.bitwarden.com`, and `icons.bitwarden.net`. Supporting cloud requires refactoring URL construction to use separate base URLs per endpoint type.
+Bitwarden Cloud requires [hCaptcha](https://www.hcaptcha.com/) verification for login from unrecognized devices. This adds a web-based challenge to the login flow.
 
-Finally, Bitwarden Cloud requires a registered client identifier per their Device Registration ADR. This identifier must be included in API requests and must be obtained from Bitwarden, Inc. before any public release targeting bitwarden.com.
+The Prizm API client (`PrizmAPIClient`) currently constructs URLs by appending paths to a single `baseURL`. Both cloud regions and self-hosted instances use distinct domains per service type (api, identity, icons). Supporting all three options requires wiring per-service URLs through to all call sites.
+
+Bitwarden Cloud requires a registered client identifier per their Device Registration ADR. This identifier must be injected at build time and must never appear in the repository.
+
+### Existing infrastructure (post-merge baseline)
+
+The following is already in the codebase and must be extended rather than created:
+
+- **`ServerEnvironment`** (`Domain/Entities/Account.swift`) — struct with `base: URL`, optional `overrides: ServerURLOverrides?`, and computed properties `apiURL`, `identityURL`, `iconsURL`. Serialised to Keychain per account under `bw.macos:{userId}:serverEnvironment`. No cloud/region variant — only models self-hosted today.
+- **`AuthRepository.setServerEnvironment(_ env:)`** — declared and implemented; currently only calls `apiClient.setBaseURL(environment.base)`, ignoring `apiURL`/`identityURL`/`iconsURL`.
+- **`PrizmAPIClient.setBaseURL(_ url: URL)`** — actor method; all ~32 endpoint methods use `base.appendingPathComponent(...)`. Per-service URL properties on `ServerEnvironment` are never passed through.
+- **`LoginView` / `LoginViewModel`** — single `serverURL: String` field, static subtitle "Self-hosted vault".
+- **`bw.macos:{userId}:serverEnvironment`** — Keychain key already in use for self-hosted accounts.
 
 ## Goals / Non-Goals
 
 **Goals:**
-- Provide a polished "Bitwarden Cloud" option alongside "Self-hosted" in the login flow
-- Auto-fill standard cloud URLs (api.bitwarden.com, identity.bitwarden.com, icons.bitwarden.net) when cloud is selected
-- Refactor `PrizmAPIClient` to use separate URLs per endpoint type (API, Identity, Icons)
-- Support hCaptcha verification through an embedded `WKWebView`
-- Persist server environment configuration per account
-- Include registered client identifier in cloud API requests
+- Three-way server picker in `LoginView`: Bitwarden Cloud (US), Bitwarden Cloud (EU), Self-hosted
+- Wire `PrizmAPIClient` to route requests via `env.apiURL` / `env.identityURL` / `env.iconsURL`
+- Support hCaptcha via `WKWebView` for cloud password login
+- Handle hCaptcha challenges via `WKWebView` for cloud password login
+- Persist server environment per account in Keychain (data layer multi-account-ready)
+- Include registered client identifier in cloud API requests; identifier injected at build time, never in repo
 
 **Non-Goals:**
-- Automatic detection of server type from URL (user must explicitly choose cloud vs self-hosted)
+- Automatic server type detection from a URL
+- Multi-account UI — running multiple accounts simultaneously (deferred to a later release)
 - Multi-device cloud sync coordination (existing sync mechanisms are unchanged)
 
 ## Decisions
 
-### Decision: Explicit cloud/self-hosted toggle in `LoginView`
+### Decision: Three-way server picker in `LoginView`
 
-Users must explicitly choose between "Bitwarden Cloud" and "Self-hosted" via a picker or toggle. The selection determines whether URLs are auto-filled (cloud) or manually entered (self-hosted). This preserves the UX principle that the user should always be in control of where their data is stored.
+The login screen SHALL present a segmented picker (or equivalent) with three options:
 
-**Alternative considered**: Automatically detect cloud vs self-hosted from the input URL. Rejected because this would create ambiguity if a self-hosted instance uses a similar domain pattern or if cloud URLs change.
+1. **Bitwarden Cloud (US)** — no URL entry; cloud service URLs auto-configured
+2. **Bitwarden Cloud (EU)** — no URL entry; EU service URLs auto-configured
+3. **Self-hosted** — shows the existing server URL field
 
-### Decision: Separate URLs per endpoint type in `PrizmAPIClient`
+Showing US and EU as distinct top-level choices makes the region decision explicit and avoids any ambiguity about which data centre stores the user's vault. The static subtitle "Self-hosted vault" is replaced by the picker.
 
-`PrizmAPIClient` shall be refactored to accept separate base URLs for API, Identity, and Icons endpoints. This matches the Bitwarden Cloud architecture (separate domains) and preserves flexibility for future self-hosted installations that might also use separate domains.
+**Alternative considered**: Single "Bitwarden Cloud" option with a secondary region dropdown. Rejected — hides a decision that has real data-residency implications; users should see it upfront.
 
-### Decision: `ServerEnvironment` entity to encapsulate configuration
+**Alternative considered**: Auto-detect region from email domain. Rejected — not reliable; same email can be registered in either region.
 
-A new Domain entity `ServerEnvironment` shall encapsulate the server type (cloud vs self-hosted) and the three URLs. This keeps the configuration type-safe and makes it easy to persist and restore the environment per account.
+### Decision: `ServerType` flat enum with three cases
 
-**Alternative considered**: Store three separate URL values without a container. Rejected because this decouples the three URLs that logically belong to a single environment configuration.
+`ServerEnvironment` SHALL gain a `ServerType` enum with three cases: `cloudUS`, `cloudEU`, `selfHosted`. The computed `apiURL`/`identityURL`/`iconsURL` properties SHALL return the correct canonical URLs per case:
 
-### Decision: Use `WKWebView` to support hCaptcha challenges
+| Case | apiURL | identityURL | iconsURL |
+|---|---|---|---|
+| `cloudUS` | `https://api.bitwarden.com` | `https://identity.bitwarden.com` | `https://icons.bitwarden.net` |
+| `cloudEU` | `https://api.bitwarden.eu` | `https://identity.bitwarden.eu` | `https://icons.bitwarden.net` |
+| `selfHosted` | `{base}/api` (or override) | `{base}/identity` (or override) | `{base}/icons` (or override) |
 
-While this is more complex for initial implementation, it provides a maximally user-friendly experience. Using the system's built-in `WKWebView` does not deviate from the principles of native-first UI for this use case.
+The existing `overrides: ServerURLOverrides?` field is retained for self-hosted instances that split services across domains. Cloud cases ignore `overrides`.
 
-API key authentication via OAuth client credentials flow
+**Alternative considered**: `cloud(region: CloudRegion)` associated-value enum. Rejected — YAGNI; two named cases are clearer and simpler than an associated value with a nested type when there are only two regions.
 
-Support personal API key authentication (client_id/client_secret) using the OAuth client credentials grant type. This bypasses the hCaptcha requirement entirely and is simpler than implementing a web view or system browser redirect.
+**Alternative considered**: Separate type per case. Rejected — breaks existing Keychain serialisation format.
 
-**Alternative considered**: Support only API key auth initially, removing the need for hCaptcha entirely. Rejected as poor user experience.
+Existing Keychain records with no `serverType` key SHALL decode as `selfHosted` (backwards-compatible; no migration step needed).
 
-**Alternative considered**: System browser OAuth redirect. Rejected as sub-optimal user experience, having to leave the app and return to it.
+### Decision: `PrizmAPIClient` accepts `ServerEnvironment` directly
 
-### Decision: Server environment persists per account
+`PrizmAPIClient` SHALL replace `setBaseURL(_ url: URL)` with `setServerEnvironment(_ env: ServerEnvironment)`. All ~32 endpoint methods SHALL route to `env.apiURL`, `env.identityURL`, or `env.iconsURL`. `AuthRepositoryImpl.setServerEnvironment(_:)` SHALL call `apiClient.setServerEnvironment(environment)` instead of `apiClient.setBaseURL(environment.base)`. The computed properties already return the right values — this is purely wiring.
 
-Server environment configuration shall be stored per account in secure `UserDefaults` (typically not a secret). When switching accounts, the correct environment for that account is restored. This ensures that multi-account users can have some accounts on cloud and others on self-hosted instances.
+### Decision: Email/password login only; registered `client_id` enables cloud auth
 
-**Alternative considered**: Global server environment setting. Rejected because this would not support mixed multi-account scenarios.
+All three server options use email + master password login. No API key login UI is needed.
 
-### Decision: Client identifier for cloud only
+The Bitwarden OAuth password grant already requires a `client_id` parameter identifying the client application — `PrizmAPIClient` sends it today as `ClientHeaders.clientId = "desktop"`. For cloud accounts this value is replaced with the registered identifier from Bitwarden, Inc., injected via xcconfig. This is transparent to the user; no extra UI is required.
 
-The registered client identifier shall be included only in requests to Bitwarden Cloud endpoints. Self-hosted Vaultwarden instances do not require this header. The client identifier shall be configurable (not hardcoded) to facilitate updates and avoid including unreleased identifiers in source code.
+If the cloud server returns an hCaptcha challenge, a `WKWebView` modal handles it before the token request is retried.
+
+**Alternative considered**: API key login (`client_credentials` grant) as a CAPTCHA bypass. Rejected — out of scope for this release; the hCaptcha `WKWebView` path covers the cloud login requirement without adding a second authentication mode.
+
+### Decision: Data layer multi-account-ready; UI single-account for this release
+
+`ServerEnvironment` is keyed by `userId` in Keychain. Adding a second account in a future release requires no data layer changes. This release manages one active account at a time. Multi-account UI is deferred.
+
+### Decision: Client identifier injected at build time via gitignored xcconfig
+
+The registered Bitwarden client identifier SHALL be set in a gitignored `LocalSecrets.xcconfig` file and surfaced in the app via an `Info.plist` key read by `Config.swift`. When the key is absent (e.g. a fresh clone), the value defaults to an empty string and cloud login fails with a clear error at runtime. CI/CD injects the value from a secret.
 
 ## Risks / Trade-offs
 
-- **Registered client identifier required for bitwarden.com release**: Per the Constitution line 220, a registered client identifier from Bitwarden, Inc. is required before any release targeting bitwarden.com. This must be obtained externally and configured at build or runtime. Mitigation: The design makes the client identifier configurable; placeholder value can be used for development.
-- **URL validation must be careful for self-hosted**: Users may enter invalid URLs. Mitigation: Validate URL schemes (require HTTPS) and basic reachability before attempting login; surface clear error messages.
+- **EU endpoint URLs must be verified against Bitwarden's official documentation** before release. The URLs in the `ServerType` table above are based on the known Bitwarden EU region setup; confirm `api.bitwarden.eu`, `identity.bitwarden.eu`, `icons.bitwarden.eu` are correct before shipping.
+- **Client identifier must never appear in the repo**: injected via gitignored xcconfig. CI injects from a secret. Development builds without the key will fail cloud login at runtime with a clear error.
+- **Self-hosted URL validation**: `AuthRepositoryImpl.validateServerURL()` already enforces HTTPS-only and strips trailing slashes. No new logic needed.

--- a/openspec/changes/hosted-cloud-support/design.md
+++ b/openspec/changes/hosted-cloud-support/design.md
@@ -83,6 +83,10 @@ If the cloud server returns an hCaptcha challenge, a `WKWebView` modal handles i
 
 **Alternative considered**: API key login (`client_credentials` grant) as a CAPTCHA bypass. Rejected — out of scope for this release; the hCaptcha `WKWebView` path covers the cloud login requirement without adding a second authentication mode.
 
+### Decision: `WKWebView` for hCaptcha (§I AppKit exception)
+
+SwiftUI has no native web view API on macOS. `WKWebView` (WebKit framework) is the only platform-provided mechanism for rendering an interactive web challenge inline. Per §I, AppKit/non-SwiftUI APIs are permitted when SwiftUI has no equivalent — this qualifies. The `WKWebView` is scoped strictly to the hCaptcha modal; no other web rendering is used in the app. This usage MUST be documented in the Complexity Tracking table when the implementation plan is written.
+
 ### Decision: Data layer multi-account-ready; UI single-account for this release
 
 `ServerEnvironment` is keyed by `userId` in Keychain. Adding a second account in a future release requires no data layer changes. This release manages one active account at a time. Multi-account UI is deferred.

--- a/openspec/changes/hosted-cloud-support/design.md
+++ b/openspec/changes/hosted-cloud-support/design.md
@@ -1,0 +1,68 @@
+## Context
+
+Prizm currently supports only self-hosted Vaultwarden instances. Users must manually configure URLs for API, Identity, and Icons endpoints (e.g., `https://vault.example.com/api/...`, `https://vault.example.com/identity/...`). While this works for self-hosted users, it is not a good experience for users of Bitwarden's hosted cloud service, who expect a simple "Log in to Bitwarden Cloud" flow similar to the official Bitwarden clients.
+
+More importantly, Bitwarden Cloud requires [hCaptcha](https://www.hcaptcha.com/) verification for login from unrecognized devices. Implementing hCaptcha support adds an additional web-based challenge to the login flow.
+
+The Prizm API client (`PrizmAPIClient`) currently constructs URLs by appending paths to a single base URL. Bitwarden Cloud uses separate domains for different services: `api.bitwarden.com`, `identity.bitwarden.com`, and `icons.bitwarden.net`. Supporting cloud requires refactoring URL construction to use separate base URLs per endpoint type.
+
+Finally, Bitwarden Cloud requires a registered client identifier per their Device Registration ADR. This identifier must be included in API requests and must be obtained from Bitwarden, Inc. before any public release targeting bitwarden.com.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a polished "Bitwarden Cloud" option alongside "Self-hosted" in the login flow
+- Auto-fill standard cloud URLs (api.bitwarden.com, identity.bitwarden.com, icons.bitwarden.net) when cloud is selected
+- Refactor `PrizmAPIClient` to use separate URLs per endpoint type (API, Identity, Icons)
+- Support hCaptcha verification through an embedded `WKWebView`
+- Persist server environment configuration per account
+- Include registered client identifier in cloud API requests
+
+**Non-Goals:**
+- Automatic detection of server type from URL (user must explicitly choose cloud vs self-hosted)
+- Multi-device cloud sync coordination (existing sync mechanisms are unchanged)
+
+## Decisions
+
+### Decision: Explicit cloud/self-hosted toggle in `LoginView`
+
+Users must explicitly choose between "Bitwarden Cloud" and "Self-hosted" via a picker or toggle. The selection determines whether URLs are auto-filled (cloud) or manually entered (self-hosted). This preserves the UX principle that the user should always be in control of where their data is stored.
+
+**Alternative considered**: Automatically detect cloud vs self-hosted from the input URL. Rejected because this would create ambiguity if a self-hosted instance uses a similar domain pattern or if cloud URLs change.
+
+### Decision: Separate URLs per endpoint type in `PrizmAPIClient`
+
+`PrizmAPIClient` shall be refactored to accept separate base URLs for API, Identity, and Icons endpoints. This matches the Bitwarden Cloud architecture (separate domains) and preserves flexibility for future self-hosted installations that might also use separate domains.
+
+### Decision: `ServerEnvironment` entity to encapsulate configuration
+
+A new Domain entity `ServerEnvironment` shall encapsulate the server type (cloud vs self-hosted) and the three URLs. This keeps the configuration type-safe and makes it easy to persist and restore the environment per account.
+
+**Alternative considered**: Store three separate URL values without a container. Rejected because this decouples the three URLs that logically belong to a single environment configuration.
+
+### Decision: Use `WKWebView` to support hCaptcha challenges
+
+While this is more complex for initial implementation, it provides a maximally user-friendly experience. Using the system's built-in `WKWebView` does not deviate from the principles of native-first UI for this use case.
+
+API key authentication via OAuth client credentials flow
+
+Support personal API key authentication (client_id/client_secret) using the OAuth client credentials grant type. This bypasses the hCaptcha requirement entirely and is simpler than implementing a web view or system browser redirect.
+
+**Alternative considered**: Support only API key auth initially, removing the need for hCaptcha entirely. Rejected as poor user experience.
+
+**Alternative considered**: System browser OAuth redirect. Rejected as sub-optimal user experience, having to leave the app and return to it.
+
+### Decision: Server environment persists per account
+
+Server environment configuration shall be stored per account in secure `UserDefaults` (typically not a secret). When switching accounts, the correct environment for that account is restored. This ensures that multi-account users can have some accounts on cloud and others on self-hosted instances.
+
+**Alternative considered**: Global server environment setting. Rejected because this would not support mixed multi-account scenarios.
+
+### Decision: Client identifier for cloud only
+
+The registered client identifier shall be included only in requests to Bitwarden Cloud endpoints. Self-hosted Vaultwarden instances do not require this header. The client identifier shall be configurable (not hardcoded) to facilitate updates and avoid including unreleased identifiers in source code.
+
+## Risks / Trade-offs
+
+- **Registered client identifier required for bitwarden.com release**: Per the Constitution line 220, a registered client identifier from Bitwarden, Inc. is required before any release targeting bitwarden.com. This must be obtained externally and configured at build or runtime. Mitigation: The design makes the client identifier configurable; placeholder value can be used for development.
+- **URL validation must be careful for self-hosted**: Users may enter invalid URLs. Mitigation: Validate URL schemes (require HTTPS) and basic reachability before attempting login; surface clear error messages.

--- a/openspec/changes/hosted-cloud-support/proposal.md
+++ b/openspec/changes/hosted-cloud-support/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Prizm currently supports self-hosted Vaultwarden instances but does not provide a built-in option for users who prefer Bitwarden's hosted cloud service.
+
+This change adds first-class support for Bitwarden Cloud alongside self-hosted servers, including proper endpoint configuration, a straightforward cloud/self-hosted toggle in the login flow, and multiple authentication / validation pathways.
+
+## What Changes
+
+- Add `ServerEnvironment` domain entity to represent cloud vs self-hosted with separate URLs for API, Identity, and Icons
+- Add `LoginView` UI toggle between "Bitwarden Cloud" (auto-filled URLs) and "Self-hosted" (manual URL entry)
+- Configure `PrizmAPIClient` to use `ServerEnvironment` URLs (not a single base URL)
+- Provide an in-app `WKWebView` modal for CAPTCHA verification
+- Persist server environment configuration per account
+- Include registered client identifier for Bitwarden Cloud requests
+
+## Capabilities
+
+### New Capabilities
+- `hosted-cloud-support`: Enable users to choose Bitwarden Cloud or self-hosted Vaultwarden as their server environment
+
+### Modified Capabilities
+- `vault-browser-ui`: Login flow includes server environment selection UI
+
+## Impact
+
+- **Domain layer**: New `ServerEnvironment` entity, modified auth use cases to support API key flow
+- **Data layer**: `PrizmAPIClient` updated to accept separate URLs per endpoint type; repository changes for server environment persistence
+- **Presentation layer**: `LoginView` updated with server environment picker and API key option
+  - If Bitwarden Cloud is selected, OAuth flow will include launching a `WKWebView` to pass Bitwarden's hosted hCaptcha
+- **No changes to vault storage or sync mechanisms** — this change only affects how endpoints are configured, not how vault data is handled

--- a/openspec/changes/hosted-cloud-support/proposal.md
+++ b/openspec/changes/hosted-cloud-support/proposal.md
@@ -2,16 +2,21 @@
 
 Prizm currently supports self-hosted Vaultwarden instances but does not provide a built-in option for users who prefer Bitwarden's hosted cloud service.
 
-This change adds first-class support for Bitwarden Cloud alongside self-hosted servers, including proper endpoint configuration, a straightforward cloud/self-hosted toggle in the login flow, and multiple authentication / validation pathways.
+This change adds first-class support for Bitwarden Cloud alongside self-hosted servers, including proper endpoint configuration and a cloud/self-hosted toggle in the login flow.
+
+## Scope
+
+**This release:** Single active account. The user picks cloud or self-hosted at login. Only one account is active at a time.
+
+**Deferred to a later release:** Running a cloud account and a self-hosted account simultaneously (multi-account UI). The data layer is designed for multi-account from the start (per-userId Keychain keys), so that release will require no data layer changes.
 
 ## What Changes
 
-- Add `ServerEnvironment` domain entity to represent cloud vs self-hosted with separate URLs for API, Identity, and Icons
-- Add `LoginView` UI toggle between "Bitwarden Cloud" (auto-filled URLs) and "Self-hosted" (manual URL entry)
-- Configure `PrizmAPIClient` to use `ServerEnvironment` URLs (not a single base URL)
-- Provide an in-app `WKWebView` modal for CAPTCHA verification
-- Persist server environment configuration per account
-- Include registered client identifier for Bitwarden Cloud requests
+- Extend `ServerEnvironment` domain entity with a three-case `ServerType` enum: `cloudUS`, `cloudEU`, `selfHosted` — each case returns the correct canonical URLs from the computed properties
+- Refactor `PrizmAPIClient` to accept a `ServerEnvironment` instead of a single base URL, wiring `apiURL`/`identityURL`/`iconsURL` through to all ~32 call sites
+- Update `LoginView` with a three-way picker (Bitwarden Cloud (US) / Bitwarden Cloud (EU) / Self-hosted); hide the server URL field for cloud options
+- Replace `ClientHeaders.clientId` (`"desktop"`) with the registered identifier from Bitwarden, Inc., injected at build time via gitignored xcconfig — this is what authorises email/password login on Bitwarden Cloud
+- Handle hCaptcha challenges via an in-app `WKWebView` modal when the cloud server requires it
 
 ## Capabilities
 
@@ -23,8 +28,7 @@ This change adds first-class support for Bitwarden Cloud alongside self-hosted s
 
 ## Impact
 
-- **Domain layer**: New `ServerEnvironment` entity, modified auth use cases to support API key flow
-- **Data layer**: `PrizmAPIClient` updated to accept separate URLs per endpoint type; repository changes for server environment persistence
-- **Presentation layer**: `LoginView` updated with server environment picker and API key option
-  - If Bitwarden Cloud is selected, OAuth flow will include launching a `WKWebView` to pass Bitwarden's hosted hCaptcha
-- **No changes to vault storage or sync mechanisms** — this change only affects how endpoints are configured, not how vault data is handled
+- **Domain layer**: `ServerEnvironment` extended with `ServerType` enum; no breaking changes to existing self-hosted accounts
+- **Data layer**: `PrizmAPIClient` refactored to use per-service URLs; `AuthRepositoryImpl.setServerEnvironment` wired to new API client method; backwards-compatible Keychain migration for existing records
+- **Presentation layer**: `LoginView` updated with server type picker and API key login option for cloud; no changes to vault browser or sync UI
+- **No changes to vault storage or sync mechanisms**

--- a/openspec/changes/hosted-cloud-support/proposal.md
+++ b/openspec/changes/hosted-cloud-support/proposal.md
@@ -30,5 +30,5 @@ This change adds first-class support for Bitwarden Cloud alongside self-hosted s
 
 - **Domain layer**: `ServerEnvironment` extended with `ServerType` enum; no breaking changes to existing self-hosted accounts
 - **Data layer**: `PrizmAPIClient` refactored to use per-service URLs; `AuthRepositoryImpl.setServerEnvironment` wired to new API client method; backwards-compatible Keychain migration for existing records
-- **Presentation layer**: `LoginView` updated with server type picker and API key login option for cloud; no changes to vault browser or sync UI
+- **Presentation layer**: `LoginView` updated with server type picker for cloud/self-hosted selection; no changes to vault browser or sync UI
 - **No changes to vault storage or sync mechanisms**

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -264,12 +264,23 @@ func resendNewDeviceOTP() async throws
 func cancelNewDeviceOTP()
 ```
 
-`AuthRepository` SHALL gain a matching method:
+`AuthRepository` SHALL gain three matching methods:
 ```swift
+/// Retries the identity token request with the supplied OTP. Zeros cached credentials after attempt.
 func loginWithNewDeviceOTP(_ otp: String) async throws -> Account
+
+/// Retries the original identity token request without an OTP, triggering the server to
+/// dispatch a new verification code. Does NOT return an Account — the user remains in
+/// the awaitingOTP state after this call.
+func requestNewDeviceOTP() async throws
+
+/// Zeros any cached credentials held from the pending new-device OTP challenge.
+func cancelNewDeviceOTP()
 ```
 
-`AuthRepositoryImpl` holds the pending environment, email, and hashed password in memory after throwing `newDeviceVerificationRequired`. `loginWithNewDeviceOTP` retries `PrizmAPIClient.identityToken` with the `newdeviceotp` form parameter added, then zeros the cached credentials immediately after the attempt (success or failure). `cancelNewDeviceOTP` zeros the cached credentials without retrying.
+`AuthRepositoryImpl` holds the pending environment, email, and hashed password in memory after throwing `newDeviceVerificationRequired`. `loginWithNewDeviceOTP` retries `PrizmAPIClient.identityToken` with the `newdeviceotp` form parameter added, then zeros cached credentials immediately after (success or failure). `requestNewDeviceOTP` re-posts the original identity token request without `newdeviceotp` — the server recognises the unverified device and sends a fresh code; no credentials are zeroed since the challenge is still pending. `cancelNewDeviceOTP` zeros cached credentials without making a network request.
+
+`LoginUseCase.resendNewDeviceOTP()` calls `auth.requestNewDeviceOTP()` — not `loginWithNewDeviceOTP`.
 
 `LoginViewModel` catches `AuthError.newDeviceVerificationRequired`, transitions to `awaitingOTP` state, and on Sign In calls `loginUseCase.completeNewDeviceOTP(otp:)`.
 
@@ -330,7 +341,7 @@ During `awaitingOTP`, email and master password fields SHALL be visible but disa
 #### Scenario: Cancel clears OTP state
 - **GIVEN** `loginState == .awaitingOTP`
 - **WHEN** the user taps Cancel
-- **THEN** `loginState` SHALL transition to `idle`
+- **THEN** `LoginViewModel` SHALL call `loginUseCase.cancelNewDeviceOTP()` before transitioning `loginState` to `idle`
 - **AND** the OTP field SHALL be hidden and its value cleared
 
 ---
@@ -455,7 +466,7 @@ Per §IV, tests MUST be written before implementation. The following are require
 - `loginState` transitions to `.idle` when Cancel is tapped from `.awaitingOTP`
 - `loginState` remains `.awaitingOTP` after an invalid OTP error; error message is set
 - `loginUseCase.resendNewDeviceOTP()` is called when "Resend code" is tapped; OTP field is cleared and confirmation is announced
-- `LoginUseCaseImpl.resendNewDeviceOTP()` calls `auth.loginWithNewDeviceOTP` without an OTP value to re-trigger server dispatch
+- `LoginUseCaseImpl.resendNewDeviceOTP()` calls `auth.requestNewDeviceOTP()` to re-trigger server dispatch
 
 **Integration tests:**
 - Full login flow against a Vaultwarden stub (existing coverage) continues to pass after the `PrizmAPIClient` refactor

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -225,30 +225,36 @@ After successful login, the `ServerEnvironment` (including `serverType`) SHALL b
 
 ### Requirement: Registered client identifier used for all cloud requests
 
-Both the OAuth password grant (`grant_type=password`) and the token refresh grant (`grant_type=refresh_token`) require a `client_id` parameter identifying the client application. Confirmed against the Bitwarden iOS reference client: both request types send the same registered identifier (`"mobile"` for the iOS client). `PrizmAPIClient` currently sends `ClientHeaders.clientId = "desktop"` in both `identityToken` (line 463) and `refreshAccessToken` (line 1004). For cloud accounts both call sites SHALL use the registered identifier injected at build time via a gitignored `.xcconfig` file. Self-hosted login is unaffected — Vaultwarden does not enforce this identifier.
+Per [ADR-0023](https://contributing.bitwarden.com/architecture/adr/integration-identifiers/), third-party clients must obtain a registered identifier from Bitwarden via a support ticket. Without it, Bitwarden Cloud rejects requests with `400 Bad Request` (missing required headers) or `403 Forbidden` (unsupported identifier). Self-hosted instances perform no such checks. Prizm has obtained its registered identifier; it is injected at build time via a gitignored `LocalSecrets.xcconfig` file and MUST NOT appear in source control.
 
-`ClientHeaders.clientId` is currently a static constant. It SHALL become instance state on `PrizmAPIClient` (set via `setServerEnvironment`) so both call sites pick up the correct value for the active environment without any per-call parameter.
+`PrizmAPIClient` currently sends `ClientHeaders.clientId = "desktop"` — a real Bitwarden-registered identifier for their own desktop client. Using it would violate ADR-0023; Prizm's own registered identifier MUST be used instead.
+
+**Enforcement by grant type:**
+- `grant_type=password` (`identityToken`): strictly enforced on cloud — unregistered `client_id` → rejected
+- `grant_type=refresh_token` (`refreshAccessToken`): server-side allowlist check is bypassed for refresh grants (confirmed in `CustomTokenRequestValidator.cs`); `client_id` is not strictly validated. However, Bitwarden's official iOS client sends the same registered identifier in refresh requests for consistency, and Prizm SHALL do the same.
+
+Both `identityToken` (line 463) and `refreshAccessToken` (line 1004) SHALL use the registered identifier for cloud accounts. `ClientHeaders.clientId` is currently a static constant and SHALL become instance state on `PrizmAPIClient` (set via `setServerEnvironment`) so both call sites pick up the correct value automatically.
 
 The `client_id` is an app-level credential, not a per-user credential. No additional login UI is needed; it is transparent to the user.
 
 #### Scenario: Registered identifier sent on cloud password login
 - **GIVEN** the active account has `serverType == .cloudUS` or `serverType == .cloudEU`
 - **WHEN** `PrizmAPIClient` posts the identity token request (`grant_type=password`)
-- **THEN** the `client_id` form parameter SHALL equal the registered identifier (not `"desktop"`)
+- **THEN** the `client_id` form parameter SHALL equal Prizm's registered identifier (not `"desktop"`)
 
 #### Scenario: Registered identifier sent on cloud token refresh
 - **GIVEN** the active account has `serverType == .cloudUS` or `serverType == .cloudEU`
 - **WHEN** `PrizmAPIClient` posts a token refresh request (`grant_type=refresh_token`)
-- **THEN** the `client_id` form parameter SHALL equal the registered identifier (not `"desktop"`)
+- **THEN** the `client_id` form parameter SHALL equal Prizm's registered identifier for consistency with official Bitwarden clients
 
 #### Scenario: Unconfigured identifier blocks cloud login
 - **GIVEN** the xcconfig value for the client identifier is empty
 - **WHEN** the user attempts to log in with a cloud option selected
-- **THEN** login SHALL fail with a clear error indicating the client identifier is not configured
+- **THEN** login SHALL fail with `AuthError.clientIdentifierNotConfigured` before any network request is made
 
 #### Scenario: Self-hosted login unaffected
 - **GIVEN** the active account has `serverType == .selfHosted`
-- **THEN** the `client_id` value used in both `identityToken` and `refreshAccessToken` SHALL remain `"desktop"` (Vaultwarden-compatible default)
+- **THEN** the `client_id` value used in both `identityToken` and `refreshAccessToken` SHALL remain `"desktop"` (Vaultwarden-compatible default; self-hosted instances do not enforce identifier checks)
 
 ---
 

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -223,15 +223,22 @@ After successful login, the `ServerEnvironment` (including `serverType`) SHALL b
 
 ---
 
-### Requirement: Registered client identifier used for cloud password login
+### Requirement: Registered client identifier used for all cloud requests
 
-The Bitwarden OAuth password grant (`grant_type=password`) requires a `client_id` parameter identifying the client application. `PrizmAPIClient` already sends this as `ClientHeaders.clientId`, currently hardcoded to `"desktop"`. For cloud accounts this value SHALL be replaced with the registered identifier obtained from Bitwarden, Inc., injected at build time via a gitignored `.xcconfig` file. Self-hosted login is unaffected — Vaultwarden does not enforce this identifier.
+Both the OAuth password grant (`grant_type=password`) and the token refresh grant (`grant_type=refresh_token`) require a `client_id` parameter identifying the client application. Confirmed against the Bitwarden iOS reference client: both request types send the same registered identifier (`"mobile"` for the iOS client). `PrizmAPIClient` currently sends `ClientHeaders.clientId = "desktop"` in both `identityToken` (line 463) and `refreshAccessToken` (line 1004). For cloud accounts both call sites SHALL use the registered identifier injected at build time via a gitignored `.xcconfig` file. Self-hosted login is unaffected — Vaultwarden does not enforce this identifier.
+
+`ClientHeaders.clientId` is currently a static constant. It SHALL become instance state on `PrizmAPIClient` (set via `setServerEnvironment`) so both call sites pick up the correct value for the active environment without any per-call parameter.
 
 The `client_id` is an app-level credential, not a per-user credential. No additional login UI is needed; it is transparent to the user.
 
 #### Scenario: Registered identifier sent on cloud password login
 - **GIVEN** the active account has `serverType == .cloudUS` or `serverType == .cloudEU`
-- **WHEN** `PrizmAPIClient` posts the identity token request
+- **WHEN** `PrizmAPIClient` posts the identity token request (`grant_type=password`)
+- **THEN** the `client_id` form parameter SHALL equal the registered identifier (not `"desktop"`)
+
+#### Scenario: Registered identifier sent on cloud token refresh
+- **GIVEN** the active account has `serverType == .cloudUS` or `serverType == .cloudEU`
+- **WHEN** `PrizmAPIClient` posts a token refresh request (`grant_type=refresh_token`)
 - **THEN** the `client_id` form parameter SHALL equal the registered identifier (not `"desktop"`)
 
 #### Scenario: Unconfigured identifier blocks cloud login
@@ -241,7 +248,7 @@ The `client_id` is an app-level credential, not a per-user credential. No additi
 
 #### Scenario: Self-hosted login unaffected
 - **GIVEN** the active account has `serverType == .selfHosted`
-- **THEN** the `client_id` value used SHALL remain `"desktop"` (Vaultwarden-compatible default)
+- **THEN** the `client_id` value used in both `identityToken` and `refreshAccessToken` SHALL remain `"desktop"` (Vaultwarden-compatible default)
 
 ---
 
@@ -447,6 +454,7 @@ Per §IV, tests MUST be written before implementation. The following are require
 - `LoginUseCaseImpl` DOES call `auth.validateServerURL` when `environment.serverType == .selfHosted`
 - Cloud login attempt with empty client identifier throws before making a network request
 - `PrizmAPIClient` includes `Bitwarden-Client-Name`, `Bitwarden-Client-Version`, and `Device-Type` headers on a cloud `identityToken` request
+- `PrizmAPIClient.refreshAccessToken` sends the registered cloud `client_id` (not `"desktop"`) when `serverType` is cloud
 - `AuthRepositoryImpl` throws `AuthError.newDeviceVerificationRequired` when the identity token response is `HTTP 400` with `{"error": "device_error"}`
 - `LoginUseCaseImpl.completeNewDeviceOTP` calls `auth.loginWithNewDeviceOTP(_:)` and triggers sync on success
 - `LoginUseCaseImpl.cancelNewDeviceOTP` calls `auth.cancelNewDeviceOTP()` and makes no network request

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -159,6 +159,61 @@ All three server options use email + master password login. When a cloud account
 
 ---
 
+### Requirement: Accessibility
+
+All new interactive controls introduced by this change MUST be fully usable via VoiceOver (§VIII).
+
+- The server picker SHALL have an `accessibilityLabel` ("Server") and expose its current value via `accessibilityValue` (e.g. "Bitwarden Cloud (US)")
+- The server URL text field SHALL retain its existing `accessibilityIdentifier` and have a meaningful `accessibilityLabel` ("Server URL")
+- The hCaptcha `WKWebView` modal SHALL have an accessible dismiss path (a labelled close button); VoiceOver focus SHALL move into the modal on presentation and return to the login form on dismissal
+- Error messages (unreachable server, invalid credentials, missing client identifier) SHALL be announced via `AccessibilityNotification.Announcement` as soon as they appear
+
+#### Scenario: Picker exposes current selection to VoiceOver
+- **WHEN** the server picker has "Bitwarden Cloud (EU)" selected
+- **THEN** VoiceOver SHALL announce the control as "Server, Bitwarden Cloud (EU)"
+
+#### Scenario: Error announced to assistive technology
+- **WHEN** an error message appears in the login form
+- **THEN** an `AccessibilityNotification.Announcement` SHALL be posted with the error text
+
+---
+
+### Requirement: Observability
+
+All new code paths MUST produce structured `os.Logger` output (§V). Secrets MUST NOT appear in logs.
+
+- Server environment selection and restoration SHALL be logged at `.info` level, including the `serverType` value
+- Each identity token request SHALL log the target `identityURL` (not the password or hash) at `.info`
+- hCaptcha challenge receipt and completion SHALL be logged at `.info`
+- Client identifier misconfiguration SHALL be logged at `.error` before surfacing to the Presentation layer
+- URL validation failures (non-HTTPS, parse error) SHALL be logged at `.error`
+
+---
+
+### Requirement: Tests
+
+Per §IV, tests MUST be written before implementation. The following are required:
+
+**Unit tests (Domain):**
+- `ServerEnvironment` with `serverType == .cloudUS` returns correct US canonical URLs
+- `ServerEnvironment` with `serverType == .cloudEU` returns correct EU canonical URLs, and `iconsURL == https://icons.bitwarden.net`
+- `ServerEnvironment` with `serverType == .selfHosted` returns `base`-derived URLs unchanged
+- Decoding a legacy JSON record (no `serverType` key) yields `serverType == .selfHosted`
+
+**Unit tests (Data):**
+- `PrizmAPIClient.setServerEnvironment()` stores the environment and subsequent requests use `env.apiURL` / `env.identityURL` as appropriate (representative call sites: `preLogin`, `identityToken`, `fetchSync`)
+- `AuthRepositoryImpl.setServerEnvironment(_:)` calls `apiClient.setServerEnvironment(_:)` (not `setBaseURL`)
+- Cloud login attempt with empty client identifier throws before making a network request
+
+**Unit tests (Presentation):**
+- `LoginViewModel` server type selection is persisted and restored across instantiation
+- Selecting a cloud type clears `serverURL`; selecting self-hosted restores the last entered URL
+
+**Integration tests:**
+- Full login flow against a Vaultwarden stub (existing coverage) continues to pass after the `PrizmAPIClient` refactor
+
+---
+
 ### Requirement: Server environment errors surfaced clearly
 
 #### Scenario: Non-HTTPS self-hosted URL rejected

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -199,7 +199,7 @@ The existing `AuthError` enum (`Domain/Repositories/AuthRepository.swift`) SHALL
 | `clientIdentifierNotConfigured` | `AuthRepositoryImpl` (before network request) | `"Prizm is not configured for Bitwarden Cloud. Contact support or use a self-hosted server."` |
 | `newDeviceVerificationRequired` | `AuthRepositoryImpl` (on `device_error` 400 response) | `nil` — handled structurally by `LoginViewModel`; triggers the OTP entry UI, not a plain error string |
 
-`newDeviceVerificationRequired` is thrown when the server returns `HTTP 400` with `{"error": "device_error"}`. `LoginViewModel` catches it and transitions to `awaitingOTP` state rather than displaying an error string.
+`newDeviceVerificationRequired` is thrown when the server returns `HTTP 400` with `{"error": "device_error"}`. `LoginViewModel` catches it and transitions to `flowState = .otpPrompt` rather than displaying an error string.
 
 **Layer boundary**: `PrizmAPIClient.identityToken` throws a Data-layer error (e.g. `IdentityTokenError.newDeviceNotVerified`) when it receives a `device_error` response. `AuthRepositoryImpl` catches that Data-layer error and translates it to `AuthError.newDeviceVerificationRequired` before rethrowing — preserving the clean architecture boundary. The Domain layer and above never import or reference `IdentityTokenError` directly.
 
@@ -270,7 +270,7 @@ func completeNewDeviceOTP(otp: String) async throws -> Account
 
 /// Re-triggers the original identity token request without an OTP, causing the server to
 /// dispatch a new verification code to the user's email. The OTP field should be cleared
-/// after calling this. Only valid when in the `awaitingOTP` state.
+/// after calling this. Only valid when in the `otpPrompt` state.
 func resendNewDeviceOTP() async throws
 
 /// Cancels a pending new-device OTP challenge and clears any cached credentials.
@@ -284,7 +284,7 @@ func loginWithNewDeviceOTP(_ otp: String) async throws -> Account
 
 /// Retries the original identity token request without an OTP, triggering the server to
 /// dispatch a new verification code. Does NOT return an Account — the user remains in
-/// the awaitingOTP state after this call.
+/// the `otpPrompt` state after this call.
 func requestNewDeviceOTP() async throws
 
 /// Zeros any cached credentials held from the pending new-device OTP challenge.
@@ -391,11 +391,11 @@ New device verification is not required on every login; Bitwarden decides when t
 - **AND** the OTP field SHALL remain visible for re-entry
 
 #### Scenario: Resend code clears OTP field and sends fresh code
-- **GIVEN** `loginState == .awaitingOTP`
+- **GIVEN** `flowState == .otpPrompt`
 - **WHEN** the user taps "Resend code"
 - **THEN** `loginUseCase.resendNewDeviceOTP()` SHALL be called
 - **AND** the OTP field SHALL be cleared
-- **AND** `loginState` SHALL transition to `loading` during the request and back to `awaitingOTP` on completion
+- **AND** `flowState` SHALL transition to `.loading` during the request and back to `.otpPrompt` on completion
 - **AND** an `AccessibilityNotification.Announcement` SHALL be posted with "A new code has been sent to your email"
 
 `LoginUseCase` SHALL gain a `resendNewDeviceOTP() async throws` method. `AuthRepositoryImpl` implements it by retrying the original identity token request without `newdeviceotp`, causing the server to recognise the unverified device and dispatch a new code.

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -463,7 +463,7 @@ New device verification is not required on every login; Bitwarden decides when t
 
 #### Scenario: Self-hosted login has no new device OTP handling
 - **GIVEN** the active account has `serverType == .selfHosted`
-- **THEN** no OTP entry field is shown; `device_error` responses SHALL surface as a generic auth error
+- **THEN** no OTP entry field is shown; `device_error` responses SHALL surface as `AuthError.invalidCredentials` (Vaultwarden does not implement new-device verification; this path should not occur in practice)
 
 ---
 

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -155,7 +155,18 @@ The internal URL construction (`URL(string: trimmed)`) in `LoginUseCaseImpl` is 
 - `loginWithPassword` completion — line 540
 - `unlockWithBiometrics` completion — line 606
 
-All requests to cloud endpoints SHALL include the required Bitwarden client headers — `Bitwarden-Client-Name`, `Bitwarden-Client-Version`, and `Device-Type` — as already implemented in `ClientHeaders`. No change to header values is required by this change; the existing values are valid for cloud requests. A unit test SHALL assert these headers are present on a representative cloud `identityToken` request.
+All requests to cloud endpoints SHALL include the required Bitwarden client headers — `Bitwarden-Client-Name`, `Bitwarden-Client-Version`, and `Device-Type`. Header audit:
+
+- `Bitwarden-Client-Version` ✓ — already set in `baseRequest()` (line 1029)
+- `Bitwarden-Client-Name` ✗ — **not currently set**; `baseRequest()` SHALL be updated to add this header (value: `Config.clientName`)
+- `Device-Type` ✓ — already set
+
+`baseRequest()` SHALL add:
+```swift
+req.setValue(Config.clientName, forHTTPHeaderField: "Bitwarden-Client-Name")
+```
+
+A unit test SHALL assert `Bitwarden-Client-Name` and `Bitwarden-Client-Version` headers are present on a representative cloud `identityToken` request.
 
 #### Scenario: cloudUS routes api requests correctly
 - **GIVEN** the active account has `serverType == .cloudUS`
@@ -475,7 +486,7 @@ Per §IV, tests MUST be written before implementation. The following are require
 - `LoginUseCaseImpl` does NOT call `auth.validateServerURL` when `environment.serverType == .cloudUS` or `.cloudEU`
 - `LoginUseCaseImpl` DOES call `auth.validateServerURL` when `environment.serverType == .selfHosted`
 - Cloud login attempt with empty client identifier throws before making a network request
-- `PrizmAPIClient` includes `Bitwarden-Client-Name`, `Bitwarden-Client-Version`, and `Device-Type` headers on a cloud `identityToken` request
+- `PrizmAPIClient.baseRequest()` sets `Bitwarden-Client-Name` and `Bitwarden-Client-Version` HTTP headers on every request; a cloud `identityToken` request includes both
 - `PrizmAPIClient.refreshAccessToken` sends the registered cloud `client_id` (not `"desktop"`) when `serverType` is cloud
 - `AuthRepositoryImpl.loginWithPassword` returns `LoginResult.requiresNewDeviceOTP` when the identity token response is `HTTP 400` with `{"error": "device_error"}`
 - `LoginUseCaseImpl.completeNewDeviceOTP` calls `auth.loginWithNewDeviceOTP(_:)` and triggers sync on success

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -282,7 +282,7 @@ func cancelNewDeviceOTP()
 
 `LoginUseCase.resendNewDeviceOTP()` calls `auth.requestNewDeviceOTP()` — not `loginWithNewDeviceOTP`.
 
-`LoginViewModel` catches `AuthError.newDeviceVerificationRequired`, transitions to `awaitingOTP` state, and on Sign In calls `loginUseCase.completeNewDeviceOTP(otp:)`.
+`LoginViewModel` catches `AuthError.newDeviceVerificationRequired`, sets `flowState = .otpPrompt`, and on Sign In (from `NewDeviceOTPView`) calls `loginUseCase.completeNewDeviceOTP(otp:)`.
 
 The `execute` method signature changes are covered by the `LoginUseCase.execute` requirement above. `LoginUseCase.protocol` doc comment SHALL be updated to reflect the new flow: `execute → (optional) completeNewDeviceOTP → sync` or `execute → (optional) completeTOTP → sync`.
 
@@ -303,46 +303,45 @@ The `execute` method signature changes are covered by the `LoginUseCase.execute`
 
 ### Requirement: `LoginViewModel` state machine
 
-`LoginViewModel` SHALL expose a `loginState: LoginState` published property. `LoginView` derives all conditional UI (OTP field visibility, field editability, button label) from this property.
+`LoginFlowState` (already defined in `LoginViewModel.swift`) SHALL gain a new case `.otpPrompt`. No new enum is introduced — the existing state machine is extended.
 
 ```swift
-enum LoginState: Equatable {
-    case idle           // initial state; all fields editable
-    case awaitingOTP    // device_error received; OTP field shown, email/password disabled
-    case loading        // network request in flight; all fields disabled
-}
+// Existing cases — unchanged:
+//   .login, .loading, .totpPrompt, .syncing(message:), .vault
+// New case added:
+case otpPrompt   // device_error received; app shows NewDeviceOTPView
 ```
 
-**Valid transitions:**
+`RootViewModel.Screen` (in `PrizmApp.swift`) SHALL gain a matching `.otpPrompt` case. `RootViewModel.handleLoginFlow(_:)` SHALL map `.otpPrompt → .otpPrompt` alongside the existing cases. `PrizmApp`'s root switch SHALL show `NewDeviceOTPView(viewModel: rootVM.loginVM)` for `.otpPrompt`, analogous to how `TOTPPromptView` is shown for `.totpPrompt`.
+
+`NewDeviceOTPView` is a new screen (separate SwiftUI view, same pattern as `TOTPPromptView`) that shows the OTP entry field, Resend button, and Cancel button. `LoginViewModel` transitions `flowState` to `.otpPrompt` when `execute` throws `AuthError.newDeviceVerificationRequired`.
+
+**Valid transitions (additions to existing `LoginFlowState` machine):**
 
 | From | Event | To |
 |---|---|---|
-| `idle` | Sign In tapped | `loading` |
-| `loading` | Auth success | (navigate away — no state change needed) |
-| `loading` | Auth failure (not device_error) | `idle` (error shown) |
-| `loading` | `newDeviceVerificationRequired` | `awaitingOTP` |
-| `awaitingOTP` | Sign In tapped (OTP submit) | `loading` |
-| `awaitingOTP` | Invalid OTP (`invalid_grant`) | `awaitingOTP` (error shown, field remains) |
-| `awaitingOTP` | Resend tapped | `loading` → `awaitingOTP` (OTP field cleared, confirmation announced) |
-| `awaitingOTP` | Cancel tapped | `idle` (OTP field hidden, fields re-enabled) |
+| `.login` | Sign In tapped | `.loading` |
+| `.loading` | Auth success | `.syncing` → `.vault` |
+| `.loading` | Auth failure (not device_error) | `.login` (error shown) |
+| `.loading` | `newDeviceVerificationRequired` | `.otpPrompt` |
+| `.otpPrompt` | Sign In tapped (OTP submit) | `.loading` |
+| `.otpPrompt` | Invalid OTP (`invalid_grant`) | `.otpPrompt` (error shown, field remains) |
+| `.otpPrompt` | Resend tapped | `.loading` → `.otpPrompt` (OTP field cleared, confirmation announced) |
+| `.otpPrompt` | Cancel tapped | `.login` (credentials zeroed) |
 
-During `awaitingOTP`, email and master password fields SHALL be visible but disabled (`.disabled(true)`) so the user sees which account they are verifying. During `loading`, all interactive controls SHALL be disabled.
+#### Scenario: OTP screen shown on device_error
+- **GIVEN** `flowState == .loading` and the server returns `device_error`
+- **THEN** `flowState` SHALL transition to `.otpPrompt`
+- **AND** `NewDeviceOTPView` SHALL be displayed
+
+#### Scenario: Cancel returns to login screen
+- **GIVEN** `flowState == .otpPrompt`
+- **WHEN** the user taps Cancel
+- **THEN** `LoginViewModel` SHALL call `loginUseCase.cancelNewDeviceOTP()` before setting `flowState` to `.login`
 
 #### Scenario: Fields disabled during loading
-- **GIVEN** `loginState == .loading`
-- **THEN** the email field, password field, server picker, and Sign In button SHALL all be non-interactive
-
-#### Scenario: OTP field visible and email/password disabled during awaitingOTP
-- **GIVEN** `loginState == .awaitingOTP`
-- **THEN** the OTP field SHALL be visible and editable
-- **AND** the email and password fields SHALL be visible but disabled
-- **AND** a "Cancel" button SHALL be visible that transitions to `idle`
-
-#### Scenario: Cancel clears OTP state
-- **GIVEN** `loginState == .awaitingOTP`
-- **WHEN** the user taps Cancel
-- **THEN** `LoginViewModel` SHALL call `loginUseCase.cancelNewDeviceOTP()` before transitioning `loginState` to `idle`
-- **AND** the OTP field SHALL be hidden and its value cleared
+- **GIVEN** `flowState == .loading`
+- **THEN** all interactive controls in the current view SHALL be non-interactive
 
 ---
 
@@ -350,7 +349,7 @@ During `awaitingOTP`, email and master password fields SHALL be visible but disa
 
 All three server options use email + master password login.
 
-When Bitwarden Cloud does not recognise the device, it returns `HTTP 400` with `{"error": "device_error", "error_description": "New device verification required"}` and sends a one-time code to the user's registered email address. The system SHALL handle this by presenting an OTP entry field inline in `LoginView` and retrying the identity token request with the `newdeviceotp` parameter.
+When Bitwarden Cloud does not recognise the device, it returns `HTTP 400` with `{"error": "device_error", "error_description": "New device verification required"}` and sends a one-time code to the user's registered email address. The system SHALL handle this by transitioning to `NewDeviceOTPView` (a dedicated screen, matching the existing `TOTPPromptView` pattern) and retrying the identity token request with the `newdeviceotp` parameter.
 
 > **Spike findings (2026-04-20)**: hCaptcha was removed from Bitwarden Cloud in [bitwarden/ios#1861](https://github.com/bitwarden/ios/pull/1861) (merged 2025-08-20). The `WKWebView` modal originally planned is not needed. The current mechanism is:
 > - **Trigger**: `HTTP 400`, `{"error": "device_error"}`
@@ -360,10 +359,10 @@ When Bitwarden Cloud does not recognise the device, it returns `HTTP 400` with `
 
 New device verification is not required on every login; Bitwarden decides when to require it based on device recognition. It does not apply to self-hosted Vaultwarden instances.
 
-#### Scenario: New device OTP field shown on device_error
+#### Scenario: New device OTP screen shown on device_error
 - **GIVEN** the user attempts password login with a cloud option selected
 - **AND** the server returns `HTTP 400` with `{"error": "device_error"}`
-- **THEN** an OTP entry field SHALL appear in `LoginView` with the label "Check your email for a verification code"
+- **THEN** `flowState` SHALL transition to `.otpPrompt` and `NewDeviceOTPView` SHALL appear with the label "Check your email for a verification code"
 - **AND** the Sign In button SHALL remain disabled until the OTP field is non-empty
 
 #### Scenario: OTP submitted and login retried
@@ -407,8 +406,8 @@ All new interactive controls introduced by this change MUST be fully usable via 
 - **WHEN** the server picker has "Bitwarden Cloud (EU)" selected
 - **THEN** VoiceOver SHALL announce the control as "Server, Bitwarden Cloud (EU)"
 
-#### Scenario: OTP field announced when it appears
-- **WHEN** the new device OTP field appears after a `device_error` response
+#### Scenario: OTP screen announced when it appears
+- **WHEN** `NewDeviceOTPView` appears after a `device_error` response
 - **THEN** an `AccessibilityNotification.Announcement` SHALL be posted with "Check your email for a verification code"
 
 #### Scenario: Error announced to assistive technology
@@ -460,11 +459,11 @@ Per §IV, tests MUST be written before implementation. The following are require
 - Selecting a cloud type clears `serverURL`; selecting self-hosted restores the last entered URL
 - `isSignInDisabled` returns `false` for cloud when email and password are non-empty, even when `serverURL` is empty
 - `isSignInDisabled` returns `true` for self-hosted when `serverURL` is empty, even when email and password are filled
-- `isSignInDisabled` returns `true` when `loginState == .awaitingOTP` and the OTP field is empty
-- `isSignInDisabled` returns `false` when `loginState == .awaitingOTP` and the OTP field is non-empty
-- `loginState` transitions to `.awaitingOTP` when `execute` throws `AuthError.newDeviceVerificationRequired`
-- `loginState` transitions to `.idle` when Cancel is tapped from `.awaitingOTP`
-- `loginState` remains `.awaitingOTP` after an invalid OTP error; error message is set
+- `isSignInDisabled` returns `true` in `NewDeviceOTPView` when the OTP field is empty
+- `isSignInDisabled` returns `false` in `NewDeviceOTPView` when the OTP field is non-empty
+- `flowState` transitions to `.otpPrompt` when `execute` throws `AuthError.newDeviceVerificationRequired`
+- `flowState` transitions to `.login` when Cancel is tapped from `NewDeviceOTPView` (after `cancelNewDeviceOTP()`)
+- `flowState` remains `.otpPrompt` after an invalid OTP error; error message is set
 - `loginUseCase.resendNewDeviceOTP()` is called when "Resend code" is tapped; OTP field is cleared and confirmation is announced
 - `LoginUseCaseImpl.resendNewDeviceOTP()` calls `auth.requestNewDeviceOTP()` to re-trigger server dispatch
 
@@ -479,7 +478,7 @@ Per §IV, tests MUST be written before implementation. The following are require
 - Sign In button is enabled for a cloud option when email and password are non-empty and `serverURL` is empty
 - Sign In button is disabled for "Self-hosted" when `serverURL` is empty even if email and password are filled
 - Successful cloud login end-to-end against a local stub (no OTP required path)
-- `device_error` response causes OTP field to appear with label "Check your email for a verification code"
+- `device_error` response causes `NewDeviceOTPView` to appear with label "Check your email for a verification code"
 - Valid OTP entered → login succeeds; OTP field disappears
 - Invalid OTP → error message shown; OTP field remains for re-entry
 
@@ -541,7 +540,7 @@ Starting value: `2026.4.0` — the current Bitwarden server release as of the im
 
 `ACCESSIBILITY.md` SHALL be updated to document:
 - The new server picker control and its VoiceOver behaviour
-- The new device OTP verification field and its `accessibilityLabel` / announcement behaviour
+- `NewDeviceOTPView` and its OTP field `accessibilityLabel` / announcement behaviour
 
 ---
 

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -30,6 +30,13 @@ The `LoginView` SHALL replace the static subtitle "Self-hosted vault" and single
 
 When a cloud option is selected, no URL entry is required or shown. When "Self-hosted" is selected, the server URL field is shown and behaves as today. The last-used selection SHALL be persisted to `UserDefaults` under the key `com.prizm.login.lastServerType` (raw `String` value of `ServerType`) and restored when `LoginViewModel` is initialised.
 
+`LoginViewModel` SHALL expose a computed property `isSignInDisabled: Bool` used by `LoginView` to disable the Sign In button. Its logic:
+- `serverType == .cloudUS` or `.cloudEU`: `true` when email or password is empty
+- `serverType == .selfHosted`: `true` when email, password, or `serverURL` is empty
+- `flowState == .otpPrompt`: `true` when the OTP field is empty
+
+`NewDeviceOTPView` uses the same `isSignInDisabled` property from `LoginViewModel` to disable its Sign In button (identical to how `TOTPPromptView` works today).
+
 #### Scenario: Picker is visible on the login screen
 - **WHEN** `LoginView` is displayed
 - **THEN** a picker offering "Bitwarden Cloud (US)", "Bitwarden Cloud (EU)", and "Self-hosted" SHALL be visible above the email field
@@ -482,7 +489,9 @@ All new interactive controls introduced by this change MUST be fully usable via 
 - The server picker SHALL have `accessibilityIdentifier` set to `AccessibilityID.Login.serverTypePicker`, `accessibilityLabel` set to "Server", and expose its current value via `accessibilityValue` (e.g. "Bitwarden Cloud (US)")
 - The server URL text field SHALL retain its existing `accessibilityIdentifier` and have a meaningful `accessibilityLabel` ("Server URL")
 - The new device OTP text field SHALL have `accessibilityIdentifier` set to `AccessibilityID.Login.newDeviceOtpField` and `accessibilityLabel` set to "Verification code"
-- Error messages (unreachable server, invalid credentials, missing client identifier, invalid OTP) SHALL be announced via `AccessibilityNotification.Announcement` as soon as they appear
+- The "Resend code" button SHALL have `accessibilityIdentifier` set to `AccessibilityID.Login.resendOtpButton` and `accessibilityLabel` set to "Resend code"
+- The "Cancel" button in `NewDeviceOTPView` SHALL have `accessibilityIdentifier` set to `AccessibilityID.Login.cancelOtpButton` and `accessibilityLabel` set to "Cancel"
+- Error messages (unreachable server, invalid credentials, missing client identifier, invalid OTP, resend failure) SHALL be announced via `AccessibilityNotification.Announcement` as soon as they appear
 
 #### Scenario: Picker exposes current selection to VoiceOver
 - **WHEN** the server picker has "Bitwarden Cloud (EU)" selected

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -2,6 +2,15 @@
 
 Defines support for Bitwarden Cloud (US and EU regions) alongside self-hosted Vaultwarden instances. Scope: single active account; user chooses server at login. Data layer is designed for multi-account from day one; multi-account UI is deferred.
 
+## Complexity Tracking
+
+Per §I and §VI, non-trivial architectural decisions and AppKit exceptions must be justified here.
+
+| Component | Type | Justification | Simpler alternative rejected |
+|---|---|---|---|
+| `WKWebView` hCaptcha modal | AppKit/WebKit exception (§I) | SwiftUI has no web rendering API on macOS; `WKWebView` is the only platform-provided mechanism for an interactive web challenge | Skipping hCaptcha entirely — rejected because Bitwarden Cloud conditionally requires it; affected users would get a silent auth failure |
+| `HCaptchaPresenter` protocol + DI | Added abstraction (§VI) | Required for XCUITest determinism; without injection the hCaptcha path cannot be exercised in CI without a live network | Single concrete `WKWebView` usage — rejected because it makes the modal untestable |
+
 ## Baseline (what already exists)
 
 - `ServerEnvironment` (`Domain/Entities/Account.swift`) — `base: URL`, `overrides: ServerURLOverrides?`, computed `apiURL`/`identityURL`/`iconsURL`. No cloud/region discriminant.
@@ -63,6 +72,8 @@ When a cloud option is selected, no URL entry is required or shown. When "Self-h
 | `selfHosted` | `{base}/api` (or override) | `{base}/identity` (or override) | `{base}/icons` (or override) |
 
 > **Reference**: Endpoint URLs confirmed via [Bitwarden's official documentation](https://bitwarden.com/help/bitwarden-addresses/).
+>
+> **Out of scope**: `events`, `scim`, `sso`, and `push` endpoints listed in Bitwarden's documentation are enterprise/admin services. `PrizmAPIClient` does not call any of them; they are not modelled in `ServerEnvironment` and are explicitly excluded from this change.
 
 Cloud cases SHALL ignore `overrides` and SHALL ignore `base` for URL routing. `selfHosted` behaviour is unchanged. Existing Keychain records without a `serverType` key SHALL decode as `selfHosted`.
 
@@ -112,6 +123,8 @@ The computed properties (`apiURL`, `identityURL`, `iconsURL`) SHALL switch on `s
 - `loginWithPassword` completion — line 540
 - `unlockWithBiometrics` completion — line 606
 
+All requests to cloud endpoints SHALL include the required Bitwarden client headers — `Bitwarden-Client-Name`, `Bitwarden-Client-Version`, and `Device-Type` — as already implemented in `ClientHeaders`. No change to header values is required by this change; the existing values are valid for cloud requests. A unit test SHALL assert these headers are present on a representative cloud `identityToken` request.
+
 #### Scenario: cloudUS routes api requests correctly
 - **GIVEN** the active account has `serverType == .cloudUS`
 - **WHEN** `PrizmAPIClient` makes a request to an `api/...` endpoint
@@ -136,6 +149,30 @@ The computed properties (`apiURL`, `identityURL`, `iconsURL`) SHALL switch on `s
 - **GIVEN** the active account has `serverType == .cloudEU`
 - **WHEN** `PrizmAPIClient.refreshAccessToken()` is called
 - **THEN** the request SHALL be sent to `https://identity.bitwarden.eu/identity/connect/token`
+
+`PrizmAPIClient` MUST NOT fall back to a different `ServerEnvironment` on request failure. A failed request SHALL surface the error directly to the caller; no automatic retry against another region or self-hosted is permitted. Switching server environments requires a new login.
+
+#### Scenario: No silent region fallback on cloud auth failure
+- **GIVEN** the active account has `serverType == .cloudUS`
+- **WHEN** `identityToken` returns an error
+- **THEN** the error SHALL be surfaced to the caller as-is
+- **AND** no request SHALL be made to `identity.bitwarden.eu` or any other environment
+
+---
+
+### Requirement: Error taxonomy
+
+The existing `AuthError` enum (`Domain/Repositories/AuthRepository.swift`) SHALL be extended with three new cases for this change. `LoginViewModel` pattern-matches all `AuthError` cases; no new error type is introduced.
+
+| Case | Thrown by | `errorDescription` |
+|---|---|---|
+| `clientIdentifierNotConfigured` | `AuthRepositoryImpl` (before network request) | `"Prizm is not configured for Bitwarden Cloud. Contact support or use a self-hosted server."` |
+| `hCaptchaRequired(siteKey: String)` | `AuthRepositoryImpl` (on challenge response) | `nil` — handled structurally by `LoginViewModel`; not shown as a plain error string |
+| `hCaptchaCancelled` | `LoginViewModel` (on modal dismiss without token) | `"Unable to complete the security challenge. To log in without this requirement, use a self-hosted Vaultwarden server."` |
+
+`hCaptchaRequired` carries the site key extracted from the server's challenge response so `LoginViewModel` can pass it to `WKWebViewHCaptchaPresenter` when constructing the challenge URL.
+
+`serverUnreachable`, `invalidCredentials`, `networkUnavailable`, and `invalidURL` already exist in `AuthError` and cover the remaining error scenarios defined in this spec without modification.
 
 ---
 
@@ -181,8 +218,17 @@ The `client_id` is an app-level credential, not a per-user credential. No additi
 
 All three server options use email + master password login. When a cloud account (`cloudUS` or `cloudEU`) triggers an hCaptcha challenge, the system SHALL present a `WKWebView` modal for the user to complete the challenge before the token request is retried. hCaptcha is not required on every login; the server decides when to require it.
 
-> **Implementation note**:
-> The exact mechanism by which the client distinguishes hCaptcha requirement from other auth failures (e.g., invalid credentials, 2FA required) is not clearly documented in public repositories and must be discovered at implementation time via testing against cloud endpoints or referencing internal documentation.
+> **Research spike required — resolve before writing tasks:**
+>
+> The following must be determined by consulting the [Bitwarden iOS client](https://github.com/bitwarden/ios) (study-only reference per Constitution External Dependencies) before implementation begins. Findings SHALL replace this block with concrete values.
+>
+> 1. **Trigger signal**: What HTTP status and response body field indicate an hCaptcha challenge is required? (Expected: `400` with a JSON error body containing a `HCaptcha_SiteKey` or similar field — verify against iOS source.)
+> 2. **Challenge URL**: What URL does the `WKWebView` load? (Expected: a Bitwarden-hosted page such as `https://vault.bitwarden.com/captcha-mobile-connector.html` that embeds the hCaptcha widget — verify; EU region may differ.)
+> 3. **Site key**: Is the hCaptcha site key static per region (hardcode in `ServerType`) or returned dynamically in the challenge response? (If dynamic, it must be extracted from the error body and passed to the challenge URL as a query parameter.)
+> 4. **JS message name**: Confirm the `WKScriptMessageHandler` message name is `"hcaptcha"` — verify against iOS source.
+> 5. **Token field name**: What form parameter name carries the hCaptcha token in the retried `identityToken` request? (Expected: `captchaResponse` or similar — verify.)
+>
+> **Do not begin implementation of the hCaptcha path until all five points are confirmed and this block is replaced with findings.**
 
 #### Scenario: hCaptcha modal shown for cloud password login
 - **GIVEN** the user attempts password login with a cloud option selected
@@ -190,7 +236,7 @@ All three server options use email + master password login. When a cloud account
 - **THEN** a `WKWebView` modal SHALL be presented
 - **AND** when hCaptcha completes, its JS SHALL call `window.webkit.messageHandlers.hcaptcha.postMessage(token)`
 - **AND** the native `WKScriptMessageHandler` SHALL receive the token, dismiss the modal, and retry `identityToken` with the token included
-- **AND** the token SHALL be held in memory only for the duration of the retry and NOT persisted
+- **AND** the token SHALL be held in memory only for the duration of the retry, NOT persisted, and zeroed from memory immediately after the retry completes or fails
 
 #### Scenario: hCaptcha challenge dismissal treated as failed login
 - **GIVEN** the hCaptcha modal is presented
@@ -210,8 +256,11 @@ All new interactive controls introduced by this change MUST be fully usable via 
 
 - The server picker SHALL have `accessibilityIdentifier` set to `AccessibilityID.Login.serverTypePicker`, `accessibilityLabel` set to "Server", and expose its current value via `accessibilityValue` (e.g. "Bitwarden Cloud (US)")
 - The server URL text field SHALL retain its existing `accessibilityIdentifier` and have a meaningful `accessibilityLabel` ("Server URL")
-- The hCaptcha `WKWebView` modal SHALL have an accessible dismiss path (a labelled close button); VoiceOver focus SHALL move into the modal on presentation and return to the login form on dismissal
+- The hCaptcha `WKWebView` modal SHALL have `accessibilityLabel` set to "Complete security challenge"; VoiceOver focus SHALL move into the modal on presentation and return to the login form on dismissal
+- The modal SHALL always expose a keyboard-accessible "Cancel" button reachable without completing the web challenge
 - Error messages (unreachable server, invalid credentials, missing client identifier) SHALL be announced via `AccessibilityNotification.Announcement` as soon as they appear
+
+> **Known limitation**: `WKWebView` renders a third-party hCaptcha widget; Prizm cannot guarantee the widget itself meets WCAG 2.1 AA. If a user cannot complete the challenge via assistive technology, the Cancel path (see scenario below) provides an exit. This limitation MUST be documented in `ACCESSIBILITY.md` with a note that self-hosted Vaultwarden is available as an alternative that does not require hCaptcha.
 
 #### Scenario: Picker exposes current selection to VoiceOver
 - **WHEN** the server picker has "Bitwarden Cloud (EU)" selected
@@ -220,6 +269,13 @@ All new interactive controls introduced by this change MUST be fully usable via 
 #### Scenario: Error announced to assistive technology
 - **WHEN** an error message appears in the login form
 - **THEN** an `AccessibilityNotification.Announcement` SHALL be posted with the error text
+
+#### Scenario: hCaptcha inaccessible path
+- **GIVEN** the hCaptcha modal is presented
+- **WHEN** the user cannot complete the challenge via assistive technology and activates the "Cancel" button
+- **THEN** the modal SHALL be dismissed
+- **AND** an error message SHALL read "Unable to complete the security challenge. To log in without this requirement, use a self-hosted Vaultwarden server."
+- **AND** the `AccessibilityNotification.Announcement` SHALL be posted with that error text
 
 ---
 
@@ -250,6 +306,7 @@ Per §IV, tests MUST be written before implementation. The following are require
 - `PrizmAPIClient.setServerEnvironment()` stores the environment and subsequent requests use `env.apiURL` / `env.identityURL` as appropriate (representative call sites: `preLogin`, `identityToken`, `refreshAccessToken`, `fetchSync`)
 - `AuthRepositoryImpl.setServerEnvironment(_:)` calls `apiClient.setServerEnvironment(_:)` (not `setBaseURL`)
 - Cloud login attempt with empty client identifier throws before making a network request
+- `PrizmAPIClient` includes `Bitwarden-Client-Name`, `Bitwarden-Client-Version`, and `Device-Type` headers on a cloud `identityToken` request
 
 **Unit tests (Presentation):**
 - `LoginViewModel` server type selection is persisted and restored across instantiation
@@ -260,6 +317,19 @@ Per §IV, tests MUST be written before implementation. The following are require
 
 **Integration tests:**
 - Full login flow against a Vaultwarden stub (existing coverage) continues to pass after the `PrizmAPIClient` refactor
+
+**UI tests (XCUITest):**
+
+`LoginViewModel` SHALL accept a `HCaptchaPresenter` protocol (injected via `AppContainer`) so XCUITest can substitute a stub that immediately fires the JS token message without loading a real `WKWebView`. Production uses `WKWebViewHCaptchaPresenter`; tests use `StubHCaptchaPresenter`.
+
+- Three-way picker is visible on `LoginView`; all three options ("Bitwarden Cloud (US)", "Bitwarden Cloud (EU)", "Self-hosted") are selectable
+- Selecting "Bitwarden Cloud (US)" or "Bitwarden Cloud (EU)" hides the server URL field
+- Selecting "Self-hosted" shows the server URL field
+- Sign In button is enabled for a cloud option when email and password are non-empty and `serverURL` is empty
+- Sign In button is disabled for "Self-hosted" when `serverURL` is empty even if email and password are filled
+- Successful cloud login end-to-end against a local Bitwarden-compatible stub (using `StubHCaptchaPresenter` to bypass real web challenge)
+- hCaptcha modal presented for cloud login: `StubHCaptchaPresenter` fires the token → login proceeds
+- hCaptcha modal dismissed without token: login error message is shown
 
 ---
 
@@ -280,3 +350,53 @@ Per §IV, tests MUST be written before implementation. The following are require
 #### Scenario: Cloud endpoints unreachable
 - **WHEN** a cloud option is selected and the corresponding endpoints cannot be reached
 - **THEN** the error SHALL indicate that Bitwarden Cloud services are temporarily unavailable
+
+---
+
+### Requirement: Document tested Bitwarden API version in `Config.swift`
+
+Per Constitution Bitwarden API Integration Requirements, `Config.swift` SHALL gain a `bitwardenApiVersion` constant recording the Bitwarden server API version this client has been tested against (e.g. `static let bitwardenApiVersion = "2025-01"`). The value SHALL be determined during the implementation spike and updated whenever the tested version changes.
+
+---
+
+### Requirement: Update `DEVELOPMENT.md` for `LocalSecrets.xcconfig`
+
+`DEVELOPMENT.md` SHALL be updated to document the new `LocalSecrets.xcconfig` setup step required for cloud login:
+- Add a `LocalSecrets.xcconfig` section explaining its purpose (injects the registered Bitwarden client identifier at build time)
+- Provide a template copy command analogous to the existing `LocalConfig.xcconfig` instructions
+- Clarify that without this file, the app will build successfully but cloud login will fail at runtime with a clear error — self-hosted login is unaffected
+
+---
+
+### Requirement: Update `SECURITY.md` (§VII)
+
+`SECURITY.md` SHALL be updated to reflect the expanded network attack surface introduced by this change:
+- Document the two cloud regions and their canonical endpoints
+- Note that hCaptcha is handled via an embedded `WKWebView` loading a Bitwarden-hosted page; the token is held in memory only for the duration of the login retry and never persisted
+- Note that the registered client identifier is injected at build time and never stored at runtime beyond the request
+
+---
+
+### Requirement: Update `ACCESSIBILITY.md` (§VIII)
+
+`ACCESSIBILITY.md` SHALL be updated to document:
+- The new server picker control and its VoiceOver behaviour
+- The hCaptcha `WKWebView` modal and its known limitation (third-party widget; WCAG 2.1 AA compliance of the widget itself cannot be guaranteed by Prizm)
+- The self-hosted alternative available to users who cannot complete the hCaptcha challenge
+
+---
+
+## Security Considerations
+
+### Certificate Pinning (§III evaluation)
+
+Certificate pinning was evaluated for `api.bitwarden.com`, `identity.bitwarden.com`, `api.bitwarden.eu`, and `identity.bitwarden.eu`.
+
+**Decision: not implemented in this release.**
+
+Rationale:
+- Bitwarden's official clients do not pin certificates.
+- macOS ATS + the system trust store provides a strong baseline; no `NSAllowsArbitraryLoads` exemptions are needed for these endpoints.
+- Operational risk: if Bitwarden rotates their TLS certificate without advance notice, pinned clients would lock all users out until an app update ships — an unacceptable availability risk for a credential vault.
+
+Revisit if Bitwarden publishes a pinning recommendation, if a CA compromise incident occurs, or if Prizm moves to a managed distribution channel with rapid OTA update capability.

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -400,7 +400,8 @@ case otpPrompt   // device_error received; app shows NewDeviceOTPView
 | `.loading` | `LoginResult.requiresNewDeviceOTP` returned | `.otpPrompt` |
 | `.otpPrompt` | Sign In tapped (OTP submit) | `.loading` |
 | `.otpPrompt` | Invalid OTP (`invalid_grant`) | `.otpPrompt` (error shown, field remains) |
-| `.otpPrompt` | Resend tapped | `.loading` → `.otpPrompt` (OTP field cleared, confirmation announced) |
+| `.otpPrompt` | Resend tapped | `.loading` → `.otpPrompt` (OTP field cleared on success, confirmation announced) |
+| `.otpPrompt` | Resend fails (network error) | `.otpPrompt` (error shown, OTP field unchanged) |
 | `.otpPrompt` | Cancel tapped | `.login` (credentials zeroed) |
 
 #### Scenario: OTP screen shown on device_error
@@ -455,9 +456,16 @@ New device verification is not required on every login; Bitwarden decides when t
 - **GIVEN** `flowState == .otpPrompt`
 - **WHEN** the user taps "Resend code"
 - **THEN** `loginUseCase.resendNewDeviceOTP()` SHALL be called
-- **AND** the OTP field SHALL be cleared
 - **AND** `flowState` SHALL transition to `.loading` during the request and back to `.otpPrompt` on completion
+- **AND** the OTP field SHALL be cleared on success
 - **AND** an `AccessibilityNotification.Announcement` SHALL be posted with "A new code has been sent to your email"
+
+#### Scenario: Resend code fails
+- **GIVEN** `flowState == .otpPrompt`
+- **WHEN** the user taps "Resend code" and `resendNewDeviceOTP()` throws (e.g. network error)
+- **THEN** `flowState` SHALL return to `.otpPrompt`
+- **AND** an error message SHALL be shown (e.g. "Could not send a new code. Check your connection and try again.")
+- **AND** the OTP field SHALL remain unchanged — the user's existing code may still be valid
 
 `LoginUseCase` SHALL gain a `resendNewDeviceOTP() async throws` method. `AuthRepositoryImpl` implements it by retrying the original identity token request without `newdeviceotp`, causing the server to recognise the unverified device and dispatch a new code.
 
@@ -540,7 +548,8 @@ Per §IV, tests MUST be written before implementation. The following are require
 - `flowState` transitions to `.otpPrompt` when `execute` returns `LoginResult.requiresNewDeviceOTP`
 - `flowState` transitions to `.login` when Cancel is tapped from `NewDeviceOTPView` (after `cancelNewDeviceOTP()`)
 - `flowState` remains `.otpPrompt` after an invalid OTP error; error message is set
-- `loginUseCase.resendNewDeviceOTP()` is called when "Resend code" is tapped; OTP field is cleared and confirmation is announced
+- `loginUseCase.resendNewDeviceOTP()` is called when "Resend code" is tapped; on success OTP field is cleared and confirmation is announced
+- `loginUseCase.resendNewDeviceOTP()` throws → `flowState` returns to `.otpPrompt`, error message set, OTP field unchanged
 - `LoginUseCaseImpl.resendNewDeviceOTP()` calls `auth.requestNewDeviceOTP()` to re-trigger server dispatch
 
 **Integration tests:**

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -1,176 +1,178 @@
 ## Purpose
 
-Defines support for Bitwarden-hosted cloud services alongside self-hosted Vaultwarden instances, including endpoint environment configuration, cloud/self-hosted server selection in the login flow, and integration with the existing Bitwarden API client.
+Defines support for Bitwarden Cloud (US and EU regions) alongside self-hosted Vaultwarden instances. Scope: single active account; user chooses server at login. Data layer is designed for multi-account from day one; multi-account UI is deferred.
 
-## Requirements
+## Baseline (what already exists)
 
-### Requirement: Login UI provides cloud/self-hosted toggle
-The system SHALL display a picker or toggle in the `LoginView` that allows users to choose between "Bitwarden Cloud" and "Self-hosted" server environments. When "Bitwarden Cloud" is selected, the system SHALL auto-fill the standard URLs (api.bitwarden.com, identity.bitwarden.com, icons.bitwarden.net) and disable manual URL fields. When "Self-hosted" is selected, the system SHALL enable manual URL entry fields and use those user-provided URLs for all API communication. The selection SHALL be persisted across app launches.
-
-#### Scenario: Toggle visible on login screen
-- **WHEN** the `LoginView` is displayed
-- **THEN** a picker or toggle SHALL be visible offering "Bitwarden Cloud" and "Self-hosted" options
-
-#### Scenario: Cloud selection auto-fills standard URLs
-- **WHEN** the user selects "Bitwarden Cloud"
-- **THEN** the API URL field SHALL be pre-filled with "https://api.bitwarden.com"
-- **AND** the Identity URL field SHALL be pre-filled with "https://identity.bitwarden.com"
-- **AND** the Icons URL field SHALL be pre-filled with "https://icons.bitwarden.net"
-- **AND** the manual URL fields SHALL be disabled (non-editable)
-
-#### Scenario: Self-hosted selection enables manual URL entry
-- **WHEN** the user selects "Self-hosted"
-- **THEN** the manual URL fields SHALL become editable
-- **AND** the fields SHALL be empty or retain previously entered values
-- **AND** the user can enter custom URLs for API, Identity, and Icons endpoints
-
-#### Scenario: Selection is persisted across app launches
-- **GIVEN** the user selected "Bitwarden Cloud" on a previous launch
-- **WHEN** the app is relaunched and the `LoginView` appears
-- **THEN** the picker SHALL retain the "Bitwarden Cloud" selection
-- **AND** the standard cloud URLs SHALL be pre-filled and disabled
-
-#### Scenario: Self-hosted URLs are persisted
-- **GIVEN** the user selected "Self-hosted" and entered custom URLs
-- **WHEN** the app is relaunched and the `LoginView` appears
-- **THEN** the picker SHALL retain the "Self-hosted" selection
-- **AND** the previously entered custom URLs SHALL be pre-filled
+- `ServerEnvironment` (`Domain/Entities/Account.swift`) — `base: URL`, `overrides: ServerURLOverrides?`, computed `apiURL`/`identityURL`/`iconsURL`. No cloud/region discriminant.
+- `AuthRepository.setServerEnvironment(_ env:)` — declared and implemented; only calls `apiClient.setBaseURL(environment.base)`.
+- `PrizmAPIClient` actor — single `baseURL`; ~32 endpoint methods all use `base.appendingPathComponent(...)`.
+- `LoginView` / `LoginViewModel` — single `serverURL: String` field, static subtitle "Self-hosted vault".
+- `bw.macos:{userId}:serverEnvironment` — Keychain key in use for self-hosted accounts.
 
 ---
 
-### Requirement: API client uses `ServerEnvironment` URLs based on selection
-The system SHALL configure `PrizmAPIClient` with the appropriate URLs based on the user's server environment selection. All network requests to `api/...` paths SHALL use the configured API base URL, all requests to `identity/...` paths SHALL use the configured Identity base URL, and all icon requests SHALL use the configured Icons base URL. The system SHALL NOT append these paths dynamically to a single base URL; each endpoint type SHALL resolve to its configured environment URL.
+### Requirement: Login UI presents a three-way server picker
 
-#### Scenario: API requests use cloud URLs when cloud is selected
-- **GIVEN** the user has selected "Bitwarden Cloud"
+The `LoginView` SHALL replace the static subtitle "Self-hosted vault" and single server URL field with a three-option picker:
+
+1. **Bitwarden Cloud (US)** — hides the server URL field
+2. **Bitwarden Cloud (EU)** — hides the server URL field
+3. **Self-hosted** — shows the server URL field as it exists today
+
+When a cloud option is selected, no URL entry is required or shown. When "Self-hosted" is selected, the server URL field is shown and behaves as today. The last-used selection SHALL be remembered across app launches.
+
+#### Scenario: Picker is visible on the login screen
+- **WHEN** `LoginView` is displayed
+- **THEN** a picker offering "Bitwarden Cloud (US)", "Bitwarden Cloud (EU)", and "Self-hosted" SHALL be visible above the email field
+
+#### Scenario: Cloud selection hides the server URL field
+- **WHEN** the user selects "Bitwarden Cloud (US)" or "Bitwarden Cloud (EU)"
+- **THEN** the server URL field SHALL be hidden
+- **AND** the email and master password fields SHALL remain visible
+
+#### Scenario: Self-hosted selection shows the server URL field
+- **WHEN** the user selects "Self-hosted"
+- **THEN** the server URL field SHALL be visible and editable
+- **AND** any previously entered URL SHALL be restored
+
+#### Scenario: Last-used selection restored on relaunch
+- **GIVEN** the user last chose "Bitwarden Cloud (EU)" before quitting
+- **WHEN** `LoginView` appears on the next launch
+- **THEN** the picker SHALL default to "Bitwarden Cloud (EU)"
+
+---
+
+### Requirement: `ServerEnvironment` extended with three-case `ServerType`
+
+`ServerEnvironment` SHALL gain a `ServerType` enum with cases `cloudUS`, `cloudEU`, and `selfHosted`. The computed properties SHALL return the following canonical URLs per case:
+
+| `serverType` | `apiURL` | `identityURL` | `iconsURL` |
+|---|---|---|---|
+| `cloudUS` | `https://api.bitwarden.com` | `https://identity.bitwarden.com` | `https://icons.bitwarden.net` |
+| `cloudEU` | `https://api.bitwarden.eu` | `https://identity.bitwarden.eu` | `https://icons.bitwarden.net` |
+| `selfHosted` | `{base}/api` (or override) | `{base}/identity` (or override) | `{base}/icons` (or override) |
+
+Cloud cases SHALL ignore `overrides`. `selfHosted` behaviour is unchanged. Existing Keychain records without a `serverType` key SHALL decode as `selfHosted`.
+
+#### Scenario: cloudUS returns US canonical URLs
+- **GIVEN** a `ServerEnvironment` with `serverType == .cloudUS`
+- **THEN** `apiURL` SHALL equal `https://api.bitwarden.com`
+- **AND** `identityURL` SHALL equal `https://identity.bitwarden.com`
+- **AND** `iconsURL` SHALL equal `https://icons.bitwarden.net`
+
+#### Scenario: cloudEU returns EU canonical URLs
+- **GIVEN** a `ServerEnvironment` with `serverType == .cloudEU`
+- **THEN** `apiURL` SHALL equal `https://api.bitwarden.eu`
+- **AND** `identityURL` SHALL equal `https://identity.bitwarden.eu`
+- **AND** `iconsURL` SHALL equal `https://icons.bitwarden.net` (global CDN; no EU-specific icons endpoint exists)
+
+#### Scenario: selfHosted returns URL-derived values
+- **GIVEN** a `ServerEnvironment` with `serverType == .selfHosted` and `base = https://vault.example.com`
+- **THEN** `apiURL` SHALL equal `https://vault.example.com/api`
+- **AND** `identityURL` SHALL equal `https://vault.example.com/identity`
+
+#### Scenario: Legacy record decoded as selfHosted
+- **GIVEN** a stored JSON record with no `serverType` key
+- **WHEN** decoded from Keychain
+- **THEN** `serverType` SHALL be `selfHosted`
+
+---
+
+### Requirement: `PrizmAPIClient` routes requests via `ServerEnvironment`
+
+`PrizmAPIClient` SHALL replace `setBaseURL(_ url: URL)` with `setServerEnvironment(_ env: ServerEnvironment)`. All ~32 endpoint methods SHALL use `env.apiURL`, `env.identityURL`, or `env.iconsURL` instead of appending to a single `base`. `AuthRepositoryImpl.setServerEnvironment(_:)` SHALL call `apiClient.setServerEnvironment(environment)`.
+
+#### Scenario: cloudUS routes api requests correctly
+- **GIVEN** the active account has `serverType == .cloudUS`
 - **WHEN** `PrizmAPIClient` makes a request to an `api/...` endpoint
 - **THEN** the request SHALL be sent to `https://api.bitwarden.com/api/...`
 
-#### Scenario: Identity requests use cloud URLs when cloud is selected
-- **GIVEN** the user has selected "Bitwarden Cloud"
+#### Scenario: cloudEU routes api requests correctly
+- **GIVEN** the active account has `serverType == .cloudEU`
+- **WHEN** `PrizmAPIClient` makes a request to an `api/...` endpoint
+- **THEN** the request SHALL be sent to `https://api.bitwarden.eu/api/...`
+
+#### Scenario: cloudEU routes identity requests correctly
+- **GIVEN** the active account has `serverType == .cloudEU`
 - **WHEN** `PrizmAPIClient` makes a request to an `identity/...` endpoint
-- **THEN** the request SHALL be sent to `https://identity.bitwarden.com/identity/...`
+- **THEN** the request SHALL be sent to `https://identity.bitwarden.eu/identity/...`
 
-#### Scenario: Icon requests use cloud URLs when cloud is selected
-- **GIVEN** the user has selected "Bitwarden Cloud"
-- **WHEN** `PrizmAPIClient` fetches a favicon or icon
-- **THEN** the request SHALL be sent to `https://icons.bitwarden.net`
-
-#### Scenario: API requests use self-hosted URLs when self-hosted is selected
-- **GIVEN** the user has selected "Self-hosted" and entered "https://vault.example.com" as the API URL
+#### Scenario: selfHosted routes to user-supplied URL
+- **GIVEN** the active account has `serverType == .selfHosted` and `base = https://vault.example.com`
 - **WHEN** `PrizmAPIClient` makes a request to an `api/...` endpoint
 - **THEN** the request SHALL be sent to `https://vault.example.com/api/...`
 
-#### Scenario: Identity requests use self-hosted URLs when self-hosted is selected
-- **GIVEN** the user has selected "Self-hosted" and entered "https://vault.example.com" as the Identity URL
-- **WHEN** `PrizmAPIClient` makes a request to an `identity/...` endpoint
-- **THEN** the request SHALL be sent to `https://vault.example.com/identity/...`
+---
 
-#### Scenario: Icons requests use self-hosted URLs when self-hosted is selected
-- **GIVEN** the user has selected "Self-hosted" and entered "https://vault.example.com" as the Icons URL
-- **WHEN** `PrizmAPIClient` fetches a favicon or icon
-- **THEN** the request SHALL be sent to `https://vault.example.com`
+### Requirement: Server environment persists per account in Keychain
+
+After successful login, the `ServerEnvironment` (including `serverType`) SHALL be written to Keychain under `bw.macos:{userId}:serverEnvironment`. On app launch the active account's environment SHALL be read from Keychain and used to configure `PrizmAPIClient`. The data layer is keyed by `userId` and is multi-account-ready.
+
+#### Scenario: Environment persisted after login
+- **GIVEN** the user logs in with "Bitwarden Cloud (EU)" selected
+- **WHEN** login succeeds
+- **THEN** a `ServerEnvironment` with `serverType == .cloudEU` SHALL be written to Keychain for that `userId`
+
+#### Scenario: Environment restored on app launch
+- **GIVEN** the active account was logged in as "Bitwarden Cloud (EU)"
+- **WHEN** the app launches and the vault is unlocked
+- **THEN** `PrizmAPIClient` SHALL use EU URLs for all requests
 
 ---
 
-### Requirement: `ServerEnvironment` configuration persists per account
-The system SHALL store the server environment selection (cloud or self-hosted) and associated URLs per account in a secure persistence layer. When the user switches accounts or after app restart, the system SHALL restore the correct server environment for each account. The active account's environment SHALL be used for all network requests.
+### Requirement: Registered client identifier used for cloud password login
 
-#### Scenario: Environment stored after successful login
-- **GIVEN** the user successfully logs in with a specific server environment
-- **WHEN** the login completes
-- **THEN** the server environment selection and URLs SHALL be persisted for that account
+The Bitwarden OAuth password grant (`grant_type=password`) requires a `client_id` parameter identifying the client application. `PrizmAPIClient` already sends this as `ClientHeaders.clientId`, currently hardcoded to `"desktop"`. For cloud accounts this value SHALL be replaced with the registered identifier obtained from Bitwarden, Inc., injected at build time via a gitignored `.xcconfig` file. Self-hosted login is unaffected — Vaultwarden does not enforce this identifier.
 
-#### Scenario: Environment restored on app launch for active account
-- **GIVEN** the user was logged into an account configured for "Bitwarden Cloud"
-- **WHEN** the app is relaunched and the vault is unlocked
-- **THEN** `PrizmAPIClient` SHALL be configured to use cloud URLs for that account
+The `client_id` is an app-level credential, not a per-user credential. No additional login UI is needed; it is transparent to the user.
 
-#### Scenario: Multiple accounts can have different environments
-- **GIVEN** Account A is configured for "Bitwarden Cloud"
-- **AND** Account B is configured for "Self-hosted" with custom URLs
-- **WHEN** the user switches from Account A to Account B
-- **THEN** `PrizmAPIClient` SHALL update to use Account B's self-hosted URLs
+#### Scenario: Registered identifier sent on cloud password login
+- **GIVEN** the active account has `serverType == .cloudUS` or `serverType == .cloudEU`
+- **WHEN** `PrizmAPIClient` posts the identity token request
+- **THEN** the `client_id` form parameter SHALL equal the registered identifier (not `"desktop"`)
 
----
+#### Scenario: Unconfigured identifier blocks cloud login
+- **GIVEN** the xcconfig value for the client identifier is empty
+- **WHEN** the user attempts to log in with a cloud option selected
+- **THEN** login SHALL fail with a clear error indicating the client identifier is not configured
 
-### Requirement: Registered client identifier is used for cloud requests
-The system SHALL include a registered client identifier in API requests when communicating with Bitwarden Cloud (`api.bitwarden.com`). The client identifier SHALL be obtained from Bitwarden, Inc. per their Device Registration requirements and shall be included in the appropriate headers per their API specification. Self-hosted Vaultwarden instances SHALL NOT require this header.
-
-#### Scenario: Client identifier present in cloud API requests
-- **GIVEN** the user has selected "Bitwarden Cloud"
-- **WHEN** `PrizmAPIClient` makes a request to a cloud API endpoint
-- **THEN** the request SHALL include the registered client identifier as part of the appropriate OAuth token exchange
-
-#### Scenario: Client identifier not required for self-hosted requests
-- **GIVEN** the user has selected "Self-hosted"
-- **WHEN** `PrizmAPIClient` makes a request to a self-hosted Vaultwarden instance
-- **THEN** the request SHALL NOT include the client identifier header
-
-#### Scenario: Missing client identifier prevents cloud login
-- **GIVEN** the user has selected "Bitwarden Cloud" and no client identifier is configured
-- **WHEN** the user attempts to log in
-- **THEN** the login SHALL fail with an error indicating that the client identifier is required
+#### Scenario: Self-hosted login unaffected
+- **GIVEN** the active account has `serverType == .selfHosted`
+- **THEN** the `client_id` value used SHALL remain `"desktop"` (Vaultwarden-compatible default)
 
 ---
 
-### Requirement: System supports CAPTCHA verification for cloud login
-The system SHALL support authentication via Bitwarden Cloud's standard pattern. As of 2026-04-18, this includes CAPTCHA verification via [hCaptcha](https://www.hcaptcha.com/). The system SHALL launch a web view modal (`WKWebView` using standard macOS configuration) in order to pass such challenges.
+### Requirement: Cloud login supports email/password with hCaptcha handling
 
-API keys SHALL be stored securely in the Keychain after a successful login.
+All three server options use email + master password login. When a cloud account (`cloudUS` or `cloudEU`) triggers an hCaptcha challenge, the system SHALL present a `WKWebView` modal for the user to complete the challenge before the token request is retried.
 
-#### Scenario: API key login option is visible for cloud
-- **GIVEN** the user has selected "Bitwarden Cloud"
-- **WHEN** the `LoginView` is displayed
-- **THEN** an option to log in with API keys SHALL be visible
+#### Scenario: hCaptcha modal shown for cloud password login
+- **GIVEN** the user attempts password login with a cloud option selected
+- **AND** the server returns an hCaptcha challenge response
+- **THEN** a `WKWebView` modal SHALL be presented
+- **AND** the token request SHALL be retried automatically on challenge completion
 
-#### Scenario: API key fields accept client_id and client_secret
-- **GIVEN** the user has chosen the API key login option
-- **WHEN** the user enters their client_id and client_secret
-- **THEN** the fields SHALL validate the format (non-empty strings)
-
-#### Scenario: API key login bypasses hCaptcha
-- **GIVEN** the user has entered valid API keys
-- **WHEN** the system submits the OAuth token request
-- **THEN** no hCaptcha challenge SHALL be presented
-- **AND** the login SHALL proceed directly on successful token exchange
-
-#### Scenario: API keys are stored in Keychain on successful login
-- **GIVEN** the user has successfully logged in via API keys
-- **WHEN** the login completes
-- **THEN** the client_id and client_secret SHALL be stored securely in the Keychain
-- **AND** future logins for this account SHALL be able to use the stored keys
-
-#### Scenario: Invalid API keys show clear error message
-- **WHEN** the user enters invalid API keys and attempts to log in
-- **THEN** an error message SHALL be displayed indicating that the API keys are invalid
-- **AND** the login SHALL not proceed
-
-#### Scenario: API key login option not shown for self-hosted by default
-- **GIVEN** the user has selected "Self-hosted"
-- **WHEN** the `LoginView` is displayed
-- **THEN** the API key login option SHALL NOT be shown (unless the self-hosted instance explicitly supports OAuth)
+#### Scenario: Self-hosted login has no hCaptcha handling
+- **GIVEN** the active account has `serverType == .selfHosted`
+- **THEN** no hCaptcha modal path exists in the login flow
 
 ---
 
-### Requirement: Errors from server environment configuration are surfaced clearly
-The system SHALL validate server environment URLs before attempting login. If the user enters an invalid URL scheme or unreachable endpoint for self-hosted configuration, the system SHALL surface a clear error message indicating the specific validation failure. Network errors during login SHALL distinguish between connectivity issues, authentication failures, and server configuration errors.
+### Requirement: Server environment errors surfaced clearly
 
-#### Scenario: Invalid URL scheme is rejected
-- **WHEN** the user enters a URL without https:// in a self-hosted field
-- **THEN** the system SHALL reject the URL and show an error message indicating that HTTPS is required
+#### Scenario: Non-HTTPS self-hosted URL rejected
+- **WHEN** the user enters a self-hosted URL without `https://`
+- **THEN** the system SHALL reject it with an error indicating HTTPS is required
 
-#### Scenario: Unreachable endpoint shows clear error
+#### Scenario: Unreachable self-hosted endpoint
 - **WHEN** the user enters a self-hosted URL that cannot be reached
-- **THEN** the login attempt SHALL fail with an error message indicating the server is unreachable
-- **AND** the specific endpoint that failed SHALL be mentioned (API or Identity)
+- **THEN** login SHALL fail with an error indicating the server is unreachable
 
-#### Scenario: Authentication failure is distinguished from network error
+#### Scenario: Authentication failure distinct from network error
 - **WHEN** login fails due to invalid credentials
-- **THEN** the error message SHALL clearly indicate an authentication failure
-- **AND** SHALL be distinct from network connectivity error messages
+- **THEN** the error SHALL clearly indicate authentication failure, not a connectivity problem
 
-#### Scenario: Cloud endpoint unreachable shows specific message
-- **WHEN** the user selects "Bitwarden Cloud" and cloud endpoints are unreachable
-- **THEN** the error message SHALL indicate that Bitwarden Cloud services are temporarily unavailable
--
+#### Scenario: Cloud endpoints unreachable
+- **WHEN** a cloud option is selected and the corresponding endpoints cannot be reached
+- **THEN** the error SHALL indicate that Bitwarden Cloud services are temporarily unavailable

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -219,6 +219,17 @@ enum LoginResult {
 
 **Layer boundary**: `PrizmAPIClient.identityToken` throws `IdentityTokenError.newDeviceNotVerified` when it receives a `device_error` response. `AuthRepositoryImpl` catches that Data-layer error and returns `LoginResult.requiresNewDeviceOTP` — preserving the clean architecture boundary. The Domain layer and above never import or reference `IdentityTokenError` directly.
 
+`IdentityTokenError` (`Data/Network/PrizmAPIClient.swift`) SHALL gain a new case:
+
+```swift
+/// The server does not recognise this device and has dispatched a one-time code
+/// to the user's registered email. Trigger: HTTP 400, `{"error": "device_error"}`.
+/// `error_description` is informational only and SHALL NOT be used as the trigger condition.
+case newDeviceNotVerified
+```
+
+Trigger condition: `HTTP 400` response whose JSON body contains `"error": "device_error"`. The `error_description` field ("New device verification required") is informational and MUST NOT be used as the discriminator — only `error` is stable across server versions.
+
 ---
 
 ### Requirement: Error taxonomy

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -1,0 +1,176 @@
+## Purpose
+
+Defines support for Bitwarden-hosted cloud services alongside self-hosted Vaultwarden instances, including endpoint environment configuration, cloud/self-hosted server selection in the login flow, and integration with the existing Bitwarden API client.
+
+## Requirements
+
+### Requirement: Login UI provides cloud/self-hosted toggle
+The system SHALL display a picker or toggle in the `LoginView` that allows users to choose between "Bitwarden Cloud" and "Self-hosted" server environments. When "Bitwarden Cloud" is selected, the system SHALL auto-fill the standard URLs (api.bitwarden.com, identity.bitwarden.com, icons.bitwarden.net) and disable manual URL fields. When "Self-hosted" is selected, the system SHALL enable manual URL entry fields and use those user-provided URLs for all API communication. The selection SHALL be persisted across app launches.
+
+#### Scenario: Toggle visible on login screen
+- **WHEN** the `LoginView` is displayed
+- **THEN** a picker or toggle SHALL be visible offering "Bitwarden Cloud" and "Self-hosted" options
+
+#### Scenario: Cloud selection auto-fills standard URLs
+- **WHEN** the user selects "Bitwarden Cloud"
+- **THEN** the API URL field SHALL be pre-filled with "https://api.bitwarden.com"
+- **AND** the Identity URL field SHALL be pre-filled with "https://identity.bitwarden.com"
+- **AND** the Icons URL field SHALL be pre-filled with "https://icons.bitwarden.net"
+- **AND** the manual URL fields SHALL be disabled (non-editable)
+
+#### Scenario: Self-hosted selection enables manual URL entry
+- **WHEN** the user selects "Self-hosted"
+- **THEN** the manual URL fields SHALL become editable
+- **AND** the fields SHALL be empty or retain previously entered values
+- **AND** the user can enter custom URLs for API, Identity, and Icons endpoints
+
+#### Scenario: Selection is persisted across app launches
+- **GIVEN** the user selected "Bitwarden Cloud" on a previous launch
+- **WHEN** the app is relaunched and the `LoginView` appears
+- **THEN** the picker SHALL retain the "Bitwarden Cloud" selection
+- **AND** the standard cloud URLs SHALL be pre-filled and disabled
+
+#### Scenario: Self-hosted URLs are persisted
+- **GIVEN** the user selected "Self-hosted" and entered custom URLs
+- **WHEN** the app is relaunched and the `LoginView` appears
+- **THEN** the picker SHALL retain the "Self-hosted" selection
+- **AND** the previously entered custom URLs SHALL be pre-filled
+
+---
+
+### Requirement: API client uses `ServerEnvironment` URLs based on selection
+The system SHALL configure `PrizmAPIClient` with the appropriate URLs based on the user's server environment selection. All network requests to `api/...` paths SHALL use the configured API base URL, all requests to `identity/...` paths SHALL use the configured Identity base URL, and all icon requests SHALL use the configured Icons base URL. The system SHALL NOT append these paths dynamically to a single base URL; each endpoint type SHALL resolve to its configured environment URL.
+
+#### Scenario: API requests use cloud URLs when cloud is selected
+- **GIVEN** the user has selected "Bitwarden Cloud"
+- **WHEN** `PrizmAPIClient` makes a request to an `api/...` endpoint
+- **THEN** the request SHALL be sent to `https://api.bitwarden.com/api/...`
+
+#### Scenario: Identity requests use cloud URLs when cloud is selected
+- **GIVEN** the user has selected "Bitwarden Cloud"
+- **WHEN** `PrizmAPIClient` makes a request to an `identity/...` endpoint
+- **THEN** the request SHALL be sent to `https://identity.bitwarden.com/identity/...`
+
+#### Scenario: Icon requests use cloud URLs when cloud is selected
+- **GIVEN** the user has selected "Bitwarden Cloud"
+- **WHEN** `PrizmAPIClient` fetches a favicon or icon
+- **THEN** the request SHALL be sent to `https://icons.bitwarden.net`
+
+#### Scenario: API requests use self-hosted URLs when self-hosted is selected
+- **GIVEN** the user has selected "Self-hosted" and entered "https://vault.example.com" as the API URL
+- **WHEN** `PrizmAPIClient` makes a request to an `api/...` endpoint
+- **THEN** the request SHALL be sent to `https://vault.example.com/api/...`
+
+#### Scenario: Identity requests use self-hosted URLs when self-hosted is selected
+- **GIVEN** the user has selected "Self-hosted" and entered "https://vault.example.com" as the Identity URL
+- **WHEN** `PrizmAPIClient` makes a request to an `identity/...` endpoint
+- **THEN** the request SHALL be sent to `https://vault.example.com/identity/...`
+
+#### Scenario: Icons requests use self-hosted URLs when self-hosted is selected
+- **GIVEN** the user has selected "Self-hosted" and entered "https://vault.example.com" as the Icons URL
+- **WHEN** `PrizmAPIClient` fetches a favicon or icon
+- **THEN** the request SHALL be sent to `https://vault.example.com`
+
+---
+
+### Requirement: `ServerEnvironment` configuration persists per account
+The system SHALL store the server environment selection (cloud or self-hosted) and associated URLs per account in a secure persistence layer. When the user switches accounts or after app restart, the system SHALL restore the correct server environment for each account. The active account's environment SHALL be used for all network requests.
+
+#### Scenario: Environment stored after successful login
+- **GIVEN** the user successfully logs in with a specific server environment
+- **WHEN** the login completes
+- **THEN** the server environment selection and URLs SHALL be persisted for that account
+
+#### Scenario: Environment restored on app launch for active account
+- **GIVEN** the user was logged into an account configured for "Bitwarden Cloud"
+- **WHEN** the app is relaunched and the vault is unlocked
+- **THEN** `PrizmAPIClient` SHALL be configured to use cloud URLs for that account
+
+#### Scenario: Multiple accounts can have different environments
+- **GIVEN** Account A is configured for "Bitwarden Cloud"
+- **AND** Account B is configured for "Self-hosted" with custom URLs
+- **WHEN** the user switches from Account A to Account B
+- **THEN** `PrizmAPIClient` SHALL update to use Account B's self-hosted URLs
+
+---
+
+### Requirement: Registered client identifier is used for cloud requests
+The system SHALL include a registered client identifier in API requests when communicating with Bitwarden Cloud (`api.bitwarden.com`). The client identifier SHALL be obtained from Bitwarden, Inc. per their Device Registration requirements and shall be included in the appropriate headers per their API specification. Self-hosted Vaultwarden instances SHALL NOT require this header.
+
+#### Scenario: Client identifier present in cloud API requests
+- **GIVEN** the user has selected "Bitwarden Cloud"
+- **WHEN** `PrizmAPIClient` makes a request to a cloud API endpoint
+- **THEN** the request SHALL include the registered client identifier as part of the appropriate OAuth token exchange
+
+#### Scenario: Client identifier not required for self-hosted requests
+- **GIVEN** the user has selected "Self-hosted"
+- **WHEN** `PrizmAPIClient` makes a request to a self-hosted Vaultwarden instance
+- **THEN** the request SHALL NOT include the client identifier header
+
+#### Scenario: Missing client identifier prevents cloud login
+- **GIVEN** the user has selected "Bitwarden Cloud" and no client identifier is configured
+- **WHEN** the user attempts to log in
+- **THEN** the login SHALL fail with an error indicating that the client identifier is required
+
+---
+
+### Requirement: System supports CAPTCHA verification for cloud login
+The system SHALL support authentication via Bitwarden Cloud's standard pattern. As of 2026-04-18, this includes CAPTCHA verification via [hCaptcha](https://www.hcaptcha.com/). The system SHALL launch a web view modal (`WKWebView` using standard macOS configuration) in order to pass such challenges.
+
+API keys SHALL be stored securely in the Keychain after a successful login.
+
+#### Scenario: API key login option is visible for cloud
+- **GIVEN** the user has selected "Bitwarden Cloud"
+- **WHEN** the `LoginView` is displayed
+- **THEN** an option to log in with API keys SHALL be visible
+
+#### Scenario: API key fields accept client_id and client_secret
+- **GIVEN** the user has chosen the API key login option
+- **WHEN** the user enters their client_id and client_secret
+- **THEN** the fields SHALL validate the format (non-empty strings)
+
+#### Scenario: API key login bypasses hCaptcha
+- **GIVEN** the user has entered valid API keys
+- **WHEN** the system submits the OAuth token request
+- **THEN** no hCaptcha challenge SHALL be presented
+- **AND** the login SHALL proceed directly on successful token exchange
+
+#### Scenario: API keys are stored in Keychain on successful login
+- **GIVEN** the user has successfully logged in via API keys
+- **WHEN** the login completes
+- **THEN** the client_id and client_secret SHALL be stored securely in the Keychain
+- **AND** future logins for this account SHALL be able to use the stored keys
+
+#### Scenario: Invalid API keys show clear error message
+- **WHEN** the user enters invalid API keys and attempts to log in
+- **THEN** an error message SHALL be displayed indicating that the API keys are invalid
+- **AND** the login SHALL not proceed
+
+#### Scenario: API key login option not shown for self-hosted by default
+- **GIVEN** the user has selected "Self-hosted"
+- **WHEN** the `LoginView` is displayed
+- **THEN** the API key login option SHALL NOT be shown (unless the self-hosted instance explicitly supports OAuth)
+
+---
+
+### Requirement: Errors from server environment configuration are surfaced clearly
+The system SHALL validate server environment URLs before attempting login. If the user enters an invalid URL scheme or unreachable endpoint for self-hosted configuration, the system SHALL surface a clear error message indicating the specific validation failure. Network errors during login SHALL distinguish between connectivity issues, authentication failures, and server configuration errors.
+
+#### Scenario: Invalid URL scheme is rejected
+- **WHEN** the user enters a URL without https:// in a self-hosted field
+- **THEN** the system SHALL reject the URL and show an error message indicating that HTTPS is required
+
+#### Scenario: Unreachable endpoint shows clear error
+- **WHEN** the user enters a self-hosted URL that cannot be reached
+- **THEN** the login attempt SHALL fail with an error message indicating the server is unreachable
+- **AND** the specific endpoint that failed SHALL be mentioned (API or Identity)
+
+#### Scenario: Authentication failure is distinguished from network error
+- **WHEN** login fails due to invalid credentials
+- **THEN** the error message SHALL clearly indicate an authentication failure
+- **AND** SHALL be distinct from network connectivity error messages
+
+#### Scenario: Cloud endpoint unreachable shows specific message
+- **WHEN** the user selects "Bitwarden Cloud" and cloud endpoints are unreachable
+- **THEN** the error message SHALL indicate that Bitwarden Cloud services are temporarily unavailable
+-

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -253,6 +253,30 @@ After successful login, the `ServerEnvironment` (including `serverType`) SHALL b
 
 Per [ADR-0023](https://contributing.bitwarden.com/architecture/adr/integration-identifiers/), third-party clients must obtain a registered identifier from Bitwarden via a support ticket. Without it, Bitwarden Cloud rejects requests with `400 Bad Request` (missing required headers) or `403 Forbidden` (unsupported identifier). Self-hosted instances perform no such checks. Prizm has obtained its registered identifier; it is injected at build time via a gitignored `LocalSecrets.xcconfig` file and MUST NOT appear in source control.
 
+**Build-time injection contract:**
+
+```
+// LocalSecrets.xcconfig  (gitignored — never commit)
+BW_CLIENT_IDENTIFIER = prizm.XXXXXXXX
+```
+
+```xml
+<!-- Prizm/Prizm-Info.plist -->
+<key>BWClientIdentifier</key>
+<string>$(BW_CLIENT_IDENTIFIER)</string>
+```
+
+```swift
+// App/Config.swift
+/// Registered Bitwarden client identifier, injected at build time via LocalSecrets.xcconfig.
+/// Empty string when LocalSecrets.xcconfig is absent — cloud login fails fast with
+/// AuthError.clientIdentifierNotConfigured before any network request is attempted.
+static let bitwardenClientIdentifier: String =
+    Bundle.main.object(forInfoDictionaryKey: "BWClientIdentifier") as? String ?? ""
+```
+
+`AuthRepositoryImpl` reads `Config.bitwardenClientIdentifier` and throws `AuthError.clientIdentifierNotConfigured` if empty before making any cloud identity token request. A template file `LocalSecrets.xcconfig.template` SHALL be committed to the repo root with empty value and copy instructions.
+
 `PrizmAPIClient` currently sends `ClientHeaders.clientId = "desktop"` — a real Bitwarden-registered identifier for their own desktop client. Using it would violate ADR-0023; Prizm's own registered identifier MUST be used instead.
 
 **Enforcement by grant type:**
@@ -485,7 +509,7 @@ Per §IV, tests MUST be written before implementation. The following are require
 - `AuthRepositoryImpl.setServerEnvironment(_:)` calls `apiClient.setServerEnvironment(_:)` (not `setBaseURL`)
 - `LoginUseCaseImpl` does NOT call `auth.validateServerURL` when `environment.serverType == .cloudUS` or `.cloudEU`
 - `LoginUseCaseImpl` DOES call `auth.validateServerURL` when `environment.serverType == .selfHosted`
-- Cloud login attempt with empty client identifier throws before making a network request
+- `Config.bitwardenClientIdentifier` empty (no `LocalSecrets.xcconfig`) → `AuthRepositoryImpl` throws `AuthError.clientIdentifierNotConfigured` before any network request
 - `PrizmAPIClient.baseRequest()` sets `Bitwarden-Client-Name` and `Bitwarden-Client-Version` HTTP headers on every request; a cloud `identityToken` request includes both
 - `PrizmAPIClient.refreshAccessToken` sends the registered cloud `client_id` (not `"desktop"`) when `serverType` is cloud
 - `AuthRepositoryImpl.loginWithPassword` returns `LoginResult.requiresNewDeviceOTP` when the identity token response is `HTTP 400` with `{"error": "device_error"}`
@@ -562,9 +586,10 @@ Starting value: `2026.4.0` — the current Bitwarden server release as of the im
 ### Requirement: Update `DEVELOPMENT.md` for `LocalSecrets.xcconfig`
 
 `DEVELOPMENT.md` SHALL be updated to document the new `LocalSecrets.xcconfig` setup step required for cloud login:
-- Add a `LocalSecrets.xcconfig` section explaining its purpose (injects the registered Bitwarden client identifier at build time)
-- Provide a template copy command analogous to the existing `LocalConfig.xcconfig` instructions
-- Clarify that without this file, the app will build successfully but cloud login will fail at runtime with a clear error — self-hosted login is unaffected
+- Add a `LocalSecrets.xcconfig` section explaining its purpose (injects `BW_CLIENT_IDENTIFIER` at build time via `BWClientIdentifier` Info.plist key, read by `Config.bitwardenClientIdentifier`)
+- Provide the copy command: `cp LocalSecrets.xcconfig.template LocalSecrets.xcconfig`
+- Note the xcconfig must be included in the Xcode project under the Debug and Release configurations (analogous to `LocalConfig.xcconfig`)
+- Clarify that without this file (or with an empty `BW_CLIENT_IDENTIFIER`), the app will build successfully but cloud login will fail at runtime with `AuthError.clientIdentifierNotConfigured` — self-hosted login is unaffected
 
 ---
 

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -62,6 +62,8 @@ When a cloud option is selected, no URL entry is required or shown. When "Self-h
 | `cloudEU` | `https://api.bitwarden.eu` | `https://identity.bitwarden.eu` | `https://icons.bitwarden.net` |
 | `selfHosted` | `{base}/api` (or override) | `{base}/identity` (or override) | `{base}/icons` (or override) |
 
+> **Reference**: Endpoint URLs confirmed via [Bitwarden's official documentation](https://bitwarden.com/help/bitwarden-addresses/).
+
 Cloud cases SHALL ignore `overrides` and SHALL ignore `base` for URL routing. `selfHosted` behaviour is unchanged. Existing Keychain records without a `serverType` key SHALL decode as `selfHosted`.
 
 `ServerType` SHALL be a `String`-backed `RawRepresentable` enum with fixed raw values: `"cloudUS"`, `"cloudEU"`, `"selfHosted"`. These raw values are part of the Keychain storage contract and MUST NOT be renamed after any release that has written Keychain data.
@@ -177,7 +179,10 @@ The `client_id` is an app-level credential, not a per-user credential. No additi
 
 ### Requirement: Cloud login supports email/password with hCaptcha handling
 
-All three server options use email + master password login. When a cloud account (`cloudUS` or `cloudEU`) triggers an hCaptcha challenge, the system SHALL present a `WKWebView` modal for the user to complete the challenge before the token request is retried.
+All three server options use email + master password login. When a cloud account (`cloudUS` or `cloudEU`) triggers an hCaptcha challenge, the system SHALL present a `WKWebView` modal for the user to complete the challenge before the token request is retried. hCaptcha is not required on every login; the server decides when to require it.
+
+> **Implementation note**:
+> The exact mechanism by which the client distinguishes hCaptcha requirement from other auth failures (e.g., invalid credentials, 2FA required) is not clearly documented in public repositories and must be discovered at implementation time via testing against cloud endpoints or referencing internal documentation.
 
 #### Scenario: hCaptcha modal shown for cloud password login
 - **GIVEN** the user attempts password login with a cloud option selected
@@ -186,6 +191,12 @@ All three server options use email + master password login. When a cloud account
 - **AND** when hCaptcha completes, its JS SHALL call `window.webkit.messageHandlers.hcaptcha.postMessage(token)`
 - **AND** the native `WKScriptMessageHandler` SHALL receive the token, dismiss the modal, and retry `identityToken` with the token included
 - **AND** the token SHALL be held in memory only for the duration of the retry and NOT persisted
+
+#### Scenario: hCaptcha challenge dismissal treated as failed login
+- **GIVEN** the hCaptcha modal is presented
+- **WHEN** the user dismisses the modal without completing the challenge
+- **THEN** the login attempt SHALL be treated as a failed login
+- **AND** an appropriate error message SHALL be displayed to the user
 
 #### Scenario: Self-hosted login has no hCaptcha handling
 - **GIVEN** the active account has `serverType == .selfHosted`

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -112,6 +112,37 @@ The computed properties (`apiURL`, `identityURL`, `iconsURL`) SHALL switch on `s
 
 ---
 
+### Requirement: `LoginUseCase.execute` accepts `ServerEnvironment`
+
+`LoginUseCase.execute` SHALL change its signature from `execute(serverURL: String, email: String, masterPassword: Data)` to `execute(environment: ServerEnvironment, email: String, masterPassword: Data)`. `LoginViewModel` is responsible for constructing the correct `ServerEnvironment` before calling the use case:
+
+```swift
+// Cloud
+let environment = ServerEnvironment.cloudUS()   // or .cloudEU()
+
+// Self-hosted
+let environment = ServerEnvironment(base: url, overrides: nil)
+```
+
+`LoginUseCaseImpl` SHALL call `auth.validateServerURL` **only** when `environment.serverType == .selfHosted`. Cloud environments SHALL skip URL validation entirely — they use hardcoded canonical URLs with no user-supplied string to validate.
+
+The internal URL construction (`URL(string: trimmed)`) in `LoginUseCaseImpl` is removed; the environment is passed directly to `auth.setServerEnvironment(environment)`.
+
+`LoginViewModel` retains responsibility for URL string validation feedback (empty field, non-HTTPS warning) before constructing the `ServerEnvironment` — this is UI-layer input validation, distinct from the use-case-layer server reachability check.
+
+#### Scenario: Cloud login skips URL validation
+- **GIVEN** `LoginViewModel` constructs `ServerEnvironment.cloudUS()`
+- **WHEN** `LoginUseCase.execute(environment:email:masterPassword:)` is called
+- **THEN** `auth.validateServerURL` SHALL NOT be called
+- **AND** `auth.setServerEnvironment` SHALL be called with the cloud environment directly
+
+#### Scenario: Self-hosted login still validates URL
+- **GIVEN** `LoginViewModel` constructs a `selfHosted` `ServerEnvironment`
+- **WHEN** `LoginUseCase.execute(environment:email:masterPassword:)` is called
+- **THEN** `auth.validateServerURL` SHALL be called before `auth.setServerEnvironment`
+
+---
+
 ### Requirement: `PrizmAPIClient` routes requests via `ServerEnvironment`
 
 `PrizmAPIClient` SHALL replace `setBaseURL(_ url: URL)` with `setServerEnvironment(_ env: ServerEnvironment)`. `setBaseURL` SHALL be removed from `PrizmAPIClientProtocol` entirely. All ~32 endpoint methods SHALL use `env.apiURL`, `env.identityURL`, or `env.iconsURL` instead of appending to a single `base`.
@@ -168,7 +199,9 @@ The existing `AuthError` enum (`Domain/Repositories/AuthRepository.swift`) SHALL
 | `clientIdentifierNotConfigured` | `AuthRepositoryImpl` (before network request) | `"Prizm is not configured for Bitwarden Cloud. Contact support or use a self-hosted server."` |
 | `newDeviceVerificationRequired` | `AuthRepositoryImpl` (on `device_error` 400 response) | `nil` — handled structurally by `LoginViewModel`; triggers the OTP entry UI, not a plain error string |
 
-`newDeviceVerificationRequired` is thrown when the server returns `HTTP 400` with `{"error": "device_error"}`. `LoginViewModel` catches it and transitions to the new device OTP entry state rather than displaying an error string.
+`newDeviceVerificationRequired` is thrown when the server returns `HTTP 400` with `{"error": "device_error"}`. `LoginViewModel` catches it and transitions to `awaitingOTP` state rather than displaying an error string.
+
+**Layer boundary**: `PrizmAPIClient.identityToken` throws a Data-layer error (e.g. `IdentityTokenError.newDeviceNotVerified`) when it receives a `device_error` response. `AuthRepositoryImpl` catches that Data-layer error and translates it to `AuthError.newDeviceVerificationRequired` before rethrowing — preserving the clean architecture boundary. The Domain layer and above never import or reference `IdentityTokenError` directly.
 
 `serverUnreachable`, `invalidCredentials`, `networkUnavailable`, and `invalidURL` already exist in `AuthError` and cover the remaining error scenarios defined in this spec without modification.
 
@@ -212,6 +245,96 @@ The `client_id` is an app-level credential, not a per-user credential. No additi
 
 ---
 
+### Requirement: `LoginUseCase` OTP retry flow
+
+`LoginUseCase` SHALL gain two new methods mirroring the existing 2FA pattern (`completeTOTP` / `cancelTOTP`):
+
+```swift
+/// Retries the identity token request with the new-device OTP the user received by email.
+/// Only valid to call after `execute` throws `AuthError.newDeviceVerificationRequired`.
+/// On success, triggers vault sync and returns the logged-in `Account`.
+func completeNewDeviceOTP(otp: String) async throws -> Account
+
+/// Re-triggers the original identity token request without an OTP, causing the server to
+/// dispatch a new verification code to the user's email. The OTP field should be cleared
+/// after calling this. Only valid when in the `awaitingOTP` state.
+func resendNewDeviceOTP() async throws
+
+/// Cancels a pending new-device OTP challenge and clears any cached credentials.
+func cancelNewDeviceOTP()
+```
+
+`AuthRepository` SHALL gain a matching method:
+```swift
+func loginWithNewDeviceOTP(_ otp: String) async throws -> Account
+```
+
+`AuthRepositoryImpl` holds the pending environment, email, and hashed password in memory after throwing `newDeviceVerificationRequired`. `loginWithNewDeviceOTP` retries `PrizmAPIClient.identityToken` with the `newdeviceotp` form parameter added, then zeros the cached credentials immediately after the attempt (success or failure). `cancelNewDeviceOTP` zeros the cached credentials without retrying.
+
+`LoginViewModel` catches `AuthError.newDeviceVerificationRequired`, transitions to `awaitingOTP` state, and on Sign In calls `loginUseCase.completeNewDeviceOTP(otp:)`.
+
+The `execute` method signature changes are covered by the `LoginUseCase.execute` requirement above. `LoginUseCase.protocol` doc comment SHALL be updated to reflect the new flow: `execute → (optional) completeNewDeviceOTP → sync` or `execute → (optional) completeTOTP → sync`.
+
+#### Scenario: `completeNewDeviceOTP` retries with OTP
+- **GIVEN** `execute` has thrown `AuthError.newDeviceVerificationRequired`
+- **WHEN** `completeNewDeviceOTP(otp:)` is called with a valid code
+- **THEN** `PrizmAPIClient.identityToken` SHALL be called with `newdeviceotp` set to the code
+- **AND** on success, cached credentials SHALL be zeroed and vault sync SHALL run
+- **AND** the `Account` SHALL be returned
+
+#### Scenario: `cancelNewDeviceOTP` clears cached credentials
+- **GIVEN** `execute` has thrown `AuthError.newDeviceVerificationRequired`
+- **WHEN** `cancelNewDeviceOTP()` is called
+- **THEN** cached credentials (environment, email, hashed password) SHALL be zeroed
+- **AND** no network request SHALL be made
+
+---
+
+### Requirement: `LoginViewModel` state machine
+
+`LoginViewModel` SHALL expose a `loginState: LoginState` published property. `LoginView` derives all conditional UI (OTP field visibility, field editability, button label) from this property.
+
+```swift
+enum LoginState: Equatable {
+    case idle           // initial state; all fields editable
+    case awaitingOTP    // device_error received; OTP field shown, email/password disabled
+    case loading        // network request in flight; all fields disabled
+}
+```
+
+**Valid transitions:**
+
+| From | Event | To |
+|---|---|---|
+| `idle` | Sign In tapped | `loading` |
+| `loading` | Auth success | (navigate away — no state change needed) |
+| `loading` | Auth failure (not device_error) | `idle` (error shown) |
+| `loading` | `newDeviceVerificationRequired` | `awaitingOTP` |
+| `awaitingOTP` | Sign In tapped (OTP submit) | `loading` |
+| `awaitingOTP` | Invalid OTP (`invalid_grant`) | `awaitingOTP` (error shown, field remains) |
+| `awaitingOTP` | Resend tapped | `loading` → `awaitingOTP` (OTP field cleared, confirmation announced) |
+| `awaitingOTP` | Cancel tapped | `idle` (OTP field hidden, fields re-enabled) |
+
+During `awaitingOTP`, email and master password fields SHALL be visible but disabled (`.disabled(true)`) so the user sees which account they are verifying. During `loading`, all interactive controls SHALL be disabled.
+
+#### Scenario: Fields disabled during loading
+- **GIVEN** `loginState == .loading`
+- **THEN** the email field, password field, server picker, and Sign In button SHALL all be non-interactive
+
+#### Scenario: OTP field visible and email/password disabled during awaitingOTP
+- **GIVEN** `loginState == .awaitingOTP`
+- **THEN** the OTP field SHALL be visible and editable
+- **AND** the email and password fields SHALL be visible but disabled
+- **AND** a "Cancel" button SHALL be visible that transitions to `idle`
+
+#### Scenario: Cancel clears OTP state
+- **GIVEN** `loginState == .awaitingOTP`
+- **WHEN** the user taps Cancel
+- **THEN** `loginState` SHALL transition to `idle`
+- **AND** the OTP field SHALL be hidden and its value cleared
+
+---
+
 ### Requirement: Cloud login supports email/password with new device OTP verification
 
 All three server options use email + master password login.
@@ -243,6 +366,16 @@ New device verification is not required on every login; Bitwarden decides when t
 - **WHEN** the server returns `HTTP 400` with `{"error": "invalid_grant"}`
 - **THEN** an error message SHALL indicate the code is invalid or expired
 - **AND** the OTP field SHALL remain visible for re-entry
+
+#### Scenario: Resend code clears OTP field and sends fresh code
+- **GIVEN** `loginState == .awaitingOTP`
+- **WHEN** the user taps "Resend code"
+- **THEN** `loginUseCase.resendNewDeviceOTP()` SHALL be called
+- **AND** the OTP field SHALL be cleared
+- **AND** `loginState` SHALL transition to `loading` during the request and back to `awaitingOTP` on completion
+- **AND** an `AccessibilityNotification.Announcement` SHALL be posted with "A new code has been sent to your email"
+
+`LoginUseCase` SHALL gain a `resendNewDeviceOTP() async throws` method. `AuthRepositoryImpl` implements it by retrying the original identity token request without `newdeviceotp`, causing the server to recognise the unverified device and dispatch a new code.
 
 #### Scenario: Self-hosted login has no new device OTP handling
 - **GIVEN** the active account has `serverType == .selfHosted`
@@ -280,6 +413,7 @@ All new code paths MUST produce structured `os.Logger` output (§V). Secrets MUS
 - Server environment selection and restoration SHALL be logged at `.info` level, including the `serverType` value
 - Each identity token request SHALL log the target `identityURL` (not the password or hash) at `.info`
 - New device verification required and OTP retry SHALL be logged at `.info`
+- Invalid or expired OTP (`invalid_grant` on retry) SHALL be logged at `.error`
 - Client identifier misconfiguration SHALL be logged at `.error` before surfacing to the Presentation layer
 - URL validation failures (non-HTTPS, parse error) SHALL be logged at `.error`
 
@@ -299,11 +433,15 @@ Per §IV, tests MUST be written before implementation. The following are require
 **Unit tests (Data):**
 - `PrizmAPIClient.setServerEnvironment()` stores the environment and subsequent requests use `env.apiURL` / `env.identityURL` as appropriate (representative call sites: `preLogin`, `identityToken`, `refreshAccessToken`, `fetchSync`)
 - `AuthRepositoryImpl.setServerEnvironment(_:)` calls `apiClient.setServerEnvironment(_:)` (not `setBaseURL`)
+- `LoginUseCaseImpl` does NOT call `auth.validateServerURL` when `environment.serverType == .cloudUS` or `.cloudEU`
+- `LoginUseCaseImpl` DOES call `auth.validateServerURL` when `environment.serverType == .selfHosted`
 - Cloud login attempt with empty client identifier throws before making a network request
 - `PrizmAPIClient` includes `Bitwarden-Client-Name`, `Bitwarden-Client-Version`, and `Device-Type` headers on a cloud `identityToken` request
 - `AuthRepositoryImpl` throws `AuthError.newDeviceVerificationRequired` when the identity token response is `HTTP 400` with `{"error": "device_error"}`
+- `LoginUseCaseImpl.completeNewDeviceOTP` calls `auth.loginWithNewDeviceOTP(_:)` and triggers sync on success
+- `LoginUseCaseImpl.cancelNewDeviceOTP` calls `auth.cancelNewDeviceOTP()` and makes no network request
 - OTP retry includes `newdeviceotp` form parameter and succeeds on a valid code
-- OTP is zeroed from memory after the retry completes or fails
+- Cached credentials (environment, email, hashed password) are zeroed after retry completes or fails, and after cancel
 
 **Unit tests (Presentation):**
 - `LoginViewModel` server type selection is persisted and restored across instantiation
@@ -311,6 +449,13 @@ Per §IV, tests MUST be written before implementation. The following are require
 - Selecting a cloud type clears `serverURL`; selecting self-hosted restores the last entered URL
 - `isSignInDisabled` returns `false` for cloud when email and password are non-empty, even when `serverURL` is empty
 - `isSignInDisabled` returns `true` for self-hosted when `serverURL` is empty, even when email and password are filled
+- `isSignInDisabled` returns `true` when `loginState == .awaitingOTP` and the OTP field is empty
+- `isSignInDisabled` returns `false` when `loginState == .awaitingOTP` and the OTP field is non-empty
+- `loginState` transitions to `.awaitingOTP` when `execute` throws `AuthError.newDeviceVerificationRequired`
+- `loginState` transitions to `.idle` when Cancel is tapped from `.awaitingOTP`
+- `loginState` remains `.awaitingOTP` after an invalid OTP error; error message is set
+- `loginUseCase.resendNewDeviceOTP()` is called when "Resend code" is tapped; OTP field is cleared and confirmation is announced
+- `LoginUseCaseImpl.resendNewDeviceOTP()` calls `auth.loginWithNewDeviceOTP` without an OTP value to re-trigger server dispatch
 
 **Integration tests:**
 - Full login flow against a Vaultwarden stub (existing coverage) continues to pass after the `PrizmAPIClient` refactor
@@ -351,7 +496,15 @@ Per §IV, tests MUST be written before implementation. The following are require
 
 ### Requirement: Document tested Bitwarden API version in `Config.swift`
 
-Per Constitution Bitwarden API Integration Requirements, `Config.swift` SHALL gain a `bitwardenApiVersion` constant recording the Bitwarden server API version this client has been tested against (e.g. `static let bitwardenApiVersion = "2025-01"`). The value SHALL be determined during the implementation spike and updated whenever the tested version changes.
+Per Constitution Bitwarden API Integration Requirements, `Config.swift` SHALL gain a `bitwardenApiVersion` constant recording the Bitwarden server API version this client has been tested against:
+
+```swift
+/// Bitwarden server API version Prizm was last tested against.
+/// Update when testing against a newer server release.
+static let bitwardenApiVersion = "2026.4.0"
+```
+
+Starting value: `2026.4.0` — the current Bitwarden server release as of the implementation spike (2026-04-20, confirmed from [bitwarden/ios v2026.4.0-bwpm](https://github.com/bitwarden/ios/releases/tag/v2026.4.0-bwpm)). Update if testing against a newer release before shipping.
 
 ---
 

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -6,10 +6,9 @@ Defines support for Bitwarden Cloud (US and EU regions) alongside self-hosted Va
 
 Per §I and §VI, non-trivial architectural decisions and AppKit exceptions must be justified here.
 
-| Component | Type | Justification | Simpler alternative rejected |
-|---|---|---|---|
-| `WKWebView` hCaptcha modal | AppKit/WebKit exception (§I) | SwiftUI has no web rendering API on macOS; `WKWebView` is the only platform-provided mechanism for an interactive web challenge | Skipping hCaptcha entirely — rejected because Bitwarden Cloud conditionally requires it; affected users would get a silent auth failure |
-| `HCaptchaPresenter` protocol + DI | Added abstraction (§VI) | Required for XCUITest determinism; without injection the hCaptcha path cannot be exercised in CI without a live network | Single concrete `WKWebView` usage — rejected because it makes the modal untestable |
+No AppKit exceptions are required for this change. New device OTP verification uses a native SwiftUI text field — no web rendering is needed.
+
+> **Spike finding (2026-04-20)**: hCaptcha was removed from Bitwarden Cloud server and all clients in [PR #1861](https://github.com/bitwarden/ios/pull/1861) (merged 2025-08-20, PM-24667). The `WKWebView` modal originally planned for this change is no longer required. New device OTP verification (email OTP on first login from an unrecognized device) is the current mechanism.
 
 ## Baseline (what already exists)
 
@@ -162,15 +161,14 @@ All requests to cloud endpoints SHALL include the required Bitwarden client head
 
 ### Requirement: Error taxonomy
 
-The existing `AuthError` enum (`Domain/Repositories/AuthRepository.swift`) SHALL be extended with three new cases for this change. `LoginViewModel` pattern-matches all `AuthError` cases; no new error type is introduced.
+The existing `AuthError` enum (`Domain/Repositories/AuthRepository.swift`) SHALL be extended with two new cases for this change. `LoginViewModel` pattern-matches all `AuthError` cases; no new error type is introduced.
 
 | Case | Thrown by | `errorDescription` |
 |---|---|---|
 | `clientIdentifierNotConfigured` | `AuthRepositoryImpl` (before network request) | `"Prizm is not configured for Bitwarden Cloud. Contact support or use a self-hosted server."` |
-| `hCaptchaRequired(siteKey: String)` | `AuthRepositoryImpl` (on challenge response) | `nil` — handled structurally by `LoginViewModel`; not shown as a plain error string |
-| `hCaptchaCancelled` | `LoginViewModel` (on modal dismiss without token) | `"Unable to complete the security challenge. To log in without this requirement, use a self-hosted Vaultwarden server."` |
+| `newDeviceVerificationRequired` | `AuthRepositoryImpl` (on `device_error` 400 response) | `nil` — handled structurally by `LoginViewModel`; triggers the OTP entry UI, not a plain error string |
 
-`hCaptchaRequired` carries the site key extracted from the server's challenge response so `LoginViewModel` can pass it to `WKWebViewHCaptchaPresenter` when constructing the challenge URL.
+`newDeviceVerificationRequired` is thrown when the server returns `HTTP 400` with `{"error": "device_error"}`. `LoginViewModel` catches it and transitions to the new device OTP entry state rather than displaying an error string.
 
 `serverUnreachable`, `invalidCredentials`, `networkUnavailable`, and `invalidURL` already exist in `AuthError` and cover the remaining error scenarios defined in this spec without modification.
 
@@ -214,39 +212,41 @@ The `client_id` is an app-level credential, not a per-user credential. No additi
 
 ---
 
-### Requirement: Cloud login supports email/password with hCaptcha handling
+### Requirement: Cloud login supports email/password with new device OTP verification
 
-All three server options use email + master password login. When a cloud account (`cloudUS` or `cloudEU`) triggers an hCaptcha challenge, the system SHALL present a `WKWebView` modal for the user to complete the challenge before the token request is retried. hCaptcha is not required on every login; the server decides when to require it.
+All three server options use email + master password login.
 
-> **Research spike required — resolve before writing tasks:**
->
-> The following must be determined by consulting the [Bitwarden iOS client](https://github.com/bitwarden/ios) (study-only reference per Constitution External Dependencies) before implementation begins. Findings SHALL replace this block with concrete values.
->
-> 1. **Trigger signal**: What HTTP status and response body field indicate an hCaptcha challenge is required? (Expected: `400` with a JSON error body containing a `HCaptcha_SiteKey` or similar field — verify against iOS source.)
-> 2. **Challenge URL**: What URL does the `WKWebView` load? (Expected: a Bitwarden-hosted page such as `https://vault.bitwarden.com/captcha-mobile-connector.html` that embeds the hCaptcha widget — verify; EU region may differ.)
-> 3. **Site key**: Is the hCaptcha site key static per region (hardcode in `ServerType`) or returned dynamically in the challenge response? (If dynamic, it must be extracted from the error body and passed to the challenge URL as a query parameter.)
-> 4. **JS message name**: Confirm the `WKScriptMessageHandler` message name is `"hcaptcha"` — verify against iOS source.
-> 5. **Token field name**: What form parameter name carries the hCaptcha token in the retried `identityToken` request? (Expected: `captchaResponse` or similar — verify.)
->
-> **Do not begin implementation of the hCaptcha path until all five points are confirmed and this block is replaced with findings.**
+When Bitwarden Cloud does not recognise the device, it returns `HTTP 400` with `{"error": "device_error", "error_description": "New device verification required"}` and sends a one-time code to the user's registered email address. The system SHALL handle this by presenting an OTP entry field inline in `LoginView` and retrying the identity token request with the `newdeviceotp` parameter.
 
-#### Scenario: hCaptcha modal shown for cloud password login
+> **Spike findings (2026-04-20)**: hCaptcha was removed from Bitwarden Cloud in [bitwarden/ios#1861](https://github.com/bitwarden/ios/pull/1861) (merged 2025-08-20). The `WKWebView` modal originally planned is not needed. The current mechanism is:
+> - **Trigger**: `HTTP 400`, `{"error": "device_error"}`
+> - **Bitwarden sends**: OTP to the user's registered email
+> - **Retry field**: `newdeviceotp=<code>` added to the `POST /connect/token` form body
+> - **No web view required** — standard SwiftUI text field
+
+New device verification is not required on every login; Bitwarden decides when to require it based on device recognition. It does not apply to self-hosted Vaultwarden instances.
+
+#### Scenario: New device OTP field shown on device_error
 - **GIVEN** the user attempts password login with a cloud option selected
-- **AND** the server returns an hCaptcha challenge response
-- **THEN** a `WKWebView` modal SHALL be presented
-- **AND** when hCaptcha completes, its JS SHALL call `window.webkit.messageHandlers.hcaptcha.postMessage(token)`
-- **AND** the native `WKScriptMessageHandler` SHALL receive the token, dismiss the modal, and retry `identityToken` with the token included
-- **AND** the token SHALL be held in memory only for the duration of the retry, NOT persisted, and zeroed from memory immediately after the retry completes or fails
+- **AND** the server returns `HTTP 400` with `{"error": "device_error"}`
+- **THEN** an OTP entry field SHALL appear in `LoginView` with the label "Check your email for a verification code"
+- **AND** the Sign In button SHALL remain disabled until the OTP field is non-empty
 
-#### Scenario: hCaptcha challenge dismissal treated as failed login
-- **GIVEN** the hCaptcha modal is presented
-- **WHEN** the user dismisses the modal without completing the challenge
-- **THEN** the login attempt SHALL be treated as a failed login
-- **AND** an appropriate error message SHALL be displayed to the user
+#### Scenario: OTP submitted and login retried
+- **GIVEN** the new device OTP field is visible and the user has entered a code
+- **WHEN** the user taps Sign In
+- **THEN** `PrizmAPIClient` SHALL retry `POST /connect/token` with the `newdeviceotp` form parameter set to the entered code
+- **AND** on success the OTP SHALL be zeroed from memory immediately
 
-#### Scenario: Self-hosted login has no hCaptcha handling
+#### Scenario: Invalid OTP shows error
+- **GIVEN** the user submits an incorrect OTP
+- **WHEN** the server returns `HTTP 400` with `{"error": "invalid_grant"}`
+- **THEN** an error message SHALL indicate the code is invalid or expired
+- **AND** the OTP field SHALL remain visible for re-entry
+
+#### Scenario: Self-hosted login has no new device OTP handling
 - **GIVEN** the active account has `serverType == .selfHosted`
-- **THEN** no hCaptcha modal path exists in the login flow
+- **THEN** no OTP entry field is shown; `device_error` responses SHALL surface as a generic auth error
 
 ---
 
@@ -256,26 +256,20 @@ All new interactive controls introduced by this change MUST be fully usable via 
 
 - The server picker SHALL have `accessibilityIdentifier` set to `AccessibilityID.Login.serverTypePicker`, `accessibilityLabel` set to "Server", and expose its current value via `accessibilityValue` (e.g. "Bitwarden Cloud (US)")
 - The server URL text field SHALL retain its existing `accessibilityIdentifier` and have a meaningful `accessibilityLabel` ("Server URL")
-- The hCaptcha `WKWebView` modal SHALL have `accessibilityLabel` set to "Complete security challenge"; VoiceOver focus SHALL move into the modal on presentation and return to the login form on dismissal
-- The modal SHALL always expose a keyboard-accessible "Cancel" button reachable without completing the web challenge
-- Error messages (unreachable server, invalid credentials, missing client identifier) SHALL be announced via `AccessibilityNotification.Announcement` as soon as they appear
-
-> **Known limitation**: `WKWebView` renders a third-party hCaptcha widget; Prizm cannot guarantee the widget itself meets WCAG 2.1 AA. If a user cannot complete the challenge via assistive technology, the Cancel path (see scenario below) provides an exit. This limitation MUST be documented in `ACCESSIBILITY.md` with a note that self-hosted Vaultwarden is available as an alternative that does not require hCaptcha.
+- The new device OTP text field SHALL have `accessibilityIdentifier` set to `AccessibilityID.Login.newDeviceOtpField` and `accessibilityLabel` set to "Verification code"
+- Error messages (unreachable server, invalid credentials, missing client identifier, invalid OTP) SHALL be announced via `AccessibilityNotification.Announcement` as soon as they appear
 
 #### Scenario: Picker exposes current selection to VoiceOver
 - **WHEN** the server picker has "Bitwarden Cloud (EU)" selected
 - **THEN** VoiceOver SHALL announce the control as "Server, Bitwarden Cloud (EU)"
 
+#### Scenario: OTP field announced when it appears
+- **WHEN** the new device OTP field appears after a `device_error` response
+- **THEN** an `AccessibilityNotification.Announcement` SHALL be posted with "Check your email for a verification code"
+
 #### Scenario: Error announced to assistive technology
 - **WHEN** an error message appears in the login form
 - **THEN** an `AccessibilityNotification.Announcement` SHALL be posted with the error text
-
-#### Scenario: hCaptcha inaccessible path
-- **GIVEN** the hCaptcha modal is presented
-- **WHEN** the user cannot complete the challenge via assistive technology and activates the "Cancel" button
-- **THEN** the modal SHALL be dismissed
-- **AND** an error message SHALL read "Unable to complete the security challenge. To log in without this requirement, use a self-hosted Vaultwarden server."
-- **AND** the `AccessibilityNotification.Announcement` SHALL be posted with that error text
 
 ---
 
@@ -285,7 +279,7 @@ All new code paths MUST produce structured `os.Logger` output (§V). Secrets MUS
 
 - Server environment selection and restoration SHALL be logged at `.info` level, including the `serverType` value
 - Each identity token request SHALL log the target `identityURL` (not the password or hash) at `.info`
-- hCaptcha challenge receipt and completion SHALL be logged at `.info`
+- New device verification required and OTP retry SHALL be logged at `.info`
 - Client identifier misconfiguration SHALL be logged at `.error` before surfacing to the Presentation layer
 - URL validation failures (non-HTTPS, parse error) SHALL be logged at `.error`
 
@@ -307,6 +301,9 @@ Per §IV, tests MUST be written before implementation. The following are require
 - `AuthRepositoryImpl.setServerEnvironment(_:)` calls `apiClient.setServerEnvironment(_:)` (not `setBaseURL`)
 - Cloud login attempt with empty client identifier throws before making a network request
 - `PrizmAPIClient` includes `Bitwarden-Client-Name`, `Bitwarden-Client-Version`, and `Device-Type` headers on a cloud `identityToken` request
+- `AuthRepositoryImpl` throws `AuthError.newDeviceVerificationRequired` when the identity token response is `HTTP 400` with `{"error": "device_error"}`
+- OTP retry includes `newdeviceotp` form parameter and succeeds on a valid code
+- OTP is zeroed from memory after the retry completes or fails
 
 **Unit tests (Presentation):**
 - `LoginViewModel` server type selection is persisted and restored across instantiation
@@ -320,16 +317,15 @@ Per §IV, tests MUST be written before implementation. The following are require
 
 **UI tests (XCUITest):**
 
-`LoginViewModel` SHALL accept a `HCaptchaPresenter` protocol (injected via `AppContainer`) so XCUITest can substitute a stub that immediately fires the JS token message without loading a real `WKWebView`. Production uses `WKWebViewHCaptchaPresenter`; tests use `StubHCaptchaPresenter`.
-
 - Three-way picker is visible on `LoginView`; all three options ("Bitwarden Cloud (US)", "Bitwarden Cloud (EU)", "Self-hosted") are selectable
 - Selecting "Bitwarden Cloud (US)" or "Bitwarden Cloud (EU)" hides the server URL field
 - Selecting "Self-hosted" shows the server URL field
 - Sign In button is enabled for a cloud option when email and password are non-empty and `serverURL` is empty
 - Sign In button is disabled for "Self-hosted" when `serverURL` is empty even if email and password are filled
-- Successful cloud login end-to-end against a local Bitwarden-compatible stub (using `StubHCaptchaPresenter` to bypass real web challenge)
-- hCaptcha modal presented for cloud login: `StubHCaptchaPresenter` fires the token → login proceeds
-- hCaptcha modal dismissed without token: login error message is shown
+- Successful cloud login end-to-end against a local stub (no OTP required path)
+- `device_error` response causes OTP field to appear with label "Check your email for a verification code"
+- Valid OTP entered → login succeeds; OTP field disappears
+- Invalid OTP → error message shown; OTP field remains for re-entry
 
 ---
 
@@ -372,7 +368,7 @@ Per Constitution Bitwarden API Integration Requirements, `Config.swift` SHALL ga
 
 `SECURITY.md` SHALL be updated to reflect the expanded network attack surface introduced by this change:
 - Document the two cloud regions and their canonical endpoints
-- Note that hCaptcha is handled via an embedded `WKWebView` loading a Bitwarden-hosted page; the token is held in memory only for the duration of the login retry and never persisted
+- Note that new device OTP verification is handled via a plain text field; the OTP is held in memory only for the duration of the retry and zeroed immediately after
 - Note that the registered client identifier is injected at build time and never stored at runtime beyond the request
 
 ---
@@ -381,8 +377,7 @@ Per Constitution Bitwarden API Integration Requirements, `Config.swift` SHALL ga
 
 `ACCESSIBILITY.md` SHALL be updated to document:
 - The new server picker control and its VoiceOver behaviour
-- The hCaptcha `WKWebView` modal and its known limitation (third-party widget; WCAG 2.1 AA compliance of the widget itself cannot be guaranteed by Prizm)
-- The self-hosted alternative available to users who cannot complete the hCaptcha challenge
+- The new device OTP verification field and its `accessibilityLabel` / announcement behaviour
 
 ---
 

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -49,7 +49,7 @@ When a cloud option is selected, no URL entry is required or shown. When "Self-h
 #### Scenario: Self-hosted selection shows the server URL field
 - **WHEN** the user selects "Self-hosted"
 - **THEN** the server URL field SHALL be visible and editable
-- **AND** any previously entered URL SHALL be restored
+- **AND** any previously entered URL SHALL be restored (persisted to `UserDefaults` under `com.prizm.login.lastServerURL`; survives app restarts and server-type switching)
 
 #### Scenario: Sign In button enabled for cloud without server URL
 - **GIVEN** the user has selected "Bitwarden Cloud (US)" or "Bitwarden Cloud (EU)"
@@ -76,6 +76,10 @@ When a cloud option is selected, no URL entry is required or shown. When "Self-h
 | `cloudUS` | `https://api.bitwarden.com` | `https://identity.bitwarden.com` | `https://icons.bitwarden.net` |
 | `cloudEU` | `https://api.bitwarden.eu` | `https://identity.bitwarden.eu` | `https://icons.bitwarden.net` |
 | `selfHosted` | `{base}/api` (or override) | `{base}/identity` (or override) | `{base}/icons` (or override) |
+
+> **URL routing note**: For self-hosted, `apiURL` includes the `/api` prefix (e.g. `https://vault.example.com/api`) and `identityURL` includes the `/identity` prefix. Endpoint methods append service-relative paths (e.g. `/accounts/prelogin`, `/connect/token`) to these URLs. This means cloud and self-hosted produce the correct final URLs without any conditional logic in the endpoint methods:
+> - Cloud: `https://api.bitwarden.com` + `/accounts/prelogin` → `https://api.bitwarden.com/accounts/prelogin`
+> - Self-hosted: `https://vault.example.com/api` + `/accounts/prelogin` → `https://vault.example.com/api/accounts/prelogin`
 
 > **Reference**: Endpoint URLs confirmed via [Bitwarden's official documentation](https://bitwarden.com/help/bitwarden-addresses/).
 >
@@ -154,6 +158,10 @@ The internal URL construction (`URL(string: trimmed)`) in `LoginUseCaseImpl` is 
 
 `PrizmAPIClient` SHALL replace `setBaseURL(_ url: URL)` with `setServerEnvironment(_ env: ServerEnvironment)`. `setBaseURL` SHALL be removed from `PrizmAPIClientProtocol` entirely. All ~32 endpoint methods SHALL use `env.apiURL`, `env.identityURL`, or `env.iconsURL` instead of appending to a single `base`.
 
+**Path prefix stripping for cloud endpoints.** The current codebase appends paths like `api/accounts/prelogin` and `identity/connect/token` to a single `baseURL`. For self-hosted Vaultwarden, these `api/` and `identity/` prefixes are routing segments that the reverse proxy uses to dispatch to the correct internal service. For Bitwarden Cloud, each service has its own hostname (`api.bitwarden.com`, `identity.bitwarden.com`) and the prefix is NOT part of the path — the correct URLs are `https://api.bitwarden.com/accounts/prelogin` and `https://identity.bitwarden.com/connect/token`.
+
+Therefore, when `serverType != .selfHosted`, endpoint methods SHALL strip the leading `api/` or `identity/` prefix from the path before appending it to the per-service URL. When `serverType == .selfHosted`, the full path (including the prefix) SHALL be appended to `base` as today. The recommended implementation approach is to have each endpoint method use the per-service URL directly and append only the service-relative path (e.g. `accounts/prelogin`, `connect/token`, `sync`), while `selfHosted` environments include the prefix in their computed `apiURL`/`identityURL` (i.e. `{base}/api`, `{base}/identity`). This way the endpoint methods use the same path regardless of server type.
+
 `APIError.baseURLNotSet` SHALL be renamed to `APIError.serverEnvironmentNotSet`. The guard that throws it — protecting against requests made before the environment is configured — is retained unchanged. All catch sites and tests that reference `baseURLNotSet` SHALL be updated to `serverEnvironmentNotSet`.
 
 `AuthRepositoryImpl` currently calls `apiClient.setBaseURL(...)` in four places — all four SHALL be updated to `apiClient.setServerEnvironment(...)`:
@@ -177,28 +185,28 @@ A unit test SHALL assert `Bitwarden-Client-Name` and `Bitwarden-Client-Version` 
 
 #### Scenario: cloudUS routes api requests correctly
 - **GIVEN** the active account has `serverType == .cloudUS`
-- **WHEN** `PrizmAPIClient` makes a request to an `api/...` endpoint
-- **THEN** the request SHALL be sent to `https://api.bitwarden.com/api/...`
+- **WHEN** `PrizmAPIClient` makes a `preLogin` request (currently `api/accounts/prelogin`)
+- **THEN** the request SHALL be sent to `https://api.bitwarden.com/accounts/prelogin` (the `api/` prefix is NOT part of the cloud path)
 
 #### Scenario: cloudEU routes api requests correctly
 - **GIVEN** the active account has `serverType == .cloudEU`
-- **WHEN** `PrizmAPIClient` makes a request to an `api/...` endpoint
-- **THEN** the request SHALL be sent to `https://api.bitwarden.eu/api/...`
+- **WHEN** `PrizmAPIClient` makes a `fetchSync` request (currently `api/sync`)
+- **THEN** the request SHALL be sent to `https://api.bitwarden.eu/sync`
 
 #### Scenario: cloudEU routes identity requests correctly
 - **GIVEN** the active account has `serverType == .cloudEU`
-- **WHEN** `PrizmAPIClient` makes a request to an `identity/...` endpoint
-- **THEN** the request SHALL be sent to `https://identity.bitwarden.eu/identity/...`
+- **WHEN** `PrizmAPIClient` makes an `identityToken` request (currently `identity/connect/token`)
+- **THEN** the request SHALL be sent to `https://identity.bitwarden.eu/connect/token` (the `identity/` prefix is NOT part of the cloud path)
 
-#### Scenario: selfHosted routes to user-supplied URL
+#### Scenario: selfHosted routes to user-supplied URL (unchanged)
 - **GIVEN** the active account has `serverType == .selfHosted` and `base = https://vault.example.com`
-- **WHEN** `PrizmAPIClient` makes a request to an `api/...` endpoint
-- **THEN** the request SHALL be sent to `https://vault.example.com/api/...`
+- **WHEN** `PrizmAPIClient` makes a `preLogin` request
+- **THEN** the request SHALL be sent to `https://vault.example.com/api/accounts/prelogin` (the `api/` prefix IS part of the self-hosted path, as today)
 
 #### Scenario: refreshAccessToken routes via identityURL
 - **GIVEN** the active account has `serverType == .cloudEU`
 - **WHEN** `PrizmAPIClient.refreshAccessToken()` is called
-- **THEN** the request SHALL be sent to `https://identity.bitwarden.eu/identity/connect/token`
+- **THEN** the request SHALL be sent to `https://identity.bitwarden.eu/connect/token`
 
 `PrizmAPIClient` MUST NOT fall back to a different `ServerEnvironment` on request failure. A failed request SHALL surface the error directly to the caller; no automatic retry against another region or self-hosted is permitted. Switching server environments requires a new login.
 
@@ -361,6 +369,8 @@ func cancelNewDeviceOTP()
 
 `AuthRepositoryImpl` holds the pending environment, email, and hashed password in memory after returning `LoginResult.requiresNewDeviceOTP`. `loginWithNewDeviceOTP` retries `PrizmAPIClient.identityToken` with the `newdeviceotp` form parameter added, then zeros cached credentials immediately after (success or failure). `requestNewDeviceOTP` re-posts the original identity token request without `newdeviceotp` — the server recognises the unverified device and sends a fresh code; no credentials are zeroed since the challenge is still pending. `cancelNewDeviceOTP` zeros cached credentials without making a network request.
 
+**`newDeviceOTP` and `twoFactorToken` are mutually exclusive.** The server returns either `device_error` (new device verification) or `TwoFactorProviders2` (2FA challenge) on a given login attempt — never both in the same response. A request SHALL never include both `newdeviceotp` and `twoFactorToken` parameters simultaneously. The two flows use separate pending state structs (`PendingNewDeviceOTP` vs `PendingTwoFactor`) and separate `LoginResult` cases.
+
 `LoginUseCase.resendNewDeviceOTP()` calls `auth.requestNewDeviceOTP()` — not `loginWithNewDeviceOTP`.
 
 `LoginViewModel` switches on `LoginResult.requiresNewDeviceOTP`, sets `flowState = .otpPrompt`, and on Sign In (from `NewDeviceOTPView`) calls `loginUseCase.completeNewDeviceOTP(otp:)` — identical in structure to the existing `.requiresTwoFactor` → `completeTOTP` path.
@@ -423,7 +433,7 @@ case otpPrompt   // device_error received; app shows NewDeviceOTPView
 
 #### Scenario: Fields disabled during loading
 - **GIVEN** `flowState == .loading`
-- **THEN** all interactive controls in the current view SHALL be non-interactive
+- **THEN** all interactive controls in the current view SHALL be non-interactive (including Cancel and Resend buttons in `NewDeviceOTPView` during a resend request — the request is brief and non-cancellable; the user waits for it to complete before interacting again)
 
 ---
 
@@ -532,7 +542,7 @@ Per §IV, tests MUST be written before implementation. The following are require
 - Round-trip encode/decode for each `ServerType` case preserves the exact raw string value (`"cloudUS"`, `"cloudEU"`, `"selfHosted"`)
 
 **Unit tests (Data):**
-- `PrizmAPIClient.setServerEnvironment()` stores the environment and subsequent requests use `env.apiURL` / `env.identityURL` as appropriate (representative call sites: `preLogin`, `identityToken`, `refreshAccessToken`, `fetchSync`)
+- `PrizmAPIClient.setServerEnvironment()` stores the environment and subsequent requests use `env.apiURL` / `env.identityURL` as appropriate — cloud requests SHALL NOT include the `api/` or `identity/` path prefix (representative call sites: `preLogin` → `apiURL/accounts/prelogin`, `identityToken` → `identityURL/connect/token`, `refreshAccessToken` → `identityURL/connect/token`, `fetchSync` → `apiURL/sync`)
 - A request made before `setServerEnvironment` is called throws `APIError.serverEnvironmentNotSet`
 - `AuthRepositoryImpl.setServerEnvironment(_:)` calls `apiClient.setServerEnvironment(_:)` (not `setBaseURL`)
 - `LoginUseCaseImpl` does NOT call `auth.validateServerURL` when `environment.serverType == .cloudUS` or `.cloudEU`
@@ -549,7 +559,7 @@ Per §IV, tests MUST be written before implementation. The following are require
 **Unit tests (Presentation):**
 - `LoginViewModel` server type selection is persisted and restored across instantiation
 - `LoginViewModel` initialised with `UserDefaults` containing `com.prizm.login.lastServerType = "cloudEU"` defaults `serverType` to `.cloudEU`
-- Selecting a cloud type clears `serverURL`; selecting self-hosted restores the last entered URL
+- Selecting a cloud type clears `serverURL`; selecting self-hosted restores the last entered URL; `serverURL` is persisted to `UserDefaults` and restored on init
 - `isSignInDisabled` returns `false` for cloud when email and password are non-empty, even when `serverURL` is empty
 - `isSignInDisabled` returns `true` for self-hosted when `serverURL` is empty, even when email and password are filled
 - `isSignInDisabled` returns `true` in `NewDeviceOTPView` when the OTP field is empty

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -20,7 +20,7 @@ The `LoginView` SHALL replace the static subtitle "Self-hosted vault" and single
 2. **Bitwarden Cloud (EU)** — hides the server URL field
 3. **Self-hosted** — shows the server URL field as it exists today
 
-When a cloud option is selected, no URL entry is required or shown. When "Self-hosted" is selected, the server URL field is shown and behaves as today. The last-used selection SHALL be remembered across app launches.
+When a cloud option is selected, no URL entry is required or shown. When "Self-hosted" is selected, the server URL field is shown and behaves as today. The last-used selection SHALL be persisted to `UserDefaults` under the key `com.prizm.login.lastServerType` (raw `String` value of `ServerType`) and restored when `LoginViewModel` is initialised.
 
 #### Scenario: Picker is visible on the login screen
 - **WHEN** `LoginView` is displayed
@@ -35,6 +35,15 @@ When a cloud option is selected, no URL entry is required or shown. When "Self-h
 - **WHEN** the user selects "Self-hosted"
 - **THEN** the server URL field SHALL be visible and editable
 - **AND** any previously entered URL SHALL be restored
+
+#### Scenario: Sign In button enabled for cloud without server URL
+- **GIVEN** the user has selected "Bitwarden Cloud (US)" or "Bitwarden Cloud (EU)"
+- **WHEN** email and master password are both non-empty
+- **THEN** the Sign In button SHALL be enabled regardless of `serverURL`
+
+#### Scenario: Sign In button still requires server URL for self-hosted
+- **GIVEN** the user has selected "Self-hosted"
+- **THEN** the Sign In button SHALL remain disabled until `serverURL`, email, and password are all non-empty
 
 #### Scenario: Last-used selection restored on relaunch
 - **GIVEN** the user last chose "Bitwarden Cloud (EU)" before quitting
@@ -53,7 +62,18 @@ When a cloud option is selected, no URL entry is required or shown. When "Self-h
 | `cloudEU` | `https://api.bitwarden.eu` | `https://identity.bitwarden.eu` | `https://icons.bitwarden.net` |
 | `selfHosted` | `{base}/api` (or override) | `{base}/identity` (or override) | `{base}/icons` (or override) |
 
-Cloud cases SHALL ignore `overrides`. `selfHosted` behaviour is unchanged. Existing Keychain records without a `serverType` key SHALL decode as `selfHosted`.
+Cloud cases SHALL ignore `overrides` and SHALL ignore `base` for URL routing. `selfHosted` behaviour is unchanged. Existing Keychain records without a `serverType` key SHALL decode as `selfHosted`.
+
+`ServerType` SHALL be a `String`-backed `RawRepresentable` enum with fixed raw values: `"cloudUS"`, `"cloudEU"`, `"selfHosted"`. These raw values are part of the Keychain storage contract and MUST NOT be renamed after any release that has written Keychain data.
+
+`ServerEnvironment` SHALL expose static factory methods for cloud cases that set `base` to a sentinel value (`https://bitwarden.com`) so the struct invariant is satisfied without exposing a meaningless URL to callers:
+
+```swift
+static func cloudUS() -> ServerEnvironment
+static func cloudEU() -> ServerEnvironment
+```
+
+The computed properties (`apiURL`, `identityURL`, `iconsURL`) SHALL switch on `serverType` and return hardcoded cloud URLs for cloud cases, falling back to `base`-derived values only for `selfHosted`. `base` MUST NOT be used for URL routing when `serverType != .selfHosted`.
 
 #### Scenario: cloudUS returns US canonical URLs
 - **GIVEN** a `ServerEnvironment` with `serverType == .cloudUS`
@@ -71,6 +91,7 @@ Cloud cases SHALL ignore `overrides`. `selfHosted` behaviour is unchanged. Exist
 - **GIVEN** a `ServerEnvironment` with `serverType == .selfHosted` and `base = https://vault.example.com`
 - **THEN** `apiURL` SHALL equal `https://vault.example.com/api`
 - **AND** `identityURL` SHALL equal `https://vault.example.com/identity`
+- **AND** `iconsURL` SHALL equal `https://vault.example.com/icons`
 
 #### Scenario: Legacy record decoded as selfHosted
 - **GIVEN** a stored JSON record with no `serverType` key
@@ -81,7 +102,13 @@ Cloud cases SHALL ignore `overrides`. `selfHosted` behaviour is unchanged. Exist
 
 ### Requirement: `PrizmAPIClient` routes requests via `ServerEnvironment`
 
-`PrizmAPIClient` SHALL replace `setBaseURL(_ url: URL)` with `setServerEnvironment(_ env: ServerEnvironment)`. All ~32 endpoint methods SHALL use `env.apiURL`, `env.identityURL`, or `env.iconsURL` instead of appending to a single `base`. `AuthRepositoryImpl.setServerEnvironment(_:)` SHALL call `apiClient.setServerEnvironment(environment)`.
+`PrizmAPIClient` SHALL replace `setBaseURL(_ url: URL)` with `setServerEnvironment(_ env: ServerEnvironment)`. `setBaseURL` SHALL be removed from `PrizmAPIClientProtocol` entirely. All ~32 endpoint methods SHALL use `env.apiURL`, `env.identityURL`, or `env.iconsURL` instead of appending to a single `base`.
+
+`AuthRepositoryImpl` currently calls `apiClient.setBaseURL(...)` in four places — all four SHALL be updated to `apiClient.setServerEnvironment(...)`:
+- `setServerEnvironment(_:)` — line 83
+- `storedAccount()` restoration — line 325
+- `loginWithPassword` completion — line 540
+- `unlockWithBiometrics` completion — line 606
 
 #### Scenario: cloudUS routes api requests correctly
 - **GIVEN** the active account has `serverType == .cloudUS`
@@ -102,6 +129,11 @@ Cloud cases SHALL ignore `overrides`. `selfHosted` behaviour is unchanged. Exist
 - **GIVEN** the active account has `serverType == .selfHosted` and `base = https://vault.example.com`
 - **WHEN** `PrizmAPIClient` makes a request to an `api/...` endpoint
 - **THEN** the request SHALL be sent to `https://vault.example.com/api/...`
+
+#### Scenario: refreshAccessToken routes via identityURL
+- **GIVEN** the active account has `serverType == .cloudEU`
+- **WHEN** `PrizmAPIClient.refreshAccessToken()` is called
+- **THEN** the request SHALL be sent to `https://identity.bitwarden.eu/identity/connect/token`
 
 ---
 
@@ -151,7 +183,9 @@ All three server options use email + master password login. When a cloud account
 - **GIVEN** the user attempts password login with a cloud option selected
 - **AND** the server returns an hCaptcha challenge response
 - **THEN** a `WKWebView` modal SHALL be presented
-- **AND** the token request SHALL be retried automatically on challenge completion
+- **AND** when hCaptcha completes, its JS SHALL call `window.webkit.messageHandlers.hcaptcha.postMessage(token)`
+- **AND** the native `WKScriptMessageHandler` SHALL receive the token, dismiss the modal, and retry `identityToken` with the token included
+- **AND** the token SHALL be held in memory only for the duration of the retry and NOT persisted
 
 #### Scenario: Self-hosted login has no hCaptcha handling
 - **GIVEN** the active account has `serverType == .selfHosted`
@@ -163,7 +197,7 @@ All three server options use email + master password login. When a cloud account
 
 All new interactive controls introduced by this change MUST be fully usable via VoiceOver (§VIII).
 
-- The server picker SHALL have an `accessibilityLabel` ("Server") and expose its current value via `accessibilityValue` (e.g. "Bitwarden Cloud (US)")
+- The server picker SHALL have `accessibilityIdentifier` set to `AccessibilityID.Login.serverTypePicker`, `accessibilityLabel` set to "Server", and expose its current value via `accessibilityValue` (e.g. "Bitwarden Cloud (US)")
 - The server URL text field SHALL retain its existing `accessibilityIdentifier` and have a meaningful `accessibilityLabel` ("Server URL")
 - The hCaptcha `WKWebView` modal SHALL have an accessible dismiss path (a labelled close button); VoiceOver focus SHALL move into the modal on presentation and return to the login form on dismissal
 - Error messages (unreachable server, invalid credentials, missing client identifier) SHALL be announced via `AccessibilityNotification.Announcement` as soon as they appear
@@ -199,15 +233,19 @@ Per §IV, tests MUST be written before implementation. The following are require
 - `ServerEnvironment` with `serverType == .cloudEU` returns correct EU canonical URLs, and `iconsURL == https://icons.bitwarden.net`
 - `ServerEnvironment` with `serverType == .selfHosted` returns `base`-derived URLs unchanged
 - Decoding a legacy JSON record (no `serverType` key) yields `serverType == .selfHosted`
+- Round-trip encode/decode for each `ServerType` case preserves the exact raw string value (`"cloudUS"`, `"cloudEU"`, `"selfHosted"`)
 
 **Unit tests (Data):**
-- `PrizmAPIClient.setServerEnvironment()` stores the environment and subsequent requests use `env.apiURL` / `env.identityURL` as appropriate (representative call sites: `preLogin`, `identityToken`, `fetchSync`)
+- `PrizmAPIClient.setServerEnvironment()` stores the environment and subsequent requests use `env.apiURL` / `env.identityURL` as appropriate (representative call sites: `preLogin`, `identityToken`, `refreshAccessToken`, `fetchSync`)
 - `AuthRepositoryImpl.setServerEnvironment(_:)` calls `apiClient.setServerEnvironment(_:)` (not `setBaseURL`)
 - Cloud login attempt with empty client identifier throws before making a network request
 
 **Unit tests (Presentation):**
 - `LoginViewModel` server type selection is persisted and restored across instantiation
+- `LoginViewModel` initialised with `UserDefaults` containing `com.prizm.login.lastServerType = "cloudEU"` defaults `serverType` to `.cloudEU`
 - Selecting a cloud type clears `serverURL`; selecting self-hosted restores the last entered URL
+- `isSignInDisabled` returns `false` for cloud when email and password are non-empty, even when `serverURL` is empty
+- `isSignInDisabled` returns `true` for self-hosted when `serverURL` is empty, even when email and password are filled
 
 **Integration tests:**
 - Full login flow against a Vaultwarden stub (existing coverage) continues to pass after the `PrizmAPIClient` refactor

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -147,6 +147,8 @@ The internal URL construction (`URL(string: trimmed)`) in `LoginUseCaseImpl` is 
 
 `PrizmAPIClient` SHALL replace `setBaseURL(_ url: URL)` with `setServerEnvironment(_ env: ServerEnvironment)`. `setBaseURL` SHALL be removed from `PrizmAPIClientProtocol` entirely. All ~32 endpoint methods SHALL use `env.apiURL`, `env.identityURL`, or `env.iconsURL` instead of appending to a single `base`.
 
+`APIError.baseURLNotSet` SHALL be renamed to `APIError.serverEnvironmentNotSet`. The guard that throws it — protecting against requests made before the environment is configured — is retained unchanged. All catch sites and tests that reference `baseURLNotSet` SHALL be updated to `serverEnvironmentNotSet`.
+
 `AuthRepositoryImpl` currently calls `apiClient.setBaseURL(...)` in four places — all four SHALL be updated to `apiClient.setServerEnvironment(...)`:
 - `setServerEnvironment(_:)` — line 83
 - `storedAccount()` restoration — line 325
@@ -468,6 +470,7 @@ Per §IV, tests MUST be written before implementation. The following are require
 
 **Unit tests (Data):**
 - `PrizmAPIClient.setServerEnvironment()` stores the environment and subsequent requests use `env.apiURL` / `env.identityURL` as appropriate (representative call sites: `preLogin`, `identityToken`, `refreshAccessToken`, `fetchSync`)
+- A request made before `setServerEnvironment` is called throws `APIError.serverEnvironmentNotSet`
 - `AuthRepositoryImpl.setServerEnvironment(_:)` calls `apiClient.setServerEnvironment(_:)` (not `setBaseURL`)
 - `LoginUseCaseImpl` does NOT call `auth.validateServerURL` when `environment.serverType == .cloudUS` or `.cloudEU`
 - `LoginUseCaseImpl` DOES call `auth.validateServerURL` when `environment.serverType == .selfHosted`

--- a/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
+++ b/openspec/changes/hosted-cloud-support/specs/hosted-cloud-support/spec.md
@@ -190,18 +190,31 @@ All requests to cloud endpoints SHALL include the required Bitwarden client head
 
 ---
 
+### Requirement: `LoginResult` extended with new device OTP case
+
+`LoginResult` (`Domain/Repositories/AuthRepository.swift`) SHALL gain a new case:
+
+```swift
+enum LoginResult {
+    case success(Account)
+    case requiresTwoFactor(TwoFactorMethod)
+    case requiresNewDeviceOTP   // server returned device_error; OTP sent to user's email
+}
+```
+
+`AuthRepositoryImpl.loginWithPassword` returns `.requiresNewDeviceOTP` when `PrizmAPIClient.identityToken` receives `HTTP 400` with `{"error": "device_error"}`. `LoginViewModel` switches on this case and transitions `flowState` to `.otpPrompt` — identical in structure to the existing `.requiresTwoFactor` → `.totpPrompt` path.
+
+**Layer boundary**: `PrizmAPIClient.identityToken` throws `IdentityTokenError.newDeviceNotVerified` when it receives a `device_error` response. `AuthRepositoryImpl` catches that Data-layer error and returns `LoginResult.requiresNewDeviceOTP` — preserving the clean architecture boundary. The Domain layer and above never import or reference `IdentityTokenError` directly.
+
+---
+
 ### Requirement: Error taxonomy
 
-The existing `AuthError` enum (`Domain/Repositories/AuthRepository.swift`) SHALL be extended with two new cases for this change. `LoginViewModel` pattern-matches all `AuthError` cases; no new error type is introduced.
+The existing `AuthError` enum (`Domain/Repositories/AuthRepository.swift`) SHALL be extended with one new case for this change. `LoginViewModel` pattern-matches all `AuthError` cases; no new error type is introduced.
 
 | Case | Thrown by | `errorDescription` |
 |---|---|---|
 | `clientIdentifierNotConfigured` | `AuthRepositoryImpl` (before network request) | `"Prizm is not configured for Bitwarden Cloud. Contact support or use a self-hosted server."` |
-| `newDeviceVerificationRequired` | `AuthRepositoryImpl` (on `device_error` 400 response) | `nil` — handled structurally by `LoginViewModel`; triggers the OTP entry UI, not a plain error string |
-
-`newDeviceVerificationRequired` is thrown when the server returns `HTTP 400` with `{"error": "device_error"}`. `LoginViewModel` catches it and transitions to `flowState = .otpPrompt` rather than displaying an error string.
-
-**Layer boundary**: `PrizmAPIClient.identityToken` throws a Data-layer error (e.g. `IdentityTokenError.newDeviceNotVerified`) when it receives a `device_error` response. `AuthRepositoryImpl` catches that Data-layer error and translates it to `AuthError.newDeviceVerificationRequired` before rethrowing — preserving the clean architecture boundary. The Domain layer and above never import or reference `IdentityTokenError` directly.
 
 `serverUnreachable`, `invalidCredentials`, `networkUnavailable`, and `invalidURL` already exist in `AuthError` and cover the remaining error scenarios defined in this spec without modification.
 
@@ -264,7 +277,7 @@ The `client_id` is an app-level credential, not a per-user credential. No additi
 
 ```swift
 /// Retries the identity token request with the new-device OTP the user received by email.
-/// Only valid to call after `execute` throws `AuthError.newDeviceVerificationRequired`.
+/// Only valid to call after `execute` returns `LoginResult.requiresNewDeviceOTP`.
 /// On success, triggers vault sync and returns the logged-in `Account`.
 func completeNewDeviceOTP(otp: String) async throws -> Account
 
@@ -291,23 +304,23 @@ func requestNewDeviceOTP() async throws
 func cancelNewDeviceOTP()
 ```
 
-`AuthRepositoryImpl` holds the pending environment, email, and hashed password in memory after throwing `newDeviceVerificationRequired`. `loginWithNewDeviceOTP` retries `PrizmAPIClient.identityToken` with the `newdeviceotp` form parameter added, then zeros cached credentials immediately after (success or failure). `requestNewDeviceOTP` re-posts the original identity token request without `newdeviceotp` — the server recognises the unverified device and sends a fresh code; no credentials are zeroed since the challenge is still pending. `cancelNewDeviceOTP` zeros cached credentials without making a network request.
+`AuthRepositoryImpl` holds the pending environment, email, and hashed password in memory after returning `LoginResult.requiresNewDeviceOTP`. `loginWithNewDeviceOTP` retries `PrizmAPIClient.identityToken` with the `newdeviceotp` form parameter added, then zeros cached credentials immediately after (success or failure). `requestNewDeviceOTP` re-posts the original identity token request without `newdeviceotp` — the server recognises the unverified device and sends a fresh code; no credentials are zeroed since the challenge is still pending. `cancelNewDeviceOTP` zeros cached credentials without making a network request.
 
 `LoginUseCase.resendNewDeviceOTP()` calls `auth.requestNewDeviceOTP()` — not `loginWithNewDeviceOTP`.
 
-`LoginViewModel` catches `AuthError.newDeviceVerificationRequired`, sets `flowState = .otpPrompt`, and on Sign In (from `NewDeviceOTPView`) calls `loginUseCase.completeNewDeviceOTP(otp:)`.
+`LoginViewModel` switches on `LoginResult.requiresNewDeviceOTP`, sets `flowState = .otpPrompt`, and on Sign In (from `NewDeviceOTPView`) calls `loginUseCase.completeNewDeviceOTP(otp:)` — identical in structure to the existing `.requiresTwoFactor` → `completeTOTP` path.
 
 The `execute` method signature changes are covered by the `LoginUseCase.execute` requirement above. `LoginUseCase.protocol` doc comment SHALL be updated to reflect the new flow: `execute → (optional) completeNewDeviceOTP → sync` or `execute → (optional) completeTOTP → sync`.
 
 #### Scenario: `completeNewDeviceOTP` retries with OTP
-- **GIVEN** `execute` has thrown `AuthError.newDeviceVerificationRequired`
+- **GIVEN** `execute` has returned `LoginResult.requiresNewDeviceOTP`
 - **WHEN** `completeNewDeviceOTP(otp:)` is called with a valid code
 - **THEN** `PrizmAPIClient.identityToken` SHALL be called with `newdeviceotp` set to the code
 - **AND** on success, cached credentials SHALL be zeroed and vault sync SHALL run
 - **AND** the `Account` SHALL be returned
 
 #### Scenario: `cancelNewDeviceOTP` clears cached credentials
-- **GIVEN** `execute` has thrown `AuthError.newDeviceVerificationRequired`
+- **GIVEN** `execute` has returned `LoginResult.requiresNewDeviceOTP`
 - **WHEN** `cancelNewDeviceOTP()` is called
 - **THEN** cached credentials (environment, email, hashed password) SHALL be zeroed
 - **AND** no network request SHALL be made
@@ -327,7 +340,7 @@ case otpPrompt   // device_error received; app shows NewDeviceOTPView
 
 `RootViewModel.Screen` (in `PrizmApp.swift`) SHALL gain a matching `.otpPrompt` case. `RootViewModel.handleLoginFlow(_:)` SHALL map `.otpPrompt → .otpPrompt` alongside the existing cases. `PrizmApp`'s root switch SHALL show `NewDeviceOTPView(viewModel: rootVM.loginVM)` for `.otpPrompt`, analogous to how `TOTPPromptView` is shown for `.totpPrompt`.
 
-`NewDeviceOTPView` is a new screen (separate SwiftUI view, same pattern as `TOTPPromptView`) that shows the OTP entry field, Resend button, and Cancel button. `LoginViewModel` transitions `flowState` to `.otpPrompt` when `execute` throws `AuthError.newDeviceVerificationRequired`.
+`NewDeviceOTPView` is a new screen (separate SwiftUI view, same pattern as `TOTPPromptView`) that shows the OTP entry field, Resend button, and Cancel button. `LoginViewModel` transitions `flowState` to `.otpPrompt` when `execute` returns `LoginResult.requiresNewDeviceOTP`.
 
 **Valid transitions (additions to existing `LoginFlowState` machine):**
 
@@ -336,7 +349,7 @@ case otpPrompt   // device_error received; app shows NewDeviceOTPView
 | `.login` | Sign In tapped | `.loading` |
 | `.loading` | Auth success | `.syncing` → `.vault` |
 | `.loading` | Auth failure (not device_error) | `.login` (error shown) |
-| `.loading` | `newDeviceVerificationRequired` | `.otpPrompt` |
+| `.loading` | `LoginResult.requiresNewDeviceOTP` returned | `.otpPrompt` |
 | `.otpPrompt` | Sign In tapped (OTP submit) | `.loading` |
 | `.otpPrompt` | Invalid OTP (`invalid_grant`) | `.otpPrompt` (error shown, field remains) |
 | `.otpPrompt` | Resend tapped | `.loading` → `.otpPrompt` (OTP field cleared, confirmation announced) |
@@ -461,7 +474,7 @@ Per §IV, tests MUST be written before implementation. The following are require
 - Cloud login attempt with empty client identifier throws before making a network request
 - `PrizmAPIClient` includes `Bitwarden-Client-Name`, `Bitwarden-Client-Version`, and `Device-Type` headers on a cloud `identityToken` request
 - `PrizmAPIClient.refreshAccessToken` sends the registered cloud `client_id` (not `"desktop"`) when `serverType` is cloud
-- `AuthRepositoryImpl` throws `AuthError.newDeviceVerificationRequired` when the identity token response is `HTTP 400` with `{"error": "device_error"}`
+- `AuthRepositoryImpl.loginWithPassword` returns `LoginResult.requiresNewDeviceOTP` when the identity token response is `HTTP 400` with `{"error": "device_error"}`
 - `LoginUseCaseImpl.completeNewDeviceOTP` calls `auth.loginWithNewDeviceOTP(_:)` and triggers sync on success
 - `LoginUseCaseImpl.cancelNewDeviceOTP` calls `auth.cancelNewDeviceOTP()` and makes no network request
 - OTP retry includes `newdeviceotp` form parameter and succeeds on a valid code
@@ -475,7 +488,7 @@ Per §IV, tests MUST be written before implementation. The following are require
 - `isSignInDisabled` returns `true` for self-hosted when `serverURL` is empty, even when email and password are filled
 - `isSignInDisabled` returns `true` in `NewDeviceOTPView` when the OTP field is empty
 - `isSignInDisabled` returns `false` in `NewDeviceOTPView` when the OTP field is non-empty
-- `flowState` transitions to `.otpPrompt` when `execute` throws `AuthError.newDeviceVerificationRequired`
+- `flowState` transitions to `.otpPrompt` when `execute` returns `LoginResult.requiresNewDeviceOTP`
 - `flowState` transitions to `.login` when Cancel is tapped from `NewDeviceOTPView` (after `cancelNewDeviceOTP()`)
 - `flowState` remains `.otpPrompt` after an invalid OTP error; error message is set
 - `loginUseCase.resendNewDeviceOTP()` is called when "Resend code" is tapped; OTP field is cleared and confirmation is announced

--- a/openspec/changes/hosted-cloud-support/tasks.md
+++ b/openspec/changes/hosted-cloud-support/tasks.md
@@ -20,6 +20,7 @@ _(Protocol declarations require no unit tests — skip straight to implementatio
 - [ ] 2.7 Add `loginWithNewDeviceOTP(_ otp: String) async throws -> Account` to `AuthRepository` protocol
 - [ ] 2.8 Add `requestNewDeviceOTP() async throws` to `AuthRepository` protocol
 - [ ] 2.9 Add `cancelNewDeviceOTP()` to `AuthRepository` protocol
+- [ ] 2.10 Update `MockLoginUseCase` (`PrizmTests/Mocks/MockLoginUseCase.swift`) to add stub implementations for `completeNewDeviceOTP`, `resendNewDeviceOTP`, `cancelNewDeviceOTP` — protocol conformance requires this before any test target compiles
 
 ## 3. Domain Unit Tests — Entities (write before Group 4, must fail first)
 
@@ -67,7 +68,7 @@ _(Protocol declarations require no unit tests — skip straight to implementatio
 - [ ] 7.3 Add `clientIdentifier: String = Config.bitwardenClientIdentifier` parameter to `AuthRepositoryImpl.init` (production callers pass no arg; tests inject `""` to verify the guard fires, or `"test-id"` to bypass it); guard cloud login: if `environment.serverType != .selfHosted && clientIdentifier.isEmpty`, throw `AuthError.clientIdentifierNotConfigured` before any network request
 - [ ] 7.4 Skip `validateServerURL` for cloud environments; call only when `environment.serverType == .selfHosted`
 - [ ] 7.5 Implement `loginWithNewDeviceOTP(_ otp: String)`: read `pendingNewDeviceOTP` (throws `AuthError.invalidCredentials` if nil); call `identityToken(email:passwordHash:deviceIdentifier:newDeviceOTP:)` using the pending struct's fields; on success call `finalizeSession(tokenResp:stretched:environment:)` using the pending struct's `stretchedKeys` and `environment`; zero `stretchedKeys` and nil `pendingNewDeviceOTP` in a `defer` block so cleanup happens on both success and failure (Constitution §III)
-- [ ] 7.6 Implement `requestNewDeviceOTP()`: re-post original `identityToken` without `newdeviceotp`; do NOT zero cached credentials
+- [ ] 7.6 Implement `requestNewDeviceOTP()`: re-post original `identityToken` without `newdeviceotp` using the pending struct's credentials; the server WILL respond with `HTTP 400 + device_error` again — this is expected (it triggers a new OTP email); catch `IdentityTokenError.newDeviceNotVerified` and treat it as **success**; propagate any other error; do NOT zero cached credentials
 - [ ] 7.7 Implement `cancelNewDeviceOTP()`: zero `pendingNewDeviceOTP!.stretchedKeys` buffers in-place (Constitution §III — same pattern as `cancelTwoFactor()`), then set `pendingNewDeviceOTP = nil`; no network request
 - [ ] 7.8 Self-hosted `device_error` response (unexpected): surface as `AuthError.invalidCredentials`
 

--- a/openspec/changes/hosted-cloud-support/tasks.md
+++ b/openspec/changes/hosted-cloud-support/tasks.md
@@ -50,7 +50,7 @@ _(Protocol declarations require no unit tests — skip straight to implementatio
 
 ## 6. Data Unit Tests — PrizmAPIClient (write before Group 5 implementation, must fail first; requires mock protocol stubs from 2.10 and the `setServerEnvironment` signature from 5.3 to compile — add the mock stub in 5.3 before writing these tests)
 
-- [x] 6.1 `setServerEnvironment` with `cloudUS` → subsequent `preLogin` request URL is `https://api.bitwarden.com/accounts/prelogin` (no `api/` prefix in path)
+- [x] 6.1 `setServerEnvironment` with `cloudUS` → subsequent `preLogin` request URL is `https://identity.bitwarden.com/accounts/prelogin` (`prelogin` lives on the identity service, not the API service — confirmed by curl)
 - [x] 6.2 `setServerEnvironment` with `cloudEU` → subsequent `identityToken` request URL is `https://identity.bitwarden.eu/connect/token` (no `identity/` prefix in path)
 - [x] 6.3 `setServerEnvironment` with `cloudEU` → subsequent `refreshAccessToken` URL is `https://identity.bitwarden.eu/connect/token`
 - [x] 6.4 `setServerEnvironment` with `selfHosted(base: https://vault.example.com)` → `fetchSync` URL is `https://vault.example.com/api/sync` (self-hosted retains `api/` prefix)

--- a/openspec/changes/hosted-cloud-support/tasks.md
+++ b/openspec/changes/hosted-cloud-support/tasks.md
@@ -3,27 +3,25 @@
 - [ ] 1.1 Add `LocalSecrets.xcconfig.template` to repo root with empty `BW_CLIENT_IDENTIFIER` and copy instructions
 - [ ] 1.2 Add `BWClientIdentifier` key to `Prizm/Prizm-Info.plist` with value `$(BW_CLIENT_IDENTIFIER)`
 - [ ] 1.3 Add `LocalSecrets.xcconfig` to `.gitignore`
-- [ ] 1.4 Include `LocalSecrets.xcconfig` in Xcode project under Debug and Release configurations (analogous to `LocalConfig.xcconfig`)
+- [ ] 1.4 Include `LocalSecrets.xcconfig` by adding `#include "LocalSecrets.xcconfig"` at the top of `LocalConfig.xcconfig` (this is already included in both Debug and Release configurations via the existing xcconfig chain)
 - [ ] 1.5 Add `Config.bitwardenClientIdentifier` to `App/Config.swift` — reads `BWClientIdentifier` from `Bundle.main`, defaults to `""`
 - [ ] 1.6 Verify `Config.clientName` exists in `Config.swift` (used in `baseRequest()` for `Bitwarden-Client-Name` header); add if absent
 
-## 2. Domain Layer — Entities and Protocols
+## 2. Domain Layer — Protocols Only
 
-- [ ] 2.1 Add `ServerType` enum (`cloudUS`, `cloudEU`, `selfHosted`) with `String` raw values to `Domain/Entities/Account.swift`
-- [ ] 2.2 Add `serverType: ServerType` property to `ServerEnvironment`; default to `.selfHosted` in `init` and in `Codable` decoding (legacy records with no key decode as `.selfHosted`)
-- [ ] 2.3 Update `ServerEnvironment` computed properties (`apiURL`, `identityURL`, `iconsURL`) to switch on `serverType` and return hardcoded cloud URLs for `cloudUS`/`cloudEU`, falling back to `base`-derived values for `selfHosted` only
-- [ ] 2.4 Add static factory methods `ServerEnvironment.cloudUS()` and `ServerEnvironment.cloudEU()` (sentinel `base = https://bitwarden.com`)
-- [ ] 2.5 Add `LoginResult.requiresNewDeviceOTP` case to `AuthRepository.swift`
-- [ ] 2.6 Add `AuthError.clientIdentifierNotConfigured` case with `errorDescription`
-- [ ] 2.7 Update `LoginUseCase` protocol: change `execute` signature to accept `environment: ServerEnvironment` instead of `serverURL: String`
-- [ ] 2.8 Add `completeNewDeviceOTP(otp: String) async throws -> Account` to `LoginUseCase` protocol
-- [ ] 2.9 Add `resendNewDeviceOTP() async throws` to `LoginUseCase` protocol
-- [ ] 2.10 Add `cancelNewDeviceOTP()` to `LoginUseCase` protocol; update protocol doc comment to describe the full login flow
-- [ ] 2.11 Add `loginWithNewDeviceOTP(_ otp: String) async throws -> Account` to `AuthRepository` protocol
-- [ ] 2.12 Add `requestNewDeviceOTP() async throws` to `AuthRepository` protocol
-- [ ] 2.13 Add `cancelNewDeviceOTP()` to `AuthRepository` protocol
+_(Protocol declarations require no unit tests — skip straight to implementation.)_
 
-## 3. Domain Unit Tests (write before implementing)
+- [ ] 2.1 Add `LoginResult.requiresNewDeviceOTP` case to `AuthRepository.swift`
+- [ ] 2.2 Add `AuthError.clientIdentifierNotConfigured` case with `errorDescription`
+- [ ] 2.3 Update `LoginUseCase` protocol: change `execute` signature to accept `environment: ServerEnvironment` instead of `serverURL: String`
+- [ ] 2.4 Add `completeNewDeviceOTP(otp: String) async throws -> Account` to `LoginUseCase` protocol
+- [ ] 2.5 Add `resendNewDeviceOTP() async throws` to `LoginUseCase` protocol
+- [ ] 2.6 Add `cancelNewDeviceOTP()` to `LoginUseCase` protocol; update protocol doc comment to describe the full login flow
+- [ ] 2.7 Add `loginWithNewDeviceOTP(_ otp: String) async throws -> Account` to `AuthRepository` protocol
+- [ ] 2.8 Add `requestNewDeviceOTP() async throws` to `AuthRepository` protocol
+- [ ] 2.9 Add `cancelNewDeviceOTP()` to `AuthRepository` protocol
+
+## 3. Domain Unit Tests — Entities (write before Group 4, must fail first)
 
 - [ ] 3.1 `ServerEnvironment` with `serverType == .cloudUS` returns `https://api.bitwarden.com`, `https://identity.bitwarden.com`, `https://icons.bitwarden.net`
 - [ ] 3.2 `ServerEnvironment` with `serverType == .cloudEU` returns `https://api.bitwarden.eu`, `https://identity.bitwarden.eu`, `https://icons.bitwarden.net`
@@ -32,128 +30,137 @@
 - [ ] 3.5 Decode a legacy JSON record (no `serverType` key) → `serverType == .selfHosted`
 - [ ] 3.6 Round-trip encode/decode for each `ServerType` case preserves exact raw string (`"cloudUS"`, `"cloudEU"`, `"selfHosted"`)
 
-## 4. Data Layer — PrizmAPIClient
+## 4. Domain Layer — Entities (implement after Group 3 tests are failing)
 
-- [ ] 4.1 Add `IdentityTokenError.newDeviceNotVerified` case; handle `HTTP 400` + `"error": "device_error"` in `identityToken` to throw it (check only `error` field, not `error_description`)
-- [ ] 4.2 Rename `APIError.baseURLNotSet` to `APIError.serverEnvironmentNotSet`; update all catch sites and existing tests
-- [ ] 4.3 Replace `setBaseURL(_ url: URL)` with `setServerEnvironment(_ env: ServerEnvironment)` on `PrizmAPIClientProtocol` and `PrizmAPIClientImpl`; remove `setBaseURL` entirely
-- [ ] 4.4 Make `clientId` instance state on `PrizmAPIClient` (set via `setServerEnvironment`): cloud environments use `Config.bitwardenClientIdentifier`, self-hosted keeps `"desktop"`
-- [ ] 4.5 Update all ~32 endpoint methods to route via `env.apiURL`, `env.identityURL`, or `env.iconsURL` instead of appending to a single `base`
-- [ ] 4.6 Add `Bitwarden-Client-Name` header to `baseRequest()` using `Config.clientName`
+- [ ] 4.1 Add `ServerType` enum (`cloudUS`, `cloudEU`, `selfHosted`) with `String` raw values to `Domain/Entities/Account.swift`
+- [ ] 4.2 Add `serverType: ServerType` property to `ServerEnvironment`; default to `.selfHosted` in `init` and in `Codable` decoding (legacy records with no key decode as `.selfHosted`)
+- [ ] 4.3 Update `ServerEnvironment` computed properties (`apiURL`, `identityURL`, `iconsURL`) to switch on `serverType` and return hardcoded cloud URLs for `cloudUS`/`cloudEU`, falling back to `base`-derived values for `selfHosted` only
+- [ ] 4.4 Add static factory methods `ServerEnvironment.cloudUS()` and `ServerEnvironment.cloudEU()` (sentinel `base = https://bitwarden.com`)
 
-## 5. Data Unit Tests — PrizmAPIClient (write before implementing)
+## 5. Data Layer — PrizmAPIClient
 
-- [ ] 5.1 `setServerEnvironment` with `cloudUS` → subsequent `preLogin` request URL uses `https://api.bitwarden.com`
-- [ ] 5.2 `setServerEnvironment` with `cloudEU` → subsequent `identityToken` request URL uses `https://identity.bitwarden.eu`
-- [ ] 5.3 `setServerEnvironment` with `cloudEU` → subsequent `refreshAccessToken` URL uses `https://identity.bitwarden.eu`
-- [ ] 5.4 `setServerEnvironment` with `selfHosted(base: https://vault.example.com)` → `fetchSync` URL uses `https://vault.example.com/api`
-- [ ] 5.5 Request made before `setServerEnvironment` throws `APIError.serverEnvironmentNotSet`
-- [ ] 5.6 Cloud `identityToken` request sends `Bitwarden-Client-Name` and `Bitwarden-Client-Version` headers
-- [ ] 5.7 Cloud `identityToken` `client_id` equals `Config.bitwardenClientIdentifier` (not `"desktop"`)
-- [ ] 5.8 Cloud `refreshAccessToken` `client_id` equals `Config.bitwardenClientIdentifier`
-- [ ] 5.9 Self-hosted `identityToken` `client_id` equals `"desktop"`
-- [ ] 5.10 `identityToken` with `HTTP 400` + `{"error": "device_error"}` throws `IdentityTokenError.newDeviceNotVerified`
+- [ ] 5.1 Add `IdentityTokenError.newDeviceNotVerified` case; handle `HTTP 400` + `"error": "device_error"` in `identityToken` to throw it (check only `error` field, not `error_description`)
+- [ ] 5.2 Rename `APIError.baseURLNotSet` to `APIError.serverEnvironmentNotSet`; update all catch sites and existing tests
+- [ ] 5.3 Replace `setBaseURL(_ url: URL)` with `setServerEnvironment(_ env: ServerEnvironment)` on `PrizmAPIClientProtocol` and `PrizmAPIClientImpl`; remove `setBaseURL` entirely
+- [ ] 5.4 Make `clientId` instance state on `PrizmAPIClient` (set via `setServerEnvironment`): cloud environments use `Config.bitwardenClientIdentifier`, self-hosted keeps `"desktop"`
+- [ ] 5.5 Update all ~32 endpoint methods to route via `env.apiURL`, `env.identityURL`, or `env.iconsURL` instead of appending to a single `base`
+- [ ] 5.6 Add `Bitwarden-Client-Name` header to `baseRequest()` using `Config.clientName`
 
-## 6. Data Layer — AuthRepositoryImpl
+## 6. Data Unit Tests — PrizmAPIClient (write before Group 5, must fail first)
 
-- [ ] 6.1 Update all four `setBaseURL` call sites to `setServerEnvironment` (lines 83, 325, 540, 606)
-- [ ] 6.2 Catch `IdentityTokenError.newDeviceNotVerified` in `loginWithPassword` and return `LoginResult.requiresNewDeviceOTP`; hold `environment`, `email`, and hashed password in memory
-- [ ] 6.3 Guard cloud login with `Config.bitwardenClientIdentifier.isEmpty` check; throw `AuthError.clientIdentifierNotConfigured` before any network request
-- [ ] 6.4 Skip `validateServerURL` for cloud environments; call only when `environment.serverType == .selfHosted`
-- [ ] 6.5 Implement `loginWithNewDeviceOTP(_ otp: String)`: retry `identityToken` with `newdeviceotp` param; zero cached credentials after (success or failure)
-- [ ] 6.6 Implement `requestNewDeviceOTP()`: re-post original `identityToken` without `newdeviceotp`; do NOT zero cached credentials
-- [ ] 6.7 Implement `cancelNewDeviceOTP()`: zero cached credentials without network request
-- [ ] 6.8 Self-hosted `device_error` response (unexpected): surface as `AuthError.invalidCredentials`
+- [ ] 6.1 `setServerEnvironment` with `cloudUS` → subsequent `preLogin` request URL uses `https://api.bitwarden.com`
+- [ ] 6.2 `setServerEnvironment` with `cloudEU` → subsequent `identityToken` request URL uses `https://identity.bitwarden.eu`
+- [ ] 6.3 `setServerEnvironment` with `cloudEU` → subsequent `refreshAccessToken` URL uses `https://identity.bitwarden.eu`
+- [ ] 6.4 `setServerEnvironment` with `selfHosted(base: https://vault.example.com)` → `fetchSync` URL uses `https://vault.example.com/api`
+- [ ] 6.5 Request made before `setServerEnvironment` throws `APIError.serverEnvironmentNotSet`
+- [ ] 6.6 Cloud `identityToken` request sends `Bitwarden-Client-Name` and `Bitwarden-Client-Version` HTTP headers
+- [ ] 6.7 Cloud `identityToken` `client_id` form parameter equals `Config.bitwardenClientIdentifier` (not `"desktop"`)
+- [ ] 6.8 Cloud `refreshAccessToken` `client_id` form parameter equals `Config.bitwardenClientIdentifier`
+- [ ] 6.9 Self-hosted `identityToken` `client_id` equals `"desktop"`
+- [ ] 6.10 `identityToken` with `HTTP 400` + `{"error": "device_error"}` throws `IdentityTokenError.newDeviceNotVerified`
 
-## 7. Data Unit Tests — AuthRepositoryImpl + LoginUseCaseImpl (write before implementing)
+## 7. Data Layer — AuthRepositoryImpl
 
-- [ ] 7.1 `AuthRepositoryImpl.setServerEnvironment` calls `apiClient.setServerEnvironment` (not `setBaseURL`)
-- [ ] 7.2 `AuthRepositoryImpl.loginWithPassword` returns `LoginResult.requiresNewDeviceOTP` when `identityToken` throws `IdentityTokenError.newDeviceNotVerified`
-- [ ] 7.3 `AuthRepositoryImpl` throws `AuthError.clientIdentifierNotConfigured` when `Config.bitwardenClientIdentifier` is empty and `serverType` is cloud — no network request made
-- [ ] 7.4 `LoginUseCaseImpl` does NOT call `auth.validateServerURL` when `environment.serverType == .cloudUS` or `.cloudEU`
-- [ ] 7.5 `LoginUseCaseImpl` DOES call `auth.validateServerURL` when `environment.serverType == .selfHosted`
-- [ ] 7.6 Cached credentials zeroed after `loginWithNewDeviceOTP` succeeds
-- [ ] 7.7 Cached credentials zeroed after `loginWithNewDeviceOTP` fails
-- [ ] 7.8 Cached credentials zeroed after `cancelNewDeviceOTP`
-- [ ] 7.9 `requestNewDeviceOTP` does NOT zero cached credentials
-- [ ] 7.10 OTP retry includes `newdeviceotp` form parameter
-- [ ] 7.11 `LoginUseCaseImpl.completeNewDeviceOTP` calls `auth.loginWithNewDeviceOTP` and triggers sync on success
-- [ ] 7.12 `LoginUseCaseImpl.cancelNewDeviceOTP` calls `auth.cancelNewDeviceOTP` and makes no network request
-- [ ] 7.13 `LoginUseCaseImpl.resendNewDeviceOTP` calls `auth.requestNewDeviceOTP` (not `loginWithNewDeviceOTP`)
+- [ ] 7.1 Update all four `setBaseURL` call sites to `setServerEnvironment` (lines 83, 325, 540, 606)
+- [ ] 7.2 Catch `IdentityTokenError.newDeviceNotVerified` in `loginWithPassword` and return `LoginResult.requiresNewDeviceOTP`; hold `environment`, `email`, and hashed password in memory
+- [ ] 7.3 Guard cloud login with `Config.bitwardenClientIdentifier.isEmpty` check; throw `AuthError.clientIdentifierNotConfigured` before any network request
+- [ ] 7.4 Skip `validateServerURL` for cloud environments; call only when `environment.serverType == .selfHosted`
+- [ ] 7.5 Implement `loginWithNewDeviceOTP(_ otp: String)`: retry `identityToken` with `newdeviceotp` param; zero cached credentials after (success or failure)
+- [ ] 7.6 Implement `requestNewDeviceOTP()`: re-post original `identityToken` without `newdeviceotp`; do NOT zero cached credentials
+- [ ] 7.7 Implement `cancelNewDeviceOTP()`: zero cached credentials without network request
+- [ ] 7.8 Self-hosted `device_error` response (unexpected): surface as `AuthError.invalidCredentials`
 
-## 8. LoginUseCaseImpl
+## 8. Data Unit Tests — AuthRepositoryImpl + LoginUseCaseImpl (write before Groups 7 + 9, must fail first)
 
-- [ ] 8.1 Update `execute` to accept `environment: ServerEnvironment`; remove internal URL string construction; pass environment directly to `auth.setServerEnvironment`
-- [ ] 8.2 Implement `completeNewDeviceOTP(otp:)`: call `auth.loginWithNewDeviceOTP`, trigger sync, return `Account`
-- [ ] 8.3 Implement `resendNewDeviceOTP()`: call `auth.requestNewDeviceOTP`
-- [ ] 8.4 Implement `cancelNewDeviceOTP()`: call `auth.cancelNewDeviceOTP`
+- [ ] 8.1 `AuthRepositoryImpl.setServerEnvironment` calls `apiClient.setServerEnvironment` (not `setBaseURL`)
+- [ ] 8.2 `AuthRepositoryImpl.loginWithPassword` returns `LoginResult.requiresNewDeviceOTP` when `identityToken` throws `IdentityTokenError.newDeviceNotVerified`
+- [ ] 8.3 `AuthRepositoryImpl` throws `AuthError.clientIdentifierNotConfigured` when `Config.bitwardenClientIdentifier` is empty and `serverType` is cloud — no network request made
+- [ ] 8.4 `LoginUseCaseImpl` does NOT call `auth.validateServerURL` when `environment.serverType == .cloudUS` or `.cloudEU`
+- [ ] 8.5 `LoginUseCaseImpl` DOES call `auth.validateServerURL` when `environment.serverType == .selfHosted`
+- [ ] 8.6 Cached credentials zeroed after `loginWithNewDeviceOTP` succeeds
+- [ ] 8.7 Cached credentials zeroed after `loginWithNewDeviceOTP` fails
+- [ ] 8.8 Cached credentials zeroed after `cancelNewDeviceOTP`
+- [ ] 8.9 `requestNewDeviceOTP` does NOT zero cached credentials
+- [ ] 8.10 OTP retry includes `newdeviceotp` form parameter
+- [ ] 8.11 `LoginUseCaseImpl.completeNewDeviceOTP` calls `auth.loginWithNewDeviceOTP` and triggers sync on success
+- [ ] 8.12 `LoginUseCaseImpl.cancelNewDeviceOTP` calls `auth.cancelNewDeviceOTP` and makes no network request
+- [ ] 8.13 `LoginUseCaseImpl.resendNewDeviceOTP` calls `auth.requestNewDeviceOTP` (not `loginWithNewDeviceOTP`)
 
-## 9. Presentation Unit Tests (write before implementing)
+## 9. LoginUseCaseImpl
 
-- [ ] 9.1 `LoginViewModel` initialised with `UserDefaults` key `com.prizm.login.lastServerType = "cloudEU"` → `serverType == .cloudEU`
-- [ ] 9.2 Selecting a cloud type persists to `UserDefaults`; selecting self-hosted restores last entered URL
-- [ ] 9.3 `isSignInDisabled` returns `false` for cloud when email and password non-empty, `serverURL` empty
-- [ ] 9.4 `isSignInDisabled` returns `true` for self-hosted when `serverURL` empty, email and password filled
-- [ ] 9.5 `isSignInDisabled` returns `true` when `flowState == .otpPrompt` and OTP field empty
-- [ ] 9.6 `isSignInDisabled` returns `false` when `flowState == .otpPrompt` and OTP field non-empty
-- [ ] 9.7 `flowState` transitions to `.otpPrompt` when `execute` returns `LoginResult.requiresNewDeviceOTP`
-- [ ] 9.8 `flowState` transitions to `.login` when Cancel tapped (after `cancelNewDeviceOTP`)
-- [ ] 9.9 `flowState` remains `.otpPrompt` after invalid OTP error; error message set
-- [ ] 9.10 `resendNewDeviceOTP` called when Resend tapped; OTP field cleared on success; confirmation announced
-- [ ] 9.11 `resendNewDeviceOTP` throws → `flowState` returns to `.otpPrompt`, error message set, OTP field unchanged
+- [ ] 9.1 Update `execute` to accept `environment: ServerEnvironment`; remove internal URL string construction; pass environment directly to `auth.setServerEnvironment`
+- [ ] 9.2 Implement `completeNewDeviceOTP(otp:)`: call `auth.loginWithNewDeviceOTP`, trigger sync, return `Account`
+- [ ] 9.3 Implement `resendNewDeviceOTP()`: call `auth.requestNewDeviceOTP`
+- [ ] 9.4 Implement `cancelNewDeviceOTP()`: call `auth.cancelNewDeviceOTP`
 
-## 10. Presentation — LoginViewModel
+## 10. Presentation Unit Tests (write before Group 11, must fail first)
 
-- [ ] 10.1 Add `serverType: ServerType` `@Published` property; persist/restore via `UserDefaults` key `com.prizm.login.lastServerType`
-- [ ] 10.2 Add `isSignInDisabled: Bool` computed property per spec logic (cloud: email+password; self-hosted: email+password+serverURL; otpPrompt: OTP field non-empty)
-- [ ] 10.3 Update `signIn()` to construct `ServerEnvironment` from `serverType` (`.cloudUS()` / `.cloudEU()` / `selfHosted` from URL string) and call `loginUseCase.execute(environment:email:masterPassword:)`
-- [ ] 10.4 Handle `LoginResult.requiresNewDeviceOTP` in `signIn()`: set `flowState = .otpPrompt`
-- [ ] 10.5 Add `otpCode: String` `@Published` property for the OTP text field
-- [ ] 10.6 Add `submitOTP()` method: calls `loginUseCase.completeNewDeviceOTP(otp: otpCode)`; on success → sync flow; on `invalid_grant` error → stay `.otpPrompt` with error message
-- [ ] 10.7 Add `resendOTP()` method: calls `loginUseCase.resendNewDeviceOTP()`; on success → clear `otpCode`, announce "A new code has been sent to your email"; on error → set error message, leave `otpCode` unchanged
-- [ ] 10.8 Add `cancelOTP()` method: calls `loginUseCase.cancelNewDeviceOTP()`, sets `flowState = .login`
-- [ ] 10.9 Post `AccessibilityNotification.Announcement` for all new error messages as they appear
+- [ ] 10.1 `LoginViewModel` initialised with `UserDefaults` key `com.prizm.login.lastServerType = "cloudEU"` → `serverType == .cloudEU`
+- [ ] 10.2 `LoginViewModel` initialised with no `UserDefaults` key → `serverType` defaults to `.cloudUS`
+- [ ] 10.3 Selecting a cloud type persists to `UserDefaults`; selecting self-hosted restores last entered URL
+- [ ] 10.4 `isSignInDisabled` returns `false` for cloud when email and password non-empty, `serverURL` empty
+- [ ] 10.5 `isSignInDisabled` returns `true` for self-hosted when `serverURL` empty, email and password filled
+- [ ] 10.6 `isSignInDisabled` returns `true` when `flowState == .otpPrompt` and `otpCode` is empty
+- [ ] 10.7 `isSignInDisabled` returns `false` when `flowState == .otpPrompt` and `otpCode` is non-empty
+- [ ] 10.8 `flowState` transitions to `.otpPrompt` when `execute` returns `LoginResult.requiresNewDeviceOTP`
+- [ ] 10.9 `flowState` transitions to `.login` when Cancel tapped (after `cancelNewDeviceOTP`)
+- [ ] 10.10 `flowState` remains `.otpPrompt` after invalid OTP error; error message set
+- [ ] 10.11 `resendNewDeviceOTP` called when Resend tapped; `otpCode` cleared on success; confirmation announced
+- [ ] 10.12 `resendNewDeviceOTP` throws → `flowState` returns to `.otpPrompt`, error message set, `otpCode` unchanged
+- [ ] 10.13 `otpCode` cleared from memory after successful OTP submission in `submitOTP()`
 
-## 11. Presentation — Views
+## 11. Presentation — LoginViewModel
 
-- [ ] 11.1 Update `LoginView`: replace static subtitle with three-way `Picker` (`serverTypePicker`) bound to `viewModel.serverType`; hide server URL field for cloud options
-- [ ] 11.2 Set `accessibilityIdentifier = AccessibilityID.Login.serverTypePicker`, `accessibilityLabel = "Server"`, `accessibilityValue` to current selection label on the picker
-- [ ] 11.3 Add `LoginFlowState.otpPrompt` case to `LoginFlowState` enum in `LoginViewModel.swift`
-- [ ] 11.4 Add `Screen.otpPrompt` case to `RootViewModel.Screen` in `PrizmApp.swift`
-- [ ] 11.5 Update `RootViewModel.handleLoginFlow` to map `.otpPrompt → .otpPrompt`
-- [ ] 11.6 Create `NewDeviceOTPView` (pattern: `TOTPPromptView`): OTP text field, Sign In button, Resend button, Cancel button
-- [ ] 11.7 Set `accessibilityIdentifier` on `NewDeviceOTPView` controls: `AccessibilityID.Login.newDeviceOtpField`, `AccessibilityID.Login.resendOtpButton`, `AccessibilityID.Login.cancelOtpButton`
-- [ ] 11.8 Update `PrizmApp` root switch to show `NewDeviceOTPView(viewModel: rootVM.loginVM)` for `.otpPrompt`
-- [ ] 11.9 Wire Sign In button `disabled` modifier to `viewModel.isSignInDisabled` in both `LoginView` and `NewDeviceOTPView`
+- [ ] 11.1 Add `serverType: ServerType` `@Published` property; persist/restore via `UserDefaults` key `com.prizm.login.lastServerType`; default to `.cloudUS` when key absent (fresh install)
+- [ ] 11.2 Add `isSignInDisabled: Bool` computed property: `true` when (cloud + email or password empty) OR (selfHosted + email, password, or serverURL empty) OR (otpPrompt + `otpCode` empty)
+- [ ] 11.3 Update `signIn()` to construct `ServerEnvironment` from `serverType` (`.cloudUS()` / `.cloudEU()` / `selfHosted` from URL string) and call `loginUseCase.execute(environment:email:masterPassword:)`
+- [ ] 11.4 Handle `LoginResult.requiresNewDeviceOTP` in `signIn()`: set `flowState = .otpPrompt`
+- [ ] 11.5 Add `otpCode: String` `@Published` property for the OTP text field
+- [ ] 11.6 Add `submitOTP()` method: calls `loginUseCase.completeNewDeviceOTP(otp: otpCode)`; clear `otpCode` immediately on call (§III); on success → sync flow; on `invalid_grant` error → stay `.otpPrompt` with error message
+- [ ] 11.7 Add `resendOTP()` method: calls `loginUseCase.resendNewDeviceOTP()`; on success → clear `otpCode`, announce "A new code has been sent to your email"; on error → set error message, leave `otpCode` unchanged
+- [ ] 11.8 Add `cancelOTP()` method: calls `loginUseCase.cancelNewDeviceOTP()`, sets `flowState = .login`
+- [ ] 11.9 Post `AccessibilityNotification.Announcement` for all new error messages as they appear
 
-## 12. Integration Test
+## 12. Presentation — Views
 
-- [ ] 12.1 Verify full login flow against Vaultwarden stub (existing integration test) passes after `PrizmAPIClient` refactor
+- [ ] 12.1 Add new identifiers to `AccessibilityID.Login` in `Presentation/AccessibilityIdentifiers.swift`: `serverTypePicker`, `newDeviceOtpField`, `resendOtpButton`, `cancelOtpButton`, `otpErrorMessage`
+- [ ] 12.2 Add `LoginFlowState.otpPrompt` case to `LoginFlowState` enum in `LoginViewModel.swift`
+- [ ] 12.3 Add `Screen.otpPrompt` case to `RootViewModel.Screen` in `PrizmApp.swift`
+- [ ] 12.4 Update `RootViewModel.handleLoginFlow` to map `.otpPrompt → .otpPrompt`
+- [ ] 12.5 Update `LoginView`: replace static subtitle with three-way `Picker` bound to `viewModel.serverType`; hide server URL field for cloud options; wire Sign In button `disabled` to `viewModel.isSignInDisabled`
+- [ ] 12.6 Apply `accessibilityIdentifier(AccessibilityID.Login.serverTypePicker)`, `accessibilityLabel("Server")`, and `accessibilityValue` (current selection label) to the picker
+- [ ] 12.7 Create `NewDeviceOTPView` (pattern: `TOTPPromptView`): header title with `.isHeader` trait, OTP text field, Sign In button, Resend button, Cancel button; wire Sign In `disabled` to `viewModel.isSignInDisabled`
+- [ ] 12.8 Apply accessibility identifiers on `NewDeviceOTPView` controls: `AccessibilityID.Login.newDeviceOtpField` (label: "Verification code"), `AccessibilityID.Login.resendOtpButton` (label: "Resend code"), `AccessibilityID.Login.cancelOtpButton` (label: "Cancel"), `AccessibilityID.Login.otpErrorMessage` on error label
+- [ ] 12.9 Update `PrizmApp` root switch to show `NewDeviceOTPView(viewModel: rootVM.loginVM)` for `.otpPrompt`
 
-## 13. XCUITest
+## 13. Integration Test
 
-- [ ] 13.1 Three-way picker visible on `LoginView`; all three options selectable
-- [ ] 13.2 Selecting cloud hides server URL field; selecting self-hosted shows it
-- [ ] 13.3 Sign In button enabled for cloud with email + password, empty `serverURL`
-- [ ] 13.4 Sign In button disabled for self-hosted when `serverURL` empty
-- [ ] 13.5 Successful cloud login against local stub (no OTP path)
-- [ ] 13.6 `device_error` response → `NewDeviceOTPView` appears with label "Check your email for a verification code"
-- [ ] 13.7 Valid OTP submitted → login succeeds; OTP field disappears
-- [ ] 13.8 Invalid OTP → error message shown; OTP field remains
+- [ ] 13.1 Verify full login flow against Vaultwarden stub (existing integration test) passes after `PrizmAPIClient` refactor
 
-## 14. Observability
+## 14. XCUITest
 
-- [ ] 14.1 Log server environment selection and restoration at `.info` (include `serverType` value; no secrets)
-- [ ] 14.2 Log each `identityToken` request at `.info` with `identityURL` (not password or hash)
-- [ ] 14.3 Log `requiresNewDeviceOTP` returned and OTP retry at `.info`
-- [ ] 14.4 Log `invalid_grant` on OTP retry at `.error`
-- [ ] 14.5 Log `clientIdentifierNotConfigured` at `.error` before surfacing to Presentation
-- [ ] 14.6 Log URL validation failures at `.error`
+- [ ] 14.1 Three-way picker visible on `LoginView`; all three options selectable
+- [ ] 14.2 Selecting cloud hides server URL field; selecting self-hosted shows it
+- [ ] 14.3 Sign In button enabled for cloud with email + password, empty `serverURL`
+- [ ] 14.4 Sign In button disabled for self-hosted when `serverURL` empty
+- [ ] 14.5 Successful cloud login against local stub (no OTP path)
+- [ ] 14.6 `device_error` response → `NewDeviceOTPView` appears with label "Check your email for a verification code"
+- [ ] 14.7 Valid OTP submitted → login succeeds; OTP field disappears
+- [ ] 14.8 Invalid OTP → error message shown (query via `AccessibilityID.Login.otpErrorMessage`); OTP field remains
 
-## 15. Documentation
+## 15. Observability
 
-- [ ] 15.1 Add `Config.bitwardenApiVersion = "2026.4.0"` to `App/Config.swift`
-- [ ] 15.2 Update `DEVELOPMENT.md`: add `LocalSecrets.xcconfig` section with copy command, xcconfig/Info.plist/Config.swift key names, and note that self-hosted login is unaffected without the file
-- [ ] 15.3 Update `SECURITY.md`: document cloud endpoints, OTP memory handling, client identifier injection
-- [ ] 15.4 Update `ACCESSIBILITY.md`: document server picker VoiceOver behaviour and `NewDeviceOTPView` OTP field/announcement behaviour
-- [ ] 15.5 Update `CLAUDE.md` active changes table: add `hosted-cloud-support` row
+- [ ] 15.1 Log server environment selection and restoration at `.info` (include `serverType` value; no secrets)
+- [ ] 15.2 Log each `identityToken` request at `.info` with `identityURL` (not password or hash)
+- [ ] 15.3 Log `requiresNewDeviceOTP` returned and OTP retry at `.info`
+- [ ] 15.4 Log `invalid_grant` on OTP retry at `.error`
+- [ ] 15.5 Log `clientIdentifierNotConfigured` at `.error` before surfacing to Presentation
+- [ ] 15.6 Log URL validation failures at `.error`
+
+## 16. Documentation
+
+- [ ] 16.1 Add `Config.bitwardenApiVersion = "2026.4.0"` to `App/Config.swift`
+- [ ] 16.2 Update `DEVELOPMENT.md`: add `LocalSecrets.xcconfig` section with copy command, xcconfig/Info.plist/Config.swift key names, and note that self-hosted login is unaffected without the file
+- [ ] 16.3 Update `SECURITY.md`: document cloud endpoints, OTP memory handling, client identifier injection
+- [ ] 16.4 Update `ACCESSIBILITY.md`: document server picker VoiceOver behaviour and `NewDeviceOTPView` OTP field/announcement behaviour
+- [ ] 16.5 Update `CLAUDE.md` active changes table: add `hosted-cloud-support` row

--- a/openspec/changes/hosted-cloud-support/tasks.md
+++ b/openspec/changes/hosted-cloud-support/tasks.md
@@ -1,0 +1,159 @@
+## 1. Build Infrastructure
+
+- [ ] 1.1 Add `LocalSecrets.xcconfig.template` to repo root with empty `BW_CLIENT_IDENTIFIER` and copy instructions
+- [ ] 1.2 Add `BWClientIdentifier` key to `Prizm/Prizm-Info.plist` with value `$(BW_CLIENT_IDENTIFIER)`
+- [ ] 1.3 Add `LocalSecrets.xcconfig` to `.gitignore`
+- [ ] 1.4 Include `LocalSecrets.xcconfig` in Xcode project under Debug and Release configurations (analogous to `LocalConfig.xcconfig`)
+- [ ] 1.5 Add `Config.bitwardenClientIdentifier` to `App/Config.swift` — reads `BWClientIdentifier` from `Bundle.main`, defaults to `""`
+- [ ] 1.6 Verify `Config.clientName` exists in `Config.swift` (used in `baseRequest()` for `Bitwarden-Client-Name` header); add if absent
+
+## 2. Domain Layer — Entities and Protocols
+
+- [ ] 2.1 Add `ServerType` enum (`cloudUS`, `cloudEU`, `selfHosted`) with `String` raw values to `Domain/Entities/Account.swift`
+- [ ] 2.2 Add `serverType: ServerType` property to `ServerEnvironment`; default to `.selfHosted` in `init` and in `Codable` decoding (legacy records with no key decode as `.selfHosted`)
+- [ ] 2.3 Update `ServerEnvironment` computed properties (`apiURL`, `identityURL`, `iconsURL`) to switch on `serverType` and return hardcoded cloud URLs for `cloudUS`/`cloudEU`, falling back to `base`-derived values for `selfHosted` only
+- [ ] 2.4 Add static factory methods `ServerEnvironment.cloudUS()` and `ServerEnvironment.cloudEU()` (sentinel `base = https://bitwarden.com`)
+- [ ] 2.5 Add `LoginResult.requiresNewDeviceOTP` case to `AuthRepository.swift`
+- [ ] 2.6 Add `AuthError.clientIdentifierNotConfigured` case with `errorDescription`
+- [ ] 2.7 Update `LoginUseCase` protocol: change `execute` signature to accept `environment: ServerEnvironment` instead of `serverURL: String`
+- [ ] 2.8 Add `completeNewDeviceOTP(otp: String) async throws -> Account` to `LoginUseCase` protocol
+- [ ] 2.9 Add `resendNewDeviceOTP() async throws` to `LoginUseCase` protocol
+- [ ] 2.10 Add `cancelNewDeviceOTP()` to `LoginUseCase` protocol; update protocol doc comment to describe the full login flow
+- [ ] 2.11 Add `loginWithNewDeviceOTP(_ otp: String) async throws -> Account` to `AuthRepository` protocol
+- [ ] 2.12 Add `requestNewDeviceOTP() async throws` to `AuthRepository` protocol
+- [ ] 2.13 Add `cancelNewDeviceOTP()` to `AuthRepository` protocol
+
+## 3. Domain Unit Tests (write before implementing)
+
+- [ ] 3.1 `ServerEnvironment` with `serverType == .cloudUS` returns `https://api.bitwarden.com`, `https://identity.bitwarden.com`, `https://icons.bitwarden.net`
+- [ ] 3.2 `ServerEnvironment` with `serverType == .cloudEU` returns `https://api.bitwarden.eu`, `https://identity.bitwarden.eu`, `https://icons.bitwarden.net`
+- [ ] 3.3 `ServerEnvironment` with `serverType == .selfHosted` and `base = https://vault.example.com` returns `base`-derived URLs unchanged
+- [ ] 3.4 Cloud cases ignore `overrides` — `ServerEnvironment.cloudUS()` with `overrides` set still returns canonical US URLs
+- [ ] 3.5 Decode a legacy JSON record (no `serverType` key) → `serverType == .selfHosted`
+- [ ] 3.6 Round-trip encode/decode for each `ServerType` case preserves exact raw string (`"cloudUS"`, `"cloudEU"`, `"selfHosted"`)
+
+## 4. Data Layer — PrizmAPIClient
+
+- [ ] 4.1 Add `IdentityTokenError.newDeviceNotVerified` case; handle `HTTP 400` + `"error": "device_error"` in `identityToken` to throw it (check only `error` field, not `error_description`)
+- [ ] 4.2 Rename `APIError.baseURLNotSet` to `APIError.serverEnvironmentNotSet`; update all catch sites and existing tests
+- [ ] 4.3 Replace `setBaseURL(_ url: URL)` with `setServerEnvironment(_ env: ServerEnvironment)` on `PrizmAPIClientProtocol` and `PrizmAPIClientImpl`; remove `setBaseURL` entirely
+- [ ] 4.4 Make `clientId` instance state on `PrizmAPIClient` (set via `setServerEnvironment`): cloud environments use `Config.bitwardenClientIdentifier`, self-hosted keeps `"desktop"`
+- [ ] 4.5 Update all ~32 endpoint methods to route via `env.apiURL`, `env.identityURL`, or `env.iconsURL` instead of appending to a single `base`
+- [ ] 4.6 Add `Bitwarden-Client-Name` header to `baseRequest()` using `Config.clientName`
+
+## 5. Data Unit Tests — PrizmAPIClient (write before implementing)
+
+- [ ] 5.1 `setServerEnvironment` with `cloudUS` → subsequent `preLogin` request URL uses `https://api.bitwarden.com`
+- [ ] 5.2 `setServerEnvironment` with `cloudEU` → subsequent `identityToken` request URL uses `https://identity.bitwarden.eu`
+- [ ] 5.3 `setServerEnvironment` with `cloudEU` → subsequent `refreshAccessToken` URL uses `https://identity.bitwarden.eu`
+- [ ] 5.4 `setServerEnvironment` with `selfHosted(base: https://vault.example.com)` → `fetchSync` URL uses `https://vault.example.com/api`
+- [ ] 5.5 Request made before `setServerEnvironment` throws `APIError.serverEnvironmentNotSet`
+- [ ] 5.6 Cloud `identityToken` request sends `Bitwarden-Client-Name` and `Bitwarden-Client-Version` headers
+- [ ] 5.7 Cloud `identityToken` `client_id` equals `Config.bitwardenClientIdentifier` (not `"desktop"`)
+- [ ] 5.8 Cloud `refreshAccessToken` `client_id` equals `Config.bitwardenClientIdentifier`
+- [ ] 5.9 Self-hosted `identityToken` `client_id` equals `"desktop"`
+- [ ] 5.10 `identityToken` with `HTTP 400` + `{"error": "device_error"}` throws `IdentityTokenError.newDeviceNotVerified`
+
+## 6. Data Layer — AuthRepositoryImpl
+
+- [ ] 6.1 Update all four `setBaseURL` call sites to `setServerEnvironment` (lines 83, 325, 540, 606)
+- [ ] 6.2 Catch `IdentityTokenError.newDeviceNotVerified` in `loginWithPassword` and return `LoginResult.requiresNewDeviceOTP`; hold `environment`, `email`, and hashed password in memory
+- [ ] 6.3 Guard cloud login with `Config.bitwardenClientIdentifier.isEmpty` check; throw `AuthError.clientIdentifierNotConfigured` before any network request
+- [ ] 6.4 Skip `validateServerURL` for cloud environments; call only when `environment.serverType == .selfHosted`
+- [ ] 6.5 Implement `loginWithNewDeviceOTP(_ otp: String)`: retry `identityToken` with `newdeviceotp` param; zero cached credentials after (success or failure)
+- [ ] 6.6 Implement `requestNewDeviceOTP()`: re-post original `identityToken` without `newdeviceotp`; do NOT zero cached credentials
+- [ ] 6.7 Implement `cancelNewDeviceOTP()`: zero cached credentials without network request
+- [ ] 6.8 Self-hosted `device_error` response (unexpected): surface as `AuthError.invalidCredentials`
+
+## 7. Data Unit Tests — AuthRepositoryImpl + LoginUseCaseImpl (write before implementing)
+
+- [ ] 7.1 `AuthRepositoryImpl.setServerEnvironment` calls `apiClient.setServerEnvironment` (not `setBaseURL`)
+- [ ] 7.2 `AuthRepositoryImpl.loginWithPassword` returns `LoginResult.requiresNewDeviceOTP` when `identityToken` throws `IdentityTokenError.newDeviceNotVerified`
+- [ ] 7.3 `AuthRepositoryImpl` throws `AuthError.clientIdentifierNotConfigured` when `Config.bitwardenClientIdentifier` is empty and `serverType` is cloud — no network request made
+- [ ] 7.4 `LoginUseCaseImpl` does NOT call `auth.validateServerURL` when `environment.serverType == .cloudUS` or `.cloudEU`
+- [ ] 7.5 `LoginUseCaseImpl` DOES call `auth.validateServerURL` when `environment.serverType == .selfHosted`
+- [ ] 7.6 Cached credentials zeroed after `loginWithNewDeviceOTP` succeeds
+- [ ] 7.7 Cached credentials zeroed after `loginWithNewDeviceOTP` fails
+- [ ] 7.8 Cached credentials zeroed after `cancelNewDeviceOTP`
+- [ ] 7.9 `requestNewDeviceOTP` does NOT zero cached credentials
+- [ ] 7.10 OTP retry includes `newdeviceotp` form parameter
+- [ ] 7.11 `LoginUseCaseImpl.completeNewDeviceOTP` calls `auth.loginWithNewDeviceOTP` and triggers sync on success
+- [ ] 7.12 `LoginUseCaseImpl.cancelNewDeviceOTP` calls `auth.cancelNewDeviceOTP` and makes no network request
+- [ ] 7.13 `LoginUseCaseImpl.resendNewDeviceOTP` calls `auth.requestNewDeviceOTP` (not `loginWithNewDeviceOTP`)
+
+## 8. LoginUseCaseImpl
+
+- [ ] 8.1 Update `execute` to accept `environment: ServerEnvironment`; remove internal URL string construction; pass environment directly to `auth.setServerEnvironment`
+- [ ] 8.2 Implement `completeNewDeviceOTP(otp:)`: call `auth.loginWithNewDeviceOTP`, trigger sync, return `Account`
+- [ ] 8.3 Implement `resendNewDeviceOTP()`: call `auth.requestNewDeviceOTP`
+- [ ] 8.4 Implement `cancelNewDeviceOTP()`: call `auth.cancelNewDeviceOTP`
+
+## 9. Presentation Unit Tests (write before implementing)
+
+- [ ] 9.1 `LoginViewModel` initialised with `UserDefaults` key `com.prizm.login.lastServerType = "cloudEU"` → `serverType == .cloudEU`
+- [ ] 9.2 Selecting a cloud type persists to `UserDefaults`; selecting self-hosted restores last entered URL
+- [ ] 9.3 `isSignInDisabled` returns `false` for cloud when email and password non-empty, `serverURL` empty
+- [ ] 9.4 `isSignInDisabled` returns `true` for self-hosted when `serverURL` empty, email and password filled
+- [ ] 9.5 `isSignInDisabled` returns `true` when `flowState == .otpPrompt` and OTP field empty
+- [ ] 9.6 `isSignInDisabled` returns `false` when `flowState == .otpPrompt` and OTP field non-empty
+- [ ] 9.7 `flowState` transitions to `.otpPrompt` when `execute` returns `LoginResult.requiresNewDeviceOTP`
+- [ ] 9.8 `flowState` transitions to `.login` when Cancel tapped (after `cancelNewDeviceOTP`)
+- [ ] 9.9 `flowState` remains `.otpPrompt` after invalid OTP error; error message set
+- [ ] 9.10 `resendNewDeviceOTP` called when Resend tapped; OTP field cleared on success; confirmation announced
+- [ ] 9.11 `resendNewDeviceOTP` throws → `flowState` returns to `.otpPrompt`, error message set, OTP field unchanged
+
+## 10. Presentation — LoginViewModel
+
+- [ ] 10.1 Add `serverType: ServerType` `@Published` property; persist/restore via `UserDefaults` key `com.prizm.login.lastServerType`
+- [ ] 10.2 Add `isSignInDisabled: Bool` computed property per spec logic (cloud: email+password; self-hosted: email+password+serverURL; otpPrompt: OTP field non-empty)
+- [ ] 10.3 Update `signIn()` to construct `ServerEnvironment` from `serverType` (`.cloudUS()` / `.cloudEU()` / `selfHosted` from URL string) and call `loginUseCase.execute(environment:email:masterPassword:)`
+- [ ] 10.4 Handle `LoginResult.requiresNewDeviceOTP` in `signIn()`: set `flowState = .otpPrompt`
+- [ ] 10.5 Add `otpCode: String` `@Published` property for the OTP text field
+- [ ] 10.6 Add `submitOTP()` method: calls `loginUseCase.completeNewDeviceOTP(otp: otpCode)`; on success → sync flow; on `invalid_grant` error → stay `.otpPrompt` with error message
+- [ ] 10.7 Add `resendOTP()` method: calls `loginUseCase.resendNewDeviceOTP()`; on success → clear `otpCode`, announce "A new code has been sent to your email"; on error → set error message, leave `otpCode` unchanged
+- [ ] 10.8 Add `cancelOTP()` method: calls `loginUseCase.cancelNewDeviceOTP()`, sets `flowState = .login`
+- [ ] 10.9 Post `AccessibilityNotification.Announcement` for all new error messages as they appear
+
+## 11. Presentation — Views
+
+- [ ] 11.1 Update `LoginView`: replace static subtitle with three-way `Picker` (`serverTypePicker`) bound to `viewModel.serverType`; hide server URL field for cloud options
+- [ ] 11.2 Set `accessibilityIdentifier = AccessibilityID.Login.serverTypePicker`, `accessibilityLabel = "Server"`, `accessibilityValue` to current selection label on the picker
+- [ ] 11.3 Add `LoginFlowState.otpPrompt` case to `LoginFlowState` enum in `LoginViewModel.swift`
+- [ ] 11.4 Add `Screen.otpPrompt` case to `RootViewModel.Screen` in `PrizmApp.swift`
+- [ ] 11.5 Update `RootViewModel.handleLoginFlow` to map `.otpPrompt → .otpPrompt`
+- [ ] 11.6 Create `NewDeviceOTPView` (pattern: `TOTPPromptView`): OTP text field, Sign In button, Resend button, Cancel button
+- [ ] 11.7 Set `accessibilityIdentifier` on `NewDeviceOTPView` controls: `AccessibilityID.Login.newDeviceOtpField`, `AccessibilityID.Login.resendOtpButton`, `AccessibilityID.Login.cancelOtpButton`
+- [ ] 11.8 Update `PrizmApp` root switch to show `NewDeviceOTPView(viewModel: rootVM.loginVM)` for `.otpPrompt`
+- [ ] 11.9 Wire Sign In button `disabled` modifier to `viewModel.isSignInDisabled` in both `LoginView` and `NewDeviceOTPView`
+
+## 12. Integration Test
+
+- [ ] 12.1 Verify full login flow against Vaultwarden stub (existing integration test) passes after `PrizmAPIClient` refactor
+
+## 13. XCUITest
+
+- [ ] 13.1 Three-way picker visible on `LoginView`; all three options selectable
+- [ ] 13.2 Selecting cloud hides server URL field; selecting self-hosted shows it
+- [ ] 13.3 Sign In button enabled for cloud with email + password, empty `serverURL`
+- [ ] 13.4 Sign In button disabled for self-hosted when `serverURL` empty
+- [ ] 13.5 Successful cloud login against local stub (no OTP path)
+- [ ] 13.6 `device_error` response → `NewDeviceOTPView` appears with label "Check your email for a verification code"
+- [ ] 13.7 Valid OTP submitted → login succeeds; OTP field disappears
+- [ ] 13.8 Invalid OTP → error message shown; OTP field remains
+
+## 14. Observability
+
+- [ ] 14.1 Log server environment selection and restoration at `.info` (include `serverType` value; no secrets)
+- [ ] 14.2 Log each `identityToken` request at `.info` with `identityURL` (not password or hash)
+- [ ] 14.3 Log `requiresNewDeviceOTP` returned and OTP retry at `.info`
+- [ ] 14.4 Log `invalid_grant` on OTP retry at `.error`
+- [ ] 14.5 Log `clientIdentifierNotConfigured` at `.error` before surfacing to Presentation
+- [ ] 14.6 Log URL validation failures at `.error`
+
+## 15. Documentation
+
+- [ ] 15.1 Add `Config.bitwardenApiVersion = "2026.4.0"` to `App/Config.swift`
+- [ ] 15.2 Update `DEVELOPMENT.md`: add `LocalSecrets.xcconfig` section with copy command, xcconfig/Info.plist/Config.swift key names, and note that self-hosted login is unaffected without the file
+- [ ] 15.3 Update `SECURITY.md`: document cloud endpoints, OTP memory handling, client identifier injection
+- [ ] 15.4 Update `ACCESSIBILITY.md`: document server picker VoiceOver behaviour and `NewDeviceOTPView` OTP field/announcement behaviour
+- [ ] 15.5 Update `CLAUDE.md` active changes table: add `hosted-cloud-support` row

--- a/openspec/changes/hosted-cloud-support/tasks.md
+++ b/openspec/changes/hosted-cloud-support/tasks.md
@@ -1,170 +1,170 @@
 ## 1. Build Infrastructure
 
-- [ ] 1.1 Add `LocalSecrets.xcconfig.template` to `Prizm/` (same directory as `LocalConfig.xcconfig`) with empty `BW_CLIENT_IDENTIFIER` and copy instructions; xcconfig `#include` paths are relative to the including file so the template must live alongside `LocalConfig.xcconfig`
-- [ ] 1.2 Add `BWClientIdentifier` key to `Prizm/Prizm/Info.plist` with value `$(BW_CLIENT_IDENTIFIER)` (actual path — the file is currently an empty `<dict/>`)
-- [ ] 1.3 Add `LocalSecrets.xcconfig` to `.gitignore`
-- [ ] 1.4 Include `LocalSecrets.xcconfig` by adding `#include "LocalSecrets.xcconfig"` at the top of `LocalConfig.xcconfig`; also add the same line to `LocalConfig.xcconfig.template` (committed) so future devs who copy the template get the include automatically — `LocalConfig.xcconfig` is gitignored so the change cannot be committed directly; both Debug and Release build configurations reference `LocalConfig.xcconfig` as their `baseConfigurationReference` in the Xcode project
-- [ ] 1.5 Add `Config.bitwardenClientIdentifier` to `App/Config.swift` — reads `BWClientIdentifier` from `Bundle.main`, defaults to `""`
-- [ ] 1.6 Verify `Config.clientName` exists in `Config.swift` (used in `baseRequest()` for `Bitwarden-Client-Name` header); add if absent
+- [x] 1.1 Add `LocalSecrets.xcconfig.template` to `Prizm/` (same directory as `LocalConfig.xcconfig`) with empty `BW_CLIENT_IDENTIFIER` and copy instructions; xcconfig `#include` paths are relative to the including file so the template must live alongside `LocalConfig.xcconfig`
+- [x] 1.2 Add `BWClientIdentifier` key to `Prizm/Prizm/Info.plist` with value `$(BW_CLIENT_IDENTIFIER)` (actual path — the file is currently an empty `<dict/>`)
+- [x] 1.3 Add `LocalSecrets.xcconfig` to `.gitignore`
+- [x] 1.4 Include `LocalSecrets.xcconfig` by adding `#include "LocalSecrets.xcconfig"` at the top of `LocalConfig.xcconfig`; also add the same line to `LocalConfig.xcconfig.template` (committed) so future devs who copy the template get the include automatically — `LocalConfig.xcconfig` is gitignored so the change cannot be committed directly; both Debug and Release build configurations reference `LocalConfig.xcconfig` as their `baseConfigurationReference` in the Xcode project
+- [x] 1.5 Add `Config.bitwardenClientIdentifier` to `App/Config.swift` — reads `BWClientIdentifier` from `Bundle.main`, defaults to `""`
+- [x] 1.6 Verify `Config.clientName` exists in `Config.swift` (used in `baseRequest()` for `Bitwarden-Client-Name` header); add if absent
 
 ## 2. Domain Layer — Protocols Only
 
 _(Protocol declarations require no unit tests — skip straight to implementation.)_
 
-- [ ] 2.1 Add `LoginResult.requiresNewDeviceOTP` case to `AuthRepository.swift`
-- [ ] 2.2 Add `AuthError.clientIdentifierNotConfigured` case with `errorDescription`
-- [ ] 2.3 Update `LoginUseCase` protocol: change `execute` signature to accept `environment: ServerEnvironment` instead of `serverURL: String`
-- [ ] 2.4 Add `completeNewDeviceOTP(otp: String) async throws -> Account` to `LoginUseCase` protocol
-- [ ] 2.5 Add `resendNewDeviceOTP() async throws` to `LoginUseCase` protocol
-- [ ] 2.6 Add `cancelNewDeviceOTP()` to `LoginUseCase` protocol; update protocol doc comment to describe the full login flow
-- [ ] 2.7 Add `loginWithNewDeviceOTP(_ otp: String) async throws -> Account` to `AuthRepository` protocol
-- [ ] 2.8 Add `requestNewDeviceOTP() async throws` to `AuthRepository` protocol
-- [ ] 2.9 Add `cancelNewDeviceOTP()` to `AuthRepository` protocol
-- [ ] 2.10 Update `MockLoginUseCase` (`PrizmTests/Mocks/MockLoginUseCase.swift`) to add stub implementations for `completeNewDeviceOTP`, `resendNewDeviceOTP`, `cancelNewDeviceOTP` — protocol conformance requires this before any test target compiles
+- [x] 2.1 Add `LoginResult.requiresNewDeviceOTP` case to `AuthRepository.swift`
+- [x] 2.2 Add `AuthError.clientIdentifierNotConfigured` case with `errorDescription`
+- [x] 2.3 Update `LoginUseCase` protocol: change `execute` signature to accept `environment: ServerEnvironment` instead of `serverURL: String`
+- [x] 2.4 Add `completeNewDeviceOTP(otp: String) async throws -> Account` to `LoginUseCase` protocol
+- [x] 2.5 Add `resendNewDeviceOTP() async throws` to `LoginUseCase` protocol
+- [x] 2.6 Add `cancelNewDeviceOTP()` to `LoginUseCase` protocol; update protocol doc comment to describe the full login flow
+- [x] 2.7 Add `loginWithNewDeviceOTP(_ otp: String) async throws -> Account` to `AuthRepository` protocol
+- [x] 2.8 Add `requestNewDeviceOTP() async throws` to `AuthRepository` protocol
+- [x] 2.9 Add `cancelNewDeviceOTP()` to `AuthRepository` protocol
+- [x] 2.10 Update `MockLoginUseCase` (`PrizmTests/Mocks/MockLoginUseCase.swift`) to add stub implementations for `completeNewDeviceOTP`, `resendNewDeviceOTP`, `cancelNewDeviceOTP` — protocol conformance requires this before any test target compiles
 
 ## 3. Domain Unit Tests — Entities (write before Group 4, must fail first)
 
-- [ ] 3.1 `ServerEnvironment` with `serverType == .cloudUS` returns `https://api.bitwarden.com`, `https://identity.bitwarden.com`, `https://icons.bitwarden.net`
-- [ ] 3.2 `ServerEnvironment` with `serverType == .cloudEU` returns `https://api.bitwarden.eu`, `https://identity.bitwarden.eu`, `https://icons.bitwarden.net`
-- [ ] 3.3 `ServerEnvironment` with `serverType == .selfHosted` and `base = https://vault.example.com` returns `base`-derived URLs unchanged
-- [ ] 3.4 Cloud cases ignore `overrides` — `ServerEnvironment.cloudUS()` with `overrides` set still returns canonical US URLs
-- [ ] 3.5 Decode a legacy JSON record (no `serverType` key) → `serverType == .selfHosted`
-- [ ] 3.6 Round-trip encode/decode for each `ServerType` case preserves exact raw string (`"cloudUS"`, `"cloudEU"`, `"selfHosted"`)
+- [x] 3.1 `ServerEnvironment` with `serverType == .cloudUS` returns `https://api.bitwarden.com`, `https://identity.bitwarden.com`, `https://icons.bitwarden.net`
+- [x] 3.2 `ServerEnvironment` with `serverType == .cloudEU` returns `https://api.bitwarden.eu`, `https://identity.bitwarden.eu`, `https://icons.bitwarden.net`
+- [x] 3.3 `ServerEnvironment` with `serverType == .selfHosted` and `base = https://vault.example.com` returns `base`-derived URLs unchanged
+- [x] 3.4 Cloud cases ignore `overrides` — `ServerEnvironment.cloudUS()` with `overrides` set still returns canonical US URLs
+- [x] 3.5 Decode a legacy JSON record (no `serverType` key) → `serverType == .selfHosted`
+- [x] 3.6 Round-trip encode/decode for each `ServerType` case preserves exact raw string (`"cloudUS"`, `"cloudEU"`, `"selfHosted"`)
 
 ## 4. Domain Layer — Entities (implement after Group 3 tests are failing)
 
-- [ ] 4.1 Add `ServerType` enum (`cloudUS`, `cloudEU`, `selfHosted`) with `String` raw values to `Domain/Entities/Account.swift`
-- [ ] 4.2 Add `serverType: ServerType` property to `ServerEnvironment`; default to `.selfHosted` in `init` and in `Codable` decoding (legacy records with no key decode as `.selfHosted`)
-- [ ] 4.3 Update `ServerEnvironment` computed properties (`apiURL`, `identityURL`, `iconsURL`) to switch on `serverType` and return hardcoded cloud URLs for `cloudUS`/`cloudEU`, falling back to `base`-derived values for `selfHosted` only
-- [ ] 4.4 Add static factory methods `ServerEnvironment.cloudUS()` and `ServerEnvironment.cloudEU()` (sentinel `base = https://bitwarden.com`)
+- [x] 4.1 Add `ServerType` enum (`cloudUS`, `cloudEU`, `selfHosted`) with `String` raw values to `Domain/Entities/Account.swift`
+- [x] 4.2 Add `serverType: ServerType` property to `ServerEnvironment`; default to `.selfHosted` in `init` and in `Codable` decoding (legacy records with no key decode as `.selfHosted`)
+- [x] 4.3 Update `ServerEnvironment` computed properties (`apiURL`, `identityURL`, `iconsURL`) to switch on `serverType` and return hardcoded cloud URLs for `cloudUS`/`cloudEU`, falling back to `base`-derived values for `selfHosted` only
+- [x] 4.4 Add static factory methods `ServerEnvironment.cloudUS()` and `ServerEnvironment.cloudEU()` (sentinel `base = https://bitwarden.com`)
 
 ## 5. Data Layer — PrizmAPIClient
 
-- [ ] 5.0 Add `newDeviceOTP: String? = nil` parameter to `identityToken` in `PrizmAPIClientProtocol`, `PrizmAPIClientImpl`, and `MockPrizmAPIClient`; when non-nil, append `newdeviceotp=<value>` to the `application/x-www-form-urlencoded` body — same endpoint, one extra optional field; default `nil` keeps all existing call sites unchanged
-- [ ] 5.1 Add `IdentityTokenError.newDeviceNotVerified` case; handle `HTTP 400` + `"error": "device_error"` in `identityToken` to throw it (check only `error` field, not `error_description`)
-- [ ] 5.2 Rename `APIError.baseURLNotSet` to `APIError.serverEnvironmentNotSet`; update all catch sites and existing tests
-- [ ] 5.3 Replace `setBaseURL(_ url: URL)` with `setServerEnvironment(_ env: ServerEnvironment)` on `PrizmAPIClientProtocol`, `PrizmAPIClientImpl`, and `MockPrizmAPIClient`; remove `setBaseURL` entirely — the mock must be updated in this same task or Group 6 tests will not compile
-- [ ] 5.4 Make `clientId` instance state on `PrizmAPIClient` (set via `setServerEnvironment`): cloud environments use `Config.bitwardenClientIdentifier`, self-hosted keeps `"desktop"`
-- [ ] 5.5 Update all ~32 endpoint methods to route via `env.apiURL`, `env.identityURL`, or `env.iconsURL` using service-relative paths (e.g. `accounts/prelogin`, `connect/token`, `sync`) — strip the `api/` and `identity/` prefixes from the current path strings; the `ServerEnvironment` computed properties absorb the difference (cloud URLs have no prefix, self-hosted URLs include it)
-- [ ] 5.6 Add `Bitwarden-Client-Name` header to `baseRequest()` using `Config.clientName`
+- [x] 5.0 Add `newDeviceOTP: String? = nil` parameter to `identityToken` in `PrizmAPIClientProtocol`, `PrizmAPIClientImpl`, and `MockPrizmAPIClient`; when non-nil, append `newdeviceotp=<value>` to the `application/x-www-form-urlencoded` body — same endpoint, one extra optional field; default `nil` keeps all existing call sites unchanged
+- [x] 5.1 Add `IdentityTokenError.newDeviceNotVerified` case; handle `HTTP 400` + `"error": "device_error"` in `identityToken` to throw it (check only `error` field, not `error_description`)
+- [x] 5.2 Rename `APIError.baseURLNotSet` to `APIError.serverEnvironmentNotSet`; update all catch sites and existing tests
+- [x] 5.3 Replace `setBaseURL(_ url: URL)` with `setServerEnvironment(_ env: ServerEnvironment)` on `PrizmAPIClientProtocol`, `PrizmAPIClientImpl`, and `MockPrizmAPIClient`; remove `setBaseURL` entirely — the mock must be updated in this same task or Group 6 tests will not compile
+- [x] 5.4 Make `clientId` instance state on `PrizmAPIClient` (set via `setServerEnvironment`): cloud environments use `Config.bitwardenClientIdentifier`, self-hosted keeps `"desktop"`
+- [x] 5.5 Update all ~32 endpoint methods to route via `env.apiURL`, `env.identityURL`, or `env.iconsURL` using service-relative paths (e.g. `accounts/prelogin`, `connect/token`, `sync`) — strip the `api/` and `identity/` prefixes from the current path strings; the `ServerEnvironment` computed properties absorb the difference (cloud URLs have no prefix, self-hosted URLs include it)
+- [x] 5.6 Add `Bitwarden-Client-Name` header to `baseRequest()` using `Config.clientName`
 
 ## 6. Data Unit Tests — PrizmAPIClient (write before Group 5 implementation, must fail first; requires mock protocol stubs from 2.10 and the `setServerEnvironment` signature from 5.3 to compile — add the mock stub in 5.3 before writing these tests)
 
-- [ ] 6.1 `setServerEnvironment` with `cloudUS` → subsequent `preLogin` request URL is `https://api.bitwarden.com/accounts/prelogin` (no `api/` prefix in path)
-- [ ] 6.2 `setServerEnvironment` with `cloudEU` → subsequent `identityToken` request URL is `https://identity.bitwarden.eu/connect/token` (no `identity/` prefix in path)
-- [ ] 6.3 `setServerEnvironment` with `cloudEU` → subsequent `refreshAccessToken` URL is `https://identity.bitwarden.eu/connect/token`
-- [ ] 6.4 `setServerEnvironment` with `selfHosted(base: https://vault.example.com)` → `fetchSync` URL is `https://vault.example.com/api/sync` (self-hosted retains `api/` prefix)
-- [ ] 6.5 Request made before `setServerEnvironment` throws `APIError.serverEnvironmentNotSet`
-- [ ] 6.6 Cloud `identityToken` request sends `Bitwarden-Client-Name` and `Bitwarden-Client-Version` HTTP headers
-- [ ] 6.7 Cloud `identityToken` `client_id` form parameter equals `Config.bitwardenClientIdentifier` (not `"desktop"`)
-- [ ] 6.8 Cloud `refreshAccessToken` `client_id` form parameter equals `Config.bitwardenClientIdentifier`
-- [ ] 6.9 Self-hosted `identityToken` `client_id` equals `"desktop"`
-- [ ] 6.10 `identityToken` with `HTTP 400` + `{"error": "device_error"}` throws `IdentityTokenError.newDeviceNotVerified`
+- [x] 6.1 `setServerEnvironment` with `cloudUS` → subsequent `preLogin` request URL is `https://api.bitwarden.com/accounts/prelogin` (no `api/` prefix in path)
+- [x] 6.2 `setServerEnvironment` with `cloudEU` → subsequent `identityToken` request URL is `https://identity.bitwarden.eu/connect/token` (no `identity/` prefix in path)
+- [x] 6.3 `setServerEnvironment` with `cloudEU` → subsequent `refreshAccessToken` URL is `https://identity.bitwarden.eu/connect/token`
+- [x] 6.4 `setServerEnvironment` with `selfHosted(base: https://vault.example.com)` → `fetchSync` URL is `https://vault.example.com/api/sync` (self-hosted retains `api/` prefix)
+- [x] 6.5 Request made before `setServerEnvironment` throws `APIError.serverEnvironmentNotSet`
+- [x] 6.6 Cloud `identityToken` request sends `Bitwarden-Client-Name` and `Bitwarden-Client-Version` HTTP headers
+- [x] 6.7 Cloud `identityToken` `client_id` form parameter equals `Config.bitwardenClientIdentifier` (not `"desktop"`)
+- [x] 6.8 Cloud `refreshAccessToken` `client_id` form parameter equals `Config.bitwardenClientIdentifier`
+- [x] 6.9 Self-hosted `identityToken` `client_id` equals `"desktop"`
+- [x] 6.10 `identityToken` with `HTTP 400` + `{"error": "device_error"}` throws `IdentityTokenError.newDeviceNotVerified`
 
 ## 7. Data Layer — AuthRepositoryImpl
 
-- [ ] 7.1 Update all four `setBaseURL` call sites to `setServerEnvironment` (lines 83, 325, 540, 606)
-- [ ] 7.2 Catch `IdentityTokenError.newDeviceNotVerified` in `loginWithPassword` and return `LoginResult.requiresNewDeviceOTP`; store a new `PendingNewDeviceOTP` struct (separate from `PendingTwoFactor`) holding `email: String`, `passwordHash: String`, `var stretchedKeys: CryptoKeys` (`var` so zeroing is possible), `deviceId: String`, `environment: ServerEnvironment`; `stretchedKeys` MUST be zeroed before the struct is released on cancel or failure (Constitution §III) — follow the same in-place mutation pattern as `cancelTwoFactor()`
-- [ ] 7.3 Add `clientIdentifier: String = Config.bitwardenClientIdentifier` parameter to `AuthRepositoryImpl.init` (production callers pass no arg; tests inject `""` to verify the guard fires, or `"test-id"` to bypass it); guard cloud login: if `environment.serverType != .selfHosted && clientIdentifier.isEmpty`, throw `AuthError.clientIdentifierNotConfigured` before any network request
-- [ ] 7.4 Skip `validateServerURL` for cloud environments; call only when `environment.serverType == .selfHosted`
-- [ ] 7.5 Implement `loginWithNewDeviceOTP(_ otp: String)`: read `pendingNewDeviceOTP` (throws `AuthError.invalidCredentials` if nil); call `identityToken(email:passwordHash:deviceIdentifier:newDeviceOTP:)` using the pending struct's fields; on success call `finalizeSession(tokenResp:stretched:environment:)` using the pending struct's `stretchedKeys` and `environment`; zero `stretchedKeys` and nil `pendingNewDeviceOTP` in a `defer` block so cleanup happens on both success and failure (Constitution §III)
-- [ ] 7.6 Implement `requestNewDeviceOTP()`: re-post original `identityToken` without `newdeviceotp` using the pending struct's credentials; the server WILL respond with `HTTP 400 + device_error` again — this is expected (it triggers a new OTP email); catch `IdentityTokenError.newDeviceNotVerified` and treat it as **success**; propagate any other error; do NOT zero cached credentials. **Implementation note**: add a code comment explaining that catching `newDeviceNotVerified` as success is intentional — the "error" response is the server's way of confirming it dispatched a new OTP email; do not "fix" this by removing the catch.
-- [ ] 7.7 Implement `cancelNewDeviceOTP()`: zero `pendingNewDeviceOTP!.stretchedKeys` buffers in-place (Constitution §III — same pattern as `cancelTwoFactor()`), then set `pendingNewDeviceOTP = nil`; no network request
-- [ ] 7.8 Self-hosted `device_error` response (unexpected): surface as `AuthError.invalidCredentials`
+- [x] 7.1 Update all four `setBaseURL` call sites to `setServerEnvironment` (lines 83, 325, 540, 606)
+- [x] 7.2 Catch `IdentityTokenError.newDeviceNotVerified` in `loginWithPassword` and return `LoginResult.requiresNewDeviceOTP`; store a new `PendingNewDeviceOTP` struct (separate from `PendingTwoFactor`) holding `email: String`, `passwordHash: String`, `var stretchedKeys: CryptoKeys` (`var` so zeroing is possible), `deviceId: String`, `environment: ServerEnvironment`; `stretchedKeys` MUST be zeroed before the struct is released on cancel or failure (Constitution §III) — follow the same in-place mutation pattern as `cancelTwoFactor()`
+- [x] 7.3 Add `clientIdentifier: String = Config.bitwardenClientIdentifier` parameter to `AuthRepositoryImpl.init` (production callers pass no arg; tests inject `""` to verify the guard fires, or `"test-id"` to bypass it); guard cloud login: if `environment.serverType != .selfHosted && clientIdentifier.isEmpty`, throw `AuthError.clientIdentifierNotConfigured` before any network request
+- [x] 7.4 Skip `validateServerURL` for cloud environments; call only when `environment.serverType == .selfHosted`
+- [x] 7.5 Implement `loginWithNewDeviceOTP(_ otp: String)`: read `pendingNewDeviceOTP` (throws `AuthError.invalidCredentials` if nil); call `identityToken(email:passwordHash:deviceIdentifier:newDeviceOTP:)` using the pending struct's fields; on success call `finalizeSession(tokenResp:stretched:environment:)` using the pending struct's `stretchedKeys` and `environment`; zero `stretchedKeys` and nil `pendingNewDeviceOTP` in a `defer` block so cleanup happens on both success and failure (Constitution §III)
+- [x] 7.6 Implement `requestNewDeviceOTP()`: re-post original `identityToken` without `newdeviceotp` using the pending struct's credentials; the server WILL respond with `HTTP 400 + device_error` again — this is expected (it triggers a new OTP email); catch `IdentityTokenError.newDeviceNotVerified` and treat it as **success**; propagate any other error; do NOT zero cached credentials. **Implementation note**: add a code comment explaining that catching `newDeviceNotVerified` as success is intentional — the "error" response is the server's way of confirming it dispatched a new OTP email; do not "fix" this by removing the catch.
+- [x] 7.7 Implement `cancelNewDeviceOTP()`: zero `pendingNewDeviceOTP!.stretchedKeys` buffers in-place (Constitution §III — same pattern as `cancelTwoFactor()`), then set `pendingNewDeviceOTP = nil`; no network request
+- [x] 7.8 Self-hosted `device_error` response (unexpected): surface as `AuthError.invalidCredentials`
 
 ## 8. Data Unit Tests — AuthRepositoryImpl + LoginUseCaseImpl (write before Groups 7 + 9, must fail first)
 
-- [ ] 8.1 `AuthRepositoryImpl.setServerEnvironment` calls `apiClient.setServerEnvironment` (not `setBaseURL`)
-- [ ] 8.2 `AuthRepositoryImpl.loginWithPassword` returns `LoginResult.requiresNewDeviceOTP` when `identityToken` throws `IdentityTokenError.newDeviceNotVerified`
-- [ ] 8.3 `AuthRepositoryImpl` throws `AuthError.clientIdentifierNotConfigured` when injected `clientIdentifier` is `""` and `serverType` is cloud — no network request made; use `init(..., clientIdentifier: "")` in the test to trigger the guard
-- [ ] 8.4 `LoginUseCaseImpl` does NOT call `auth.validateServerURL` when `environment.serverType == .cloudUS` or `.cloudEU`
-- [ ] 8.5 `LoginUseCaseImpl` DOES call `auth.validateServerURL` when `environment.serverType == .selfHosted`
-- [ ] 8.6 Cached credentials zeroed after `loginWithNewDeviceOTP` succeeds
-- [ ] 8.7 Cached credentials zeroed after `loginWithNewDeviceOTP` fails
-- [ ] 8.8 Cached credentials zeroed after `cancelNewDeviceOTP`
-- [ ] 8.9 `requestNewDeviceOTP` does NOT zero cached credentials
-- [ ] 8.10 OTP retry includes `newdeviceotp` form parameter
-- [ ] 8.11 `LoginUseCaseImpl.completeNewDeviceOTP` calls `auth.loginWithNewDeviceOTP` and triggers sync on success
-- [ ] 8.12 `LoginUseCaseImpl.cancelNewDeviceOTP` calls `auth.cancelNewDeviceOTP` and makes no network request
-- [ ] 8.13 `LoginUseCaseImpl.resendNewDeviceOTP` calls `auth.requestNewDeviceOTP` (not `loginWithNewDeviceOTP`)
+- [x] 8.1 `AuthRepositoryImpl.setServerEnvironment` calls `apiClient.setServerEnvironment` (not `setBaseURL`)
+- [x] 8.2 `AuthRepositoryImpl.loginWithPassword` returns `LoginResult.requiresNewDeviceOTP` when `identityToken` throws `IdentityTokenError.newDeviceNotVerified`
+- [x] 8.3 `AuthRepositoryImpl` throws `AuthError.clientIdentifierNotConfigured` when injected `clientIdentifier` is `""` and `serverType` is cloud — no network request made; use `init(..., clientIdentifier: "")` in the test to trigger the guard
+- [x] 8.4 `LoginUseCaseImpl` does NOT call `auth.validateServerURL` when `environment.serverType == .cloudUS` or `.cloudEU`
+- [x] 8.5 `LoginUseCaseImpl` DOES call `auth.validateServerURL` when `environment.serverType == .selfHosted`
+- [x] 8.6 Cached credentials zeroed after `loginWithNewDeviceOTP` succeeds
+- [x] 8.7 Cached credentials zeroed after `loginWithNewDeviceOTP` fails
+- [x] 8.8 Cached credentials zeroed after `cancelNewDeviceOTP`
+- [x] 8.9 `requestNewDeviceOTP` does NOT zero cached credentials
+- [x] 8.10 OTP retry includes `newdeviceotp` form parameter
+- [x] 8.11 `LoginUseCaseImpl.completeNewDeviceOTP` calls `auth.loginWithNewDeviceOTP` and triggers sync on success
+- [x] 8.12 `LoginUseCaseImpl.cancelNewDeviceOTP` calls `auth.cancelNewDeviceOTP` and makes no network request
+- [x] 8.13 `LoginUseCaseImpl.resendNewDeviceOTP` calls `auth.requestNewDeviceOTP` (not `loginWithNewDeviceOTP`)
 
 ## 9. LoginUseCaseImpl
 
-- [ ] 9.1 Update `execute` to accept `environment: ServerEnvironment`; remove internal URL string construction; pass environment directly to `auth.setServerEnvironment`
-- [ ] 9.2 Implement `completeNewDeviceOTP(otp:)`: call `auth.loginWithNewDeviceOTP`, trigger sync, return `Account`
-- [ ] 9.3 Implement `resendNewDeviceOTP()`: call `auth.requestNewDeviceOTP`
-- [ ] 9.4 Implement `cancelNewDeviceOTP()`: call `auth.cancelNewDeviceOTP`
+- [x] 9.1 Update `execute` to accept `environment: ServerEnvironment`; remove internal URL string construction; pass environment directly to `auth.setServerEnvironment`
+- [x] 9.2 Implement `completeNewDeviceOTP(otp:)`: call `auth.loginWithNewDeviceOTP`, trigger sync, return `Account`
+- [x] 9.3 Implement `resendNewDeviceOTP()`: call `auth.requestNewDeviceOTP`
+- [x] 9.4 Implement `cancelNewDeviceOTP()`: call `auth.cancelNewDeviceOTP`
 
 ## 10. Presentation Unit Tests (write before Group 11, must fail first)
 
-- [ ] 10.1 `LoginViewModel` initialised with `UserDefaults` key `com.prizm.login.lastServerType = "cloudEU"` → `serverType == .cloudEU`
-- [ ] 10.2 `LoginViewModel` initialised with no `UserDefaults` key → `serverType` defaults to `.cloudUS`
-- [ ] 10.3 Selecting a cloud type persists to `UserDefaults`; selecting self-hosted restores last entered URL; `serverURL` persisted to `UserDefaults` and restored on init
-- [ ] 10.4 `isSignInDisabled` returns `true` when `flowState == .loading` (prevents double-submit regardless of field content)
-- [ ] 10.5 `isSignInDisabled` returns `false` for cloud when email and password non-empty, `serverURL` empty
-- [ ] 10.6 `isSignInDisabled` returns `true` for self-hosted when `serverURL` empty, email and password filled
-- [ ] 10.7 `isSignInDisabled` returns `true` when `flowState == .otpPrompt` and `otpCode` is empty
-- [ ] 10.8 `isSignInDisabled` returns `false` when `flowState == .otpPrompt` and `otpCode` is non-empty
-- [ ] 10.9 `flowState` transitions to `.otpPrompt` when `execute` returns `LoginResult.requiresNewDeviceOTP`
-- [ ] 10.10 `flowState` transitions to `.login` when Cancel tapped (after `cancelNewDeviceOTP`)
-- [ ] 10.11 `flowState` remains `.otpPrompt` after invalid OTP error; error message set
-- [ ] 10.12 `resendNewDeviceOTP` called when Resend tapped; `otpCode` cleared on success; confirmation announced
-- [ ] 10.13 `resendNewDeviceOTP` throws → `flowState` returns to `.otpPrompt`, error message set, `otpCode` unchanged
-- [ ] 10.14 `otpCode` cleared from memory after successful OTP submission in `submitOTP()`
+- [x] 10.1 `LoginViewModel` initialised with `UserDefaults` key `com.prizm.login.lastServerType = "cloudEU"` → `serverType == .cloudEU`
+- [x] 10.2 `LoginViewModel` initialised with no `UserDefaults` key → `serverType` defaults to `.cloudUS`
+- [x] 10.3 Selecting a cloud type persists to `UserDefaults`; selecting self-hosted restores last entered URL; `serverURL` persisted to `UserDefaults` and restored on init
+- [x] 10.4 `isSignInDisabled` returns `true` when `flowState == .loading` (prevents double-submit regardless of field content)
+- [x] 10.5 `isSignInDisabled` returns `false` for cloud when email and password non-empty, `serverURL` empty
+- [x] 10.6 `isSignInDisabled` returns `true` for self-hosted when `serverURL` empty, email and password filled
+- [x] 10.7 `isSignInDisabled` returns `true` when `flowState == .otpPrompt` and `otpCode` is empty
+- [x] 10.8 `isSignInDisabled` returns `false` when `flowState == .otpPrompt` and `otpCode` is non-empty
+- [x] 10.9 `flowState` transitions to `.otpPrompt` when `execute` returns `LoginResult.requiresNewDeviceOTP`
+- [x] 10.10 `flowState` transitions to `.login` when Cancel tapped (after `cancelNewDeviceOTP`)
+- [x] 10.11 `flowState` remains `.otpPrompt` after invalid OTP error; error message set
+- [x] 10.12 `resendNewDeviceOTP` called when Resend tapped; `otpCode` cleared on success; confirmation announced
+- [x] 10.13 `resendNewDeviceOTP` throws → `flowState` returns to `.otpPrompt`, error message set, `otpCode` unchanged
+- [x] 10.14 `otpCode` cleared from memory after successful OTP submission in `submitOTP()`
 
 ## 11. Presentation — LoginViewModel
 
-- [ ] 11.1 Add `serverType: ServerType` `@Published` property; persist/restore via `UserDefaults` key `com.prizm.login.lastServerType`; default to `.cloudUS` when key absent (fresh install)
-- [ ] 11.1a Persist `serverURL` to `UserDefaults` key `com.prizm.login.lastServerURL` when the user modifies it; restore on init so the self-hosted URL survives app restarts and server-type switching within a session
-- [ ] 11.2 Add `isSignInDisabled: Bool` computed property: `true` when `flowState == .loading` (prevents double-submit) OR (cloud + email or password empty) OR (selfHosted + email, password, or serverURL empty) OR (otpPrompt + `otpCode` empty)
-- [ ] 11.3 Update `signIn()` to construct `ServerEnvironment` from `serverType` (`.cloudUS()` / `.cloudEU()` / `selfHosted` from URL string) and call `loginUseCase.execute(environment:email:masterPassword:)`
-- [ ] 11.4 Handle `LoginResult.requiresNewDeviceOTP` in `signIn()`: set `flowState = .otpPrompt`
-- [ ] 11.5 Add `otpCode: String` `@Published` property for the OTP text field
-- [ ] 11.6 Add `submitOTP()` method: calls `loginUseCase.completeNewDeviceOTP(otp: otpCode)`; clear `otpCode` immediately on call (§III); on success → sync flow; on `invalid_grant` error → stay `.otpPrompt` with error message
-- [ ] 11.7 Add `resendOTP()` method: calls `loginUseCase.resendNewDeviceOTP()`; on success → clear `otpCode`, announce "A new code has been sent to your email"; on error → set error message, leave `otpCode` unchanged
-- [ ] 11.8 Add `cancelOTP()` method: calls `loginUseCase.cancelNewDeviceOTP()`, sets `flowState = .login`
-- [ ] 11.9 Post `AccessibilityNotification.Announcement` for all new error messages as they appear
+- [x] 11.1 Add `serverType: ServerType` `@Published` property; persist/restore via `UserDefaults` key `com.prizm.login.lastServerType`; default to `.cloudUS` when key absent (fresh install)
+- [x] 11.1a Persist `serverURL` to `UserDefaults` key `com.prizm.login.lastServerURL` when the user modifies it; restore on init so the self-hosted URL survives app restarts and server-type switching within a session
+- [x] 11.2 Add `isSignInDisabled: Bool` computed property: `true` when `flowState == .loading` (prevents double-submit) OR (cloud + email or password empty) OR (selfHosted + email, password, or serverURL empty) OR (otpPrompt + `otpCode` empty)
+- [x] 11.3 Update `signIn()` to construct `ServerEnvironment` from `serverType` (`.cloudUS()` / `.cloudEU()` / `selfHosted` from URL string) and call `loginUseCase.execute(environment:email:masterPassword:)`
+- [x] 11.4 Handle `LoginResult.requiresNewDeviceOTP` in `signIn()`: set `flowState = .otpPrompt`
+- [x] 11.5 Add `otpCode: String` `@Published` property for the OTP text field
+- [x] 11.6 Add `submitOTP()` method: calls `loginUseCase.completeNewDeviceOTP(otp: otpCode)`; clear `otpCode` immediately on call (§III); on success → sync flow; on `invalid_grant` error → stay `.otpPrompt` with error message
+- [x] 11.7 Add `resendOTP()` method: calls `loginUseCase.resendNewDeviceOTP()`; on success → clear `otpCode`, announce "A new code has been sent to your email"; on error → set error message, leave `otpCode` unchanged
+- [x] 11.8 Add `cancelOTP()` method: calls `loginUseCase.cancelNewDeviceOTP()`, sets `flowState = .login`
+- [x] 11.9 Post `AccessibilityNotification.Announcement` for all new error messages as they appear
 
 ## 12. Presentation — Views
 
-- [ ] 12.1 Add new identifiers to `AccessibilityID.Login` in `Presentation/AccessibilityIdentifiers.swift`: `serverTypePicker`, `newDeviceOtpField`, `resendOtpButton`, `cancelOtpButton`, `otpErrorMessage`
-- [ ] 12.2 Add `LoginFlowState.otpPrompt` case to `LoginFlowState` enum in `LoginViewModel.swift`
-- [ ] 12.3 Add `Screen.otpPrompt` case to `RootViewModel.Screen` in `PrizmApp.swift`
-- [ ] 12.4 Update `RootViewModel.handleLoginFlow` to map `.otpPrompt → .otpPrompt`
-- [ ] 12.5 Update `LoginView`: replace static subtitle with three-way `Picker` bound to `viewModel.serverType`; hide server URL field for cloud options; wire Sign In button `disabled` to `viewModel.isSignInDisabled`
-- [ ] 12.6 Apply `accessibilityIdentifier(AccessibilityID.Login.serverTypePicker)`, `accessibilityLabel("Server")`, and `accessibilityValue` (current selection label) to the picker
-- [ ] 12.7 Create `NewDeviceOTPView` (pattern: `TOTPPromptView`): header title with `.isHeader` trait, OTP text field, Sign In button, Resend button, Cancel button; wire Sign In `disabled` to `viewModel.isSignInDisabled`
-- [ ] 12.8 Apply accessibility identifiers on `NewDeviceOTPView` controls: `AccessibilityID.Login.newDeviceOtpField` (label: "Verification code"), `AccessibilityID.Login.resendOtpButton` (label: "Resend code"), `AccessibilityID.Login.cancelOtpButton` (label: "Cancel"), `AccessibilityID.Login.otpErrorMessage` on error label
-- [ ] 12.9 Update `PrizmApp` root switch to show `NewDeviceOTPView(viewModel: rootVM.loginVM)` for `.otpPrompt`
+- [x] 12.1 Add new identifiers to `AccessibilityID.Login` in `Presentation/AccessibilityIdentifiers.swift`: `serverTypePicker`, `newDeviceOtpField`, `resendOtpButton`, `cancelOtpButton`, `otpErrorMessage`
+- [x] 12.2 Add `LoginFlowState.otpPrompt` case to `LoginFlowState` enum in `LoginViewModel.swift`
+- [x] 12.3 Add `Screen.otpPrompt` case to `RootViewModel.Screen` in `PrizmApp.swift`
+- [x] 12.4 Update `RootViewModel.handleLoginFlow` to map `.otpPrompt → .otpPrompt`
+- [x] 12.5 Update `LoginView`: replace static subtitle with three-way `Picker` bound to `viewModel.serverType`; hide server URL field for cloud options; wire Sign In button `disabled` to `viewModel.isSignInDisabled`
+- [x] 12.6 Apply `accessibilityIdentifier(AccessibilityID.Login.serverTypePicker)`, `accessibilityLabel("Server")`, and `accessibilityValue` (current selection label) to the picker
+- [x] 12.7 Create `NewDeviceOTPView` (pattern: `TOTPPromptView`): header title with `.isHeader` trait, OTP text field, Sign In button, Resend button, Cancel button; wire Sign In `disabled` to `viewModel.isSignInDisabled`
+- [x] 12.8 Apply accessibility identifiers on `NewDeviceOTPView` controls: `AccessibilityID.Login.newDeviceOtpField` (label: "Verification code"), `AccessibilityID.Login.resendOtpButton` (label: "Resend code"), `AccessibilityID.Login.cancelOtpButton` (label: "Cancel"), `AccessibilityID.Login.otpErrorMessage` on error label
+- [x] 12.9 Update `PrizmApp` root switch to show `NewDeviceOTPView(viewModel: rootVM.loginVM)` for `.otpPrompt`
 
 ## 13. Integration Test
 
-- [ ] 13.1 Verify full login flow against Vaultwarden stub (existing integration test) passes after `PrizmAPIClient` refactor
+- [x] 13.1 Verify full login flow against Vaultwarden stub (existing integration test) passes after `PrizmAPIClient` refactor
 
 ## 14. XCUITest
 
-- [ ] 14.1 Three-way picker visible on `LoginView`; all three options selectable
-- [ ] 14.2 Selecting cloud hides server URL field; selecting self-hosted shows it
-- [ ] 14.3 Sign In button enabled for cloud with email + password, empty `serverURL`
-- [ ] 14.4 Sign In button disabled for self-hosted when `serverURL` empty
-- [ ] 14.5 Successful cloud login against local stub (no OTP path)
-- [ ] 14.6 `device_error` response → `NewDeviceOTPView` appears with label "Check your email for a verification code"
-- [ ] 14.7 Valid OTP submitted → login succeeds; OTP field disappears
-- [ ] 14.8 Invalid OTP → error message shown (query via `AccessibilityID.Login.otpErrorMessage`); OTP field remains
+- [x] 14.1 Three-way picker visible on `LoginView`; all three options selectable
+- [x] 14.2 Selecting cloud hides server URL field; selecting self-hosted shows it
+- [x] 14.3 Sign In button enabled for cloud with email + password, empty `serverURL`
+- [x] 14.4 Sign In button disabled for self-hosted when `serverURL` empty
+- [x] 14.5 Successful cloud login against local stub (no OTP path)
+- [x] 14.6 `device_error` response → `NewDeviceOTPView` appears with label "Check your email for a verification code"
+- [x] 14.7 Valid OTP submitted → login succeeds; OTP field disappears
+- [x] 14.8 Invalid OTP → error message shown (query via `AccessibilityID.Login.otpErrorMessage`); OTP field remains
 
 ## 15. Observability
 
-- [ ] 15.1 Log server environment selection and restoration at `.info` (include `serverType` value; no secrets)
-- [ ] 15.2 Log each `identityToken` request at `.info` with `identityURL` (not password or hash)
-- [ ] 15.3 Log `requiresNewDeviceOTP` returned and OTP retry at `.info`
-- [ ] 15.4 Log `invalid_grant` on OTP retry at `.error`
-- [ ] 15.5 Log `clientIdentifierNotConfigured` at `.error` before surfacing to Presentation
-- [ ] 15.6 Log URL validation failures at `.error`
+- [x] 15.1 Log server environment selection and restoration at `.info` (include `serverType` value; no secrets)
+- [x] 15.2 Log each `identityToken` request at `.info` with `identityURL` (not password or hash)
+- [x] 15.3 Log `requiresNewDeviceOTP` returned and OTP retry at `.info`
+- [x] 15.4 Log `invalid_grant` on OTP retry at `.error`
+- [x] 15.5 Log `clientIdentifierNotConfigured` at `.error` before surfacing to Presentation
+- [x] 15.6 Log URL validation failures at `.error`
 
 ## 16. Documentation
 
-- [ ] 16.1 Add `Config.bitwardenApiVersion = "2026.4.0"` to `App/Config.swift`
-- [ ] 16.2 Update `DEVELOPMENT.md`: add `LocalSecrets.xcconfig` section with copy command, xcconfig/Info.plist/Config.swift key names, and note that self-hosted login is unaffected without the file
-- [ ] 16.3 Update `SECURITY.md`: document cloud endpoints, OTP memory handling, client identifier injection
-- [ ] 16.4 Update `ACCESSIBILITY.md`: document server picker VoiceOver behaviour and `NewDeviceOTPView` OTP field/announcement behaviour
-- [ ] 16.5 Update `CLAUDE.md` active changes table: add `hosted-cloud-support` row
+- [x] 16.1 Add `Config.bitwardenApiVersion = "2026.4.0"` to `App/Config.swift`
+- [x] 16.2 Update `DEVELOPMENT.md`: add `LocalSecrets.xcconfig` section with copy command, xcconfig/Info.plist/Config.swift key names, and note that self-hosted login is unaffected without the file
+- [x] 16.3 Update `SECURITY.md`: document cloud endpoints, OTP memory handling, client identifier injection
+- [x] 16.4 Update `ACCESSIBILITY.md`: document server picker VoiceOver behaviour and `NewDeviceOTPView` OTP field/announcement behaviour
+- [x] 16.5 Update `CLAUDE.md` active changes table: add `hosted-cloud-support` row

--- a/openspec/changes/hosted-cloud-support/tasks.md
+++ b/openspec/changes/hosted-cloud-support/tasks.md
@@ -45,15 +45,15 @@ _(Protocol declarations require no unit tests — skip straight to implementatio
 - [ ] 5.2 Rename `APIError.baseURLNotSet` to `APIError.serverEnvironmentNotSet`; update all catch sites and existing tests
 - [ ] 5.3 Replace `setBaseURL(_ url: URL)` with `setServerEnvironment(_ env: ServerEnvironment)` on `PrizmAPIClientProtocol`, `PrizmAPIClientImpl`, and `MockPrizmAPIClient`; remove `setBaseURL` entirely — the mock must be updated in this same task or Group 6 tests will not compile
 - [ ] 5.4 Make `clientId` instance state on `PrizmAPIClient` (set via `setServerEnvironment`): cloud environments use `Config.bitwardenClientIdentifier`, self-hosted keeps `"desktop"`
-- [ ] 5.5 Update all ~32 endpoint methods to route via `env.apiURL`, `env.identityURL`, or `env.iconsURL` instead of appending to a single `base`
+- [ ] 5.5 Update all ~32 endpoint methods to route via `env.apiURL`, `env.identityURL`, or `env.iconsURL` using service-relative paths (e.g. `accounts/prelogin`, `connect/token`, `sync`) — strip the `api/` and `identity/` prefixes from the current path strings; the `ServerEnvironment` computed properties absorb the difference (cloud URLs have no prefix, self-hosted URLs include it)
 - [ ] 5.6 Add `Bitwarden-Client-Name` header to `baseRequest()` using `Config.clientName`
 
-## 6. Data Unit Tests — PrizmAPIClient (write before Group 5, must fail first)
+## 6. Data Unit Tests — PrizmAPIClient (write before Group 5 implementation, must fail first; requires mock protocol stubs from 2.10 and the `setServerEnvironment` signature from 5.3 to compile — add the mock stub in 5.3 before writing these tests)
 
-- [ ] 6.1 `setServerEnvironment` with `cloudUS` → subsequent `preLogin` request URL uses `https://api.bitwarden.com`
-- [ ] 6.2 `setServerEnvironment` with `cloudEU` → subsequent `identityToken` request URL uses `https://identity.bitwarden.eu`
-- [ ] 6.3 `setServerEnvironment` with `cloudEU` → subsequent `refreshAccessToken` URL uses `https://identity.bitwarden.eu`
-- [ ] 6.4 `setServerEnvironment` with `selfHosted(base: https://vault.example.com)` → `fetchSync` URL uses `https://vault.example.com/api`
+- [ ] 6.1 `setServerEnvironment` with `cloudUS` → subsequent `preLogin` request URL is `https://api.bitwarden.com/accounts/prelogin` (no `api/` prefix in path)
+- [ ] 6.2 `setServerEnvironment` with `cloudEU` → subsequent `identityToken` request URL is `https://identity.bitwarden.eu/connect/token` (no `identity/` prefix in path)
+- [ ] 6.3 `setServerEnvironment` with `cloudEU` → subsequent `refreshAccessToken` URL is `https://identity.bitwarden.eu/connect/token`
+- [ ] 6.4 `setServerEnvironment` with `selfHosted(base: https://vault.example.com)` → `fetchSync` URL is `https://vault.example.com/api/sync` (self-hosted retains `api/` prefix)
 - [ ] 6.5 Request made before `setServerEnvironment` throws `APIError.serverEnvironmentNotSet`
 - [ ] 6.6 Cloud `identityToken` request sends `Bitwarden-Client-Name` and `Bitwarden-Client-Version` HTTP headers
 - [ ] 6.7 Cloud `identityToken` `client_id` form parameter equals `Config.bitwardenClientIdentifier` (not `"desktop"`)
@@ -68,7 +68,7 @@ _(Protocol declarations require no unit tests — skip straight to implementatio
 - [ ] 7.3 Add `clientIdentifier: String = Config.bitwardenClientIdentifier` parameter to `AuthRepositoryImpl.init` (production callers pass no arg; tests inject `""` to verify the guard fires, or `"test-id"` to bypass it); guard cloud login: if `environment.serverType != .selfHosted && clientIdentifier.isEmpty`, throw `AuthError.clientIdentifierNotConfigured` before any network request
 - [ ] 7.4 Skip `validateServerURL` for cloud environments; call only when `environment.serverType == .selfHosted`
 - [ ] 7.5 Implement `loginWithNewDeviceOTP(_ otp: String)`: read `pendingNewDeviceOTP` (throws `AuthError.invalidCredentials` if nil); call `identityToken(email:passwordHash:deviceIdentifier:newDeviceOTP:)` using the pending struct's fields; on success call `finalizeSession(tokenResp:stretched:environment:)` using the pending struct's `stretchedKeys` and `environment`; zero `stretchedKeys` and nil `pendingNewDeviceOTP` in a `defer` block so cleanup happens on both success and failure (Constitution §III)
-- [ ] 7.6 Implement `requestNewDeviceOTP()`: re-post original `identityToken` without `newdeviceotp` using the pending struct's credentials; the server WILL respond with `HTTP 400 + device_error` again — this is expected (it triggers a new OTP email); catch `IdentityTokenError.newDeviceNotVerified` and treat it as **success**; propagate any other error; do NOT zero cached credentials
+- [ ] 7.6 Implement `requestNewDeviceOTP()`: re-post original `identityToken` without `newdeviceotp` using the pending struct's credentials; the server WILL respond with `HTTP 400 + device_error` again — this is expected (it triggers a new OTP email); catch `IdentityTokenError.newDeviceNotVerified` and treat it as **success**; propagate any other error; do NOT zero cached credentials. **Implementation note**: add a code comment explaining that catching `newDeviceNotVerified` as success is intentional — the "error" response is the server's way of confirming it dispatched a new OTP email; do not "fix" this by removing the catch.
 - [ ] 7.7 Implement `cancelNewDeviceOTP()`: zero `pendingNewDeviceOTP!.stretchedKeys` buffers in-place (Constitution §III — same pattern as `cancelTwoFactor()`), then set `pendingNewDeviceOTP = nil`; no network request
 - [ ] 7.8 Self-hosted `device_error` response (unexpected): surface as `AuthError.invalidCredentials`
 
@@ -99,7 +99,7 @@ _(Protocol declarations require no unit tests — skip straight to implementatio
 
 - [ ] 10.1 `LoginViewModel` initialised with `UserDefaults` key `com.prizm.login.lastServerType = "cloudEU"` → `serverType == .cloudEU`
 - [ ] 10.2 `LoginViewModel` initialised with no `UserDefaults` key → `serverType` defaults to `.cloudUS`
-- [ ] 10.3 Selecting a cloud type persists to `UserDefaults`; selecting self-hosted restores last entered URL
+- [ ] 10.3 Selecting a cloud type persists to `UserDefaults`; selecting self-hosted restores last entered URL; `serverURL` persisted to `UserDefaults` and restored on init
 - [ ] 10.4 `isSignInDisabled` returns `true` when `flowState == .loading` (prevents double-submit regardless of field content)
 - [ ] 10.5 `isSignInDisabled` returns `false` for cloud when email and password non-empty, `serverURL` empty
 - [ ] 10.6 `isSignInDisabled` returns `true` for self-hosted when `serverURL` empty, email and password filled
@@ -115,6 +115,7 @@ _(Protocol declarations require no unit tests — skip straight to implementatio
 ## 11. Presentation — LoginViewModel
 
 - [ ] 11.1 Add `serverType: ServerType` `@Published` property; persist/restore via `UserDefaults` key `com.prizm.login.lastServerType`; default to `.cloudUS` when key absent (fresh install)
+- [ ] 11.1a Persist `serverURL` to `UserDefaults` key `com.prizm.login.lastServerURL` when the user modifies it; restore on init so the self-hosted URL survives app restarts and server-type switching within a session
 - [ ] 11.2 Add `isSignInDisabled: Bool` computed property: `true` when `flowState == .loading` (prevents double-submit) OR (cloud + email or password empty) OR (selfHosted + email, password, or serverURL empty) OR (otpPrompt + `otpCode` empty)
 - [ ] 11.3 Update `signIn()` to construct `ServerEnvironment` from `serverType` (`.cloudUS()` / `.cloudEU()` / `selfHosted` from URL string) and call `loginUseCase.execute(environment:email:masterPassword:)`
 - [ ] 11.4 Handle `LoginResult.requiresNewDeviceOTP` in `signIn()`: set `flowState = .otpPrompt`

--- a/openspec/changes/hosted-cloud-support/tasks.md
+++ b/openspec/changes/hosted-cloud-support/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Build Infrastructure
 
-- [ ] 1.1 Add `LocalSecrets.xcconfig.template` to repo root with empty `BW_CLIENT_IDENTIFIER` and copy instructions
-- [ ] 1.2 Add `BWClientIdentifier` key to `Prizm/Prizm-Info.plist` with value `$(BW_CLIENT_IDENTIFIER)`
+- [ ] 1.1 Add `LocalSecrets.xcconfig.template` to `Prizm/` (same directory as `LocalConfig.xcconfig`) with empty `BW_CLIENT_IDENTIFIER` and copy instructions; xcconfig `#include` paths are relative to the including file so the template must live alongside `LocalConfig.xcconfig`
+- [ ] 1.2 Add `BWClientIdentifier` key to `Prizm/Prizm/Info.plist` with value `$(BW_CLIENT_IDENTIFIER)` (actual path — the file is currently an empty `<dict/>`)
 - [ ] 1.3 Add `LocalSecrets.xcconfig` to `.gitignore`
-- [ ] 1.4 Include `LocalSecrets.xcconfig` by adding `#include "LocalSecrets.xcconfig"` at the top of `LocalConfig.xcconfig` (this is already included in both Debug and Release configurations via the existing xcconfig chain)
+- [ ] 1.4 Include `LocalSecrets.xcconfig` by adding `#include "LocalSecrets.xcconfig"` at the top of `LocalConfig.xcconfig`; also add the same line to `LocalConfig.xcconfig.template` (committed) so future devs who copy the template get the include automatically — `LocalConfig.xcconfig` is gitignored so the change cannot be committed directly; both Debug and Release build configurations reference `LocalConfig.xcconfig` as their `baseConfigurationReference` in the Xcode project
 - [ ] 1.5 Add `Config.bitwardenClientIdentifier` to `App/Config.swift` — reads `BWClientIdentifier` from `Bundle.main`, defaults to `""`
 - [ ] 1.6 Verify `Config.clientName` exists in `Config.swift` (used in `baseRequest()` for `Bitwarden-Client-Name` header); add if absent
 
@@ -39,9 +39,10 @@ _(Protocol declarations require no unit tests — skip straight to implementatio
 
 ## 5. Data Layer — PrizmAPIClient
 
+- [ ] 5.0 Add `newDeviceOTP: String? = nil` parameter to `identityToken` in `PrizmAPIClientProtocol`, `PrizmAPIClientImpl`, and `MockPrizmAPIClient`; when non-nil, append `newdeviceotp=<value>` to the `application/x-www-form-urlencoded` body — same endpoint, one extra optional field; default `nil` keeps all existing call sites unchanged
 - [ ] 5.1 Add `IdentityTokenError.newDeviceNotVerified` case; handle `HTTP 400` + `"error": "device_error"` in `identityToken` to throw it (check only `error` field, not `error_description`)
 - [ ] 5.2 Rename `APIError.baseURLNotSet` to `APIError.serverEnvironmentNotSet`; update all catch sites and existing tests
-- [ ] 5.3 Replace `setBaseURL(_ url: URL)` with `setServerEnvironment(_ env: ServerEnvironment)` on `PrizmAPIClientProtocol` and `PrizmAPIClientImpl`; remove `setBaseURL` entirely
+- [ ] 5.3 Replace `setBaseURL(_ url: URL)` with `setServerEnvironment(_ env: ServerEnvironment)` on `PrizmAPIClientProtocol`, `PrizmAPIClientImpl`, and `MockPrizmAPIClient`; remove `setBaseURL` entirely — the mock must be updated in this same task or Group 6 tests will not compile
 - [ ] 5.4 Make `clientId` instance state on `PrizmAPIClient` (set via `setServerEnvironment`): cloud environments use `Config.bitwardenClientIdentifier`, self-hosted keeps `"desktop"`
 - [ ] 5.5 Update all ~32 endpoint methods to route via `env.apiURL`, `env.identityURL`, or `env.iconsURL` instead of appending to a single `base`
 - [ ] 5.6 Add `Bitwarden-Client-Name` header to `baseRequest()` using `Config.clientName`
@@ -62,19 +63,19 @@ _(Protocol declarations require no unit tests — skip straight to implementatio
 ## 7. Data Layer — AuthRepositoryImpl
 
 - [ ] 7.1 Update all four `setBaseURL` call sites to `setServerEnvironment` (lines 83, 325, 540, 606)
-- [ ] 7.2 Catch `IdentityTokenError.newDeviceNotVerified` in `loginWithPassword` and return `LoginResult.requiresNewDeviceOTP`; hold `environment`, `email`, and hashed password in memory
-- [ ] 7.3 Guard cloud login with `Config.bitwardenClientIdentifier.isEmpty` check; throw `AuthError.clientIdentifierNotConfigured` before any network request
+- [ ] 7.2 Catch `IdentityTokenError.newDeviceNotVerified` in `loginWithPassword` and return `LoginResult.requiresNewDeviceOTP`; store a new `PendingNewDeviceOTP` struct (separate from `PendingTwoFactor`) holding `email: String`, `passwordHash: String`, `var stretchedKeys: CryptoKeys` (`var` so zeroing is possible), `deviceId: String`, `environment: ServerEnvironment`; `stretchedKeys` MUST be zeroed before the struct is released on cancel or failure (Constitution §III) — follow the same in-place mutation pattern as `cancelTwoFactor()`
+- [ ] 7.3 Add `clientIdentifier: String = Config.bitwardenClientIdentifier` parameter to `AuthRepositoryImpl.init` (production callers pass no arg; tests inject `""` to verify the guard fires, or `"test-id"` to bypass it); guard cloud login: if `environment.serverType != .selfHosted && clientIdentifier.isEmpty`, throw `AuthError.clientIdentifierNotConfigured` before any network request
 - [ ] 7.4 Skip `validateServerURL` for cloud environments; call only when `environment.serverType == .selfHosted`
-- [ ] 7.5 Implement `loginWithNewDeviceOTP(_ otp: String)`: retry `identityToken` with `newdeviceotp` param; zero cached credentials after (success or failure)
+- [ ] 7.5 Implement `loginWithNewDeviceOTP(_ otp: String)`: read `pendingNewDeviceOTP` (throws `AuthError.invalidCredentials` if nil); call `identityToken(email:passwordHash:deviceIdentifier:newDeviceOTP:)` using the pending struct's fields; on success call `finalizeSession(tokenResp:stretched:environment:)` using the pending struct's `stretchedKeys` and `environment`; zero `stretchedKeys` and nil `pendingNewDeviceOTP` in a `defer` block so cleanup happens on both success and failure (Constitution §III)
 - [ ] 7.6 Implement `requestNewDeviceOTP()`: re-post original `identityToken` without `newdeviceotp`; do NOT zero cached credentials
-- [ ] 7.7 Implement `cancelNewDeviceOTP()`: zero cached credentials without network request
+- [ ] 7.7 Implement `cancelNewDeviceOTP()`: zero `pendingNewDeviceOTP!.stretchedKeys` buffers in-place (Constitution §III — same pattern as `cancelTwoFactor()`), then set `pendingNewDeviceOTP = nil`; no network request
 - [ ] 7.8 Self-hosted `device_error` response (unexpected): surface as `AuthError.invalidCredentials`
 
 ## 8. Data Unit Tests — AuthRepositoryImpl + LoginUseCaseImpl (write before Groups 7 + 9, must fail first)
 
 - [ ] 8.1 `AuthRepositoryImpl.setServerEnvironment` calls `apiClient.setServerEnvironment` (not `setBaseURL`)
 - [ ] 8.2 `AuthRepositoryImpl.loginWithPassword` returns `LoginResult.requiresNewDeviceOTP` when `identityToken` throws `IdentityTokenError.newDeviceNotVerified`
-- [ ] 8.3 `AuthRepositoryImpl` throws `AuthError.clientIdentifierNotConfigured` when `Config.bitwardenClientIdentifier` is empty and `serverType` is cloud — no network request made
+- [ ] 8.3 `AuthRepositoryImpl` throws `AuthError.clientIdentifierNotConfigured` when injected `clientIdentifier` is `""` and `serverType` is cloud — no network request made; use `init(..., clientIdentifier: "")` in the test to trigger the guard
 - [ ] 8.4 `LoginUseCaseImpl` does NOT call `auth.validateServerURL` when `environment.serverType == .cloudUS` or `.cloudEU`
 - [ ] 8.5 `LoginUseCaseImpl` DOES call `auth.validateServerURL` when `environment.serverType == .selfHosted`
 - [ ] 8.6 Cached credentials zeroed after `loginWithNewDeviceOTP` succeeds
@@ -98,21 +99,22 @@ _(Protocol declarations require no unit tests — skip straight to implementatio
 - [ ] 10.1 `LoginViewModel` initialised with `UserDefaults` key `com.prizm.login.lastServerType = "cloudEU"` → `serverType == .cloudEU`
 - [ ] 10.2 `LoginViewModel` initialised with no `UserDefaults` key → `serverType` defaults to `.cloudUS`
 - [ ] 10.3 Selecting a cloud type persists to `UserDefaults`; selecting self-hosted restores last entered URL
-- [ ] 10.4 `isSignInDisabled` returns `false` for cloud when email and password non-empty, `serverURL` empty
-- [ ] 10.5 `isSignInDisabled` returns `true` for self-hosted when `serverURL` empty, email and password filled
-- [ ] 10.6 `isSignInDisabled` returns `true` when `flowState == .otpPrompt` and `otpCode` is empty
-- [ ] 10.7 `isSignInDisabled` returns `false` when `flowState == .otpPrompt` and `otpCode` is non-empty
-- [ ] 10.8 `flowState` transitions to `.otpPrompt` when `execute` returns `LoginResult.requiresNewDeviceOTP`
-- [ ] 10.9 `flowState` transitions to `.login` when Cancel tapped (after `cancelNewDeviceOTP`)
-- [ ] 10.10 `flowState` remains `.otpPrompt` after invalid OTP error; error message set
-- [ ] 10.11 `resendNewDeviceOTP` called when Resend tapped; `otpCode` cleared on success; confirmation announced
-- [ ] 10.12 `resendNewDeviceOTP` throws → `flowState` returns to `.otpPrompt`, error message set, `otpCode` unchanged
-- [ ] 10.13 `otpCode` cleared from memory after successful OTP submission in `submitOTP()`
+- [ ] 10.4 `isSignInDisabled` returns `true` when `flowState == .loading` (prevents double-submit regardless of field content)
+- [ ] 10.5 `isSignInDisabled` returns `false` for cloud when email and password non-empty, `serverURL` empty
+- [ ] 10.6 `isSignInDisabled` returns `true` for self-hosted when `serverURL` empty, email and password filled
+- [ ] 10.7 `isSignInDisabled` returns `true` when `flowState == .otpPrompt` and `otpCode` is empty
+- [ ] 10.8 `isSignInDisabled` returns `false` when `flowState == .otpPrompt` and `otpCode` is non-empty
+- [ ] 10.9 `flowState` transitions to `.otpPrompt` when `execute` returns `LoginResult.requiresNewDeviceOTP`
+- [ ] 10.10 `flowState` transitions to `.login` when Cancel tapped (after `cancelNewDeviceOTP`)
+- [ ] 10.11 `flowState` remains `.otpPrompt` after invalid OTP error; error message set
+- [ ] 10.12 `resendNewDeviceOTP` called when Resend tapped; `otpCode` cleared on success; confirmation announced
+- [ ] 10.13 `resendNewDeviceOTP` throws → `flowState` returns to `.otpPrompt`, error message set, `otpCode` unchanged
+- [ ] 10.14 `otpCode` cleared from memory after successful OTP submission in `submitOTP()`
 
 ## 11. Presentation — LoginViewModel
 
 - [ ] 11.1 Add `serverType: ServerType` `@Published` property; persist/restore via `UserDefaults` key `com.prizm.login.lastServerType`; default to `.cloudUS` when key absent (fresh install)
-- [ ] 11.2 Add `isSignInDisabled: Bool` computed property: `true` when (cloud + email or password empty) OR (selfHosted + email, password, or serverURL empty) OR (otpPrompt + `otpCode` empty)
+- [ ] 11.2 Add `isSignInDisabled: Bool` computed property: `true` when `flowState == .loading` (prevents double-submit) OR (cloud + email or password empty) OR (selfHosted + email, password, or serverURL empty) OR (otpPrompt + `otpCode` empty)
 - [ ] 11.3 Update `signIn()` to construct `ServerEnvironment` from `serverType` (`.cloudUS()` / `.cloudEU()` / `selfHosted` from URL string) and call `loginUseCase.execute(environment:email:masterPassword:)`
 - [ ] 11.4 Handle `LoginResult.requiresNewDeviceOTP` in `signIn()`: set `flowState = .otpPrompt`
 - [ ] 11.5 Add `otpCode: String` `@Published` property for the OTP text field


### PR DESCRIPTION
## Problem

Homebrew-distributed builds are unsigned (`CODE_SIGNING_ALLOWED=NO` in `release.yml`), so they lack the `keychain-access-groups` entitlement. Any `SecItem` call with `kSecUseDataProtectionKeychain: true` returns `-34018` (`errSecMissingEntitlement`). Sign-in fails immediately after successful auth with:

> `The operation couldn't be completed. (Prizm.KeychainError error 0.)`

Reported in #58.

## Fix

`KeychainServiceImpl.init` now probes the data protection keychain once at startup:

- `errSecMissingEntitlement` → `useDataProtectionKeychain = false` → falls back to legacy login keychain
- Any other status (including `errSecItemNotFound`) → `useDataProtectionKeychain = true` (signed builds, no change)

Explicit `Bool` param kept for test targets that pass `false` directly — no test changes needed.

## Security delta

`kSecAttrAccessibleWhenUnlockedThisDeviceOnly` still applies on the legacy login keychain — items are not iCloud-backed and not migrated to new devices. The only difference: macOS shows a *"Prizm wants to use your login keychain"* prompt on first launch after each Homebrew update (new binary = new ACL entry). README updated to set that expectation.

## Test plan

- [ ] Unsigned build: sign in succeeds, no `-34018` error
- [ ] macOS login keychain prompt appears on first launch — click Allow
- [ ] Existing tests pass (`KeychainServiceImpl(useDataProtectionKeychain: false)` unaffected)

Closes #58