### PR TITLE
fix(keychain): fall back to login keychain on unsigned builds

### DIFF
--- a/Prizm/Data/Keychain/KeychainService.swift
+++ b/Prizm/Data/Keychain/KeychainService.swift
@@ -58,14 +58,32 @@ final class KeychainServiceImpl: KeychainService {
     private let service = "com.prizm"
     private let logger = Logger(subsystem: "com.prizm", category: "KeychainService")
 
-    /// When `true` (default, production), routes all queries through the modern data
-    /// protection keychain (`kSecUseDataProtectionKeychain`), which requires the
-    /// `keychain-access-groups` entitlement. Pass `false` in test targets that run
-    /// without code signing, where the entitlement is unavailable.
+    /// When `true`, routes all queries through the modern data protection keychain
+    /// (`kSecUseDataProtectionKeychain`), which requires the `keychain-access-groups`
+    /// entitlement. Auto-detected at init: unsigned builds (e.g. Homebrew) receive
+    /// `false` and fall back to the legacy login keychain.
+    /// Pass an explicit value in tests to bypass the probe.
     private let useDataProtectionKeychain: Bool
 
-    init(useDataProtectionKeychain: Bool = true) {
-        self.useDataProtectionKeychain = useDataProtectionKeychain
+    init(useDataProtectionKeychain: Bool? = nil) {
+        if let explicit = useDataProtectionKeychain {
+            self.useDataProtectionKeychain = explicit
+            return
+        }
+        // Probe whether the data protection keychain is accessible. Unsigned builds
+        // lack the `keychain-access-groups` entitlement and receive -34018
+        // (errSecMissingEntitlement). errSecItemNotFound means the keychain is
+        // reachable — just no item stored yet.
+        let probe: [CFString: Any] = [
+            kSecClass:                     kSecClassGenericPassword,
+            kSecAttrService:               "com.prizm.probe",
+            kSecAttrAccount:               "entitlement-check",
+            kSecUseDataProtectionKeychain: true,
+            kSecMatchLimit:                kSecMatchLimitOne,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(probe as CFDictionary, &result)
+        self.useDataProtectionKeychain = (status != errSecMissingEntitlement)
     }
 
     /// Returns the base Keychain query dictionary for `key`.

--- a/Prizm/Data/Keychain/KeychainService.swift
+++ b/Prizm/Data/Keychain/KeychainService.swift
@@ -76,14 +76,17 @@ final class KeychainServiceImpl: KeychainService {
         // reachable — just no item stored yet.
         let probe: [CFString: Any] = [
             kSecClass:                     kSecClassGenericPassword,
-            kSecAttrService:               "com.prizm.probe",
-            kSecAttrAccount:               "entitlement-check",
+            kSecAttrService:               "com.prizm",
+            kSecAttrAccount:               "__entitlement-probe__",
             kSecUseDataProtectionKeychain: true,
             kSecMatchLimit:                kSecMatchLimitOne,
         ]
-        var result: AnyObject?
-        let status = SecItemCopyMatching(probe as CFDictionary, &result)
-        self.useDataProtectionKeychain = (status != errSecMissingEntitlement)
+        let status = SecItemCopyMatching(probe as CFDictionary, nil)
+        // Confirm reachability by checking for known-good statuses only.
+        // Any other code (e.g. errSecInteractionNotAllowed on cold boot) must not
+        // be treated as confirmation — it would arm the data-protection path and
+        // cause all real SecItem calls to fail with errSecMissingEntitlement.
+        self.useDataProtectionKeychain = (status == errSecItemNotFound || status == errSecSuccess)
     }
 
     /// Returns the base Keychain query dictionary for `key`.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ brew install --cask prizm
 
 The app is not notarized. After downloading, right-click (Control-click) the `.app` and choose **Open**, then confirm. You only need to do this once. After that, you can open it normally.
 
+macOS will also show a **"Prizm wants to use your login keychain"** prompt on first launch — click **Allow**. This is expected for unsigned apps; Prizm uses it to store credentials securely.
+
 Alternatively, from Terminal:
 
 ```bash


### PR DESCRIPTION
## Problem

Homebrew-distributed builds are unsigned (`CODE_SIGNING_ALLOWED=NO` in `release.yml`), so they lack the `keychain-access-groups` entitlement. Any `SecItem` call with `kSecUseDataProtectionKeychain: true` returns `-34018` (`errSecMissingEntitlement`). Sign-in fails immediately after successful auth with:

> `The operation couldn't be completed. (Prizm.KeychainError error 0.)`

Reported in #58.

## Fix

`KeychainServiceImpl.init` now probes the data protection keychain once at startup:

- `errSecItemNotFound` or `errSecSuccess` → entitlement present → `useDataProtectionKeychain = true` (signed builds, no change)
- Anything else (including `-34018`) → `useDataProtectionKeychain = false` → falls back to legacy login keychain

Using a positive allowlist of known-good statuses prevents transient errors (e.g. `errSecInteractionNotAllowed` on cold boot) from falsely enabling the data-protection path.

Explicit `Bool` param kept for test targets that pass `false` directly — no test changes needed.

**`BiometricKeychainServiceImpl` is intentionally unchanged.** Disabling data protection keychain there would silently drop the biometric ACL, degrading security without a visible error. Biometric unlock works normally on unsigned builds.

## Security delta

`kSecAttrAccessibleWhenUnlockedThisDeviceOnly` still applies on the legacy login keychain — items are not iCloud-backed and not migrated to new devices. The only difference: macOS shows a *"Prizm wants to use your login keychain"* prompt on first launch after each Homebrew update (new binary = new ACL entry). README updated to set that expectation.

## Test plan

- [ ] Unsigned build: sign in succeeds, no `-34018` error
- [ ] macOS login keychain prompt appears on first launch — click Allow
- [ ] Signed/dev build: behaviour unchanged (data protection keychain still used)
- [ ] Existing tests pass (`KeychainServiceImpl(useDataProtectionKeychain: false)` unaffected)

Closes #58