### PR TITLE
fix(keychain): probe data protection keychain with a write, not a read

### DIFF
--- a/Prizm/Data/Keychain/KeychainService.swift
+++ b/Prizm/Data/Keychain/KeychainService.swift
@@ -103,7 +103,10 @@ final class KeychainServiceImpl: KeychainService {
         self.useDataProtectionKeychain = entitled
         if entitled {
             probe[kSecValueData] = nil
-            SecItemDelete(probe as CFDictionary)
+            let deleteStatus = SecItemDelete(probe as CFDictionary)
+            if deleteStatus != errSecSuccess {
+                logger.error("Failed to delete entitlement probe item: status \(deleteStatus)")
+            }
         } else {
             logger.info("Data protection keychain unavailable (status \(status)) — falling back to login keychain")
         }

--- a/Prizm/Data/Keychain/KeychainService.swift
+++ b/Prizm/Data/Keychain/KeychainService.swift
@@ -70,23 +70,43 @@ final class KeychainServiceImpl: KeychainService {
             self.useDataProtectionKeychain = explicit
             return
         }
-        // Probe whether the data protection keychain is accessible. Unsigned builds
-        // lack the `keychain-access-groups` entitlement and receive -34018
-        // (errSecMissingEntitlement). errSecItemNotFound means the keychain is
-        // reachable — just no item stored yet.
-        let probe: [CFString: Any] = [
+        // Probe whether the data protection keychain is *writable*. Unsigned builds
+        // (Homebrew, teamless local builds) lack the `keychain-access-groups`
+        // entitlement and must fall back to the legacy login keychain — #60.
+        //
+        // The probe must be a write, not a read: as of macOS 26.5,
+        // SecItemCopyMatching no longer enforces the entitlement and returns
+        // errSecItemNotFound where SecItemAdd fails with -34018
+        // (errSecMissingEntitlement). A read probe therefore arms the
+        // data-protection path on unsigned builds and the first real write —
+        // storing the device identifier during sign-in — fails with the exact
+        // error #60 was meant to prevent.
+        //
+        // The probe item mirrors the attributes of real writes (same service and
+        // kSecAttrAccessible) so it exercises the same policy checks, and is
+        // deleted immediately on success.
+        var probe: [CFString: Any] = [
             kSecClass:                     kSecClassGenericPassword,
             kSecAttrService:               "com.prizm",
             kSecAttrAccount:               "__entitlement-probe__",
+            kSecAttrAccessible:            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
             kSecUseDataProtectionKeychain: true,
-            kSecMatchLimit:                kSecMatchLimitOne,
+            kSecValueData:                 Data("probe".utf8),
         ]
-        let status = SecItemCopyMatching(probe as CFDictionary, nil)
-        // Confirm reachability by checking for known-good statuses only.
-        // Any other code (e.g. errSecInteractionNotAllowed on cold boot) must not
-        // be treated as confirmation — it would arm the data-protection path and
-        // cause all real SecItem calls to fail with errSecMissingEntitlement.
-        self.useDataProtectionKeychain = (status == errSecItemNotFound || status == errSecSuccess)
+        let status = SecItemAdd(probe as CFDictionary, nil)
+        // Only known-good statuses confirm the entitlement: errSecSuccess, or
+        // errSecDuplicateItem from a probe item a previous crashed run left behind.
+        // Any other code (e.g. errSecInteractionNotAllowed while the keychain is
+        // locked) selects the legacy fallback rather than risking -34018 on real
+        // writes.
+        let entitled = (status == errSecSuccess || status == errSecDuplicateItem)
+        self.useDataProtectionKeychain = entitled
+        if entitled {
+            probe[kSecValueData] = nil
+            SecItemDelete(probe as CFDictionary)
+        } else {
+            logger.info("Data protection keychain unavailable (status \(status)) — falling back to login keychain")
+        }
     }
 
     /// Returns the base Keychain query dictionary for `key`.

--- a/Prizm/PrizmTests/Data/KeychainServiceTests.swift
+++ b/Prizm/PrizmTests/Data/KeychainServiceTests.swift
@@ -61,4 +61,25 @@ final class KeychainServiceTests: XCTestCase {
             XCTAssertEqual(error as? KeychainError, .itemNotFound)
         }
     }
+
+    // MARK: - Entitlement probe (#60)
+
+    /// Regression test for the unsigned-build fallback (#60): an instance created with
+    /// the auto-probe must be able to complete a write immediately after init — this is
+    /// the operation that gates sign-in (device identifier storage).
+    ///
+    /// On runners without the `keychain-access-groups` entitlement (CI, Homebrew,
+    /// teamless local builds) the probe must select the legacy login keychain; on
+    /// entitled builds the data protection keychain is used directly. Either way the
+    /// write must succeed. A read-based probe fails this test on unsigned runners:
+    /// as of macOS 26.5 `SecItemCopyMatching` returns `errSecItemNotFound` without
+    /// the entitlement, while `SecItemAdd` still fails with -34018.
+    func testProbedInitCanWriteRegardlessOfEntitlement() throws {
+        let probed = KeychainServiceImpl()
+        let key = "bw.macos.test:probed-write"
+        defer { try? probed.delete(key: key) }
+
+        try probed.write(data: Data("probe".utf8), key: key)
+        XCTAssertEqual(try probed.read(key: key), Data("probe".utf8))
+    }
 }


### PR DESCRIPTION
As of macOS 26.5, SecItemCopyMatching with kSecUseDataProtectionKeychain no longer enforces the keychain-access-groups entitlement — it returns errSecItemNotFound on unsigned builds where SecItemAdd still fails with -34018 (errSecMissingEntitlement). The read-based probe from #60 therefore armed the data-protection path on unsigned builds (Homebrew, CI-style teamless local builds), and sign-in failed with KeychainError on the very first write (device identifier storage) — the exact regression #60 fixed.

Probe with SecItemAdd instead, mirroring the attributes of real writes, and delete the probe item immediately. Only errSecSuccess or errSecDuplicateItem (leftover from a crashed run) confirm the entitlement; any other status selects the legacy login-keychain fallback. The fallback decision is now logged per the observability principle.

Adds a regression test that exercises the auto-probe path end-to-end: a probed instance must complete a write immediately after init on both entitled and unsigned runners.